### PR TITLE
Change min sdk support to API - 14 (4.0)

### DIFF
--- a/android/source/VideoLocker/build.gradle
+++ b/android/source/VideoLocker/build.gradle
@@ -180,7 +180,7 @@ android {
     defaultConfig {
         applicationId "org.edx.mobile"
         // minimum version is Android 4.0
-        minSdkVersion 16
+        minSdkVersion 14
         targetSdkVersion 21
         versionCode 40
         versionName "1.0.03"
@@ -232,7 +232,7 @@ android {
 
             versionCode 40
             versionName '1.0.03'
-            minSdkVersion 16
+            minSdkVersion 14
             targetSdkVersion 21
         }
     }


### PR DESCRIPTION
@nasthagiri @rohan-dhamal-clarice - We had previously changed minSdk version to 16 (4.1) for exo player integration. 
But as exo player is not getting integrated we will revert back to supporting minSdk version to 14 (4.0).

Please review. 