### PR TITLE
Set maxLength to 100 for Edittext views

### DIFF
--- a/android/source/VideoLocker/res/values/text_styles.xml
+++ b/android/source/VideoLocker/res/values/text_styles.xml
@@ -58,7 +58,7 @@
         <item name="android:paddingLeft">10dp</item>
         <item name="android:paddingRight">10dp</item>
         <item name="font">OpenSans-Regular.ttf</item>
-        <item name="android:maxLength">60</item>
+        <item name="android:maxLength">100</item>
     </style>
 
     <style name="downloading_message">


### PR DESCRIPTION
@nasthagiri @rohan-dhamal-clarice - There was a crash on few phones where if the user while inputting his credentials on Edittext, selected from the prompted text, and the selected text is greater than the maxlength, it would crash the application. 
I was unable to reproduce the issue but have increased the maxLength from 60 to 100.

Please review
Jira: https://openedx.atlassian.net/browse/MOB-1351
