### PR TITLE
Crash handle for null pointer exception on VideoListActivity

### DIFF
--- a/android/source/VideoLocker/src/org/edx/mobile/view/VideoListActivity.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/VideoListActivity.java
@@ -125,7 +125,15 @@ VideoListCallback, IPlayerEventCallback {
     @Override
     protected void onRestoreInstanceState(Bundle savedInstanceState) {
         if (savedInstanceState != null) {
-            super.onRestoreInstanceState(savedInstanceState);
+            //FIXME: There is an error of null pointer exception on some devices when super function is called.
+            //This is a workaround where the crash is handled in
+            //try catch and hence the app does not crash
+            try{
+                super.onRestoreInstanceState(savedInstanceState);
+            }catch(Exception e){
+                e.printStackTrace();
+                LogUtil.error("player_issue","Null pointer exception on onRestoreInstanceState");
+            }
             restore(savedInstanceState);
         }
     }


### PR DESCRIPTION
@nasthagiri @rohan-dhamal-clarice - There is a crash on some devices during playing a video, if the device is switched to landscape and the switched back to portrait, there was a null pointer exception which was occurring when in the super class function is called. 
This has been handled by adding a try catch. This is a work around and there is no crash but will need to fixed going forward..
Please review

Jira link - https://openedx.atlassian.net/browse/MOB-1230
Fabric link - https://fabric.io/edx-inc/android/apps/org.edx.mobile/issues/5490348765f8dfea155a2ab5