### PR TITLE
Do not set player display in surfaceChanged callback

### DIFF
--- a/android/source/VideoLocker/src/org/edx/mobile/player/Player.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/player/Player.java
@@ -316,7 +316,7 @@ OnCompletionListener, OnInfoListener, IPlayer {
 
                 @Override
                 public void surfaceDestroyed(SurfaceHolder holder) {
-                    LogUtil.log("Player", "surface destroyed");
+                    // nothing to be done here
                 }
 
                 @Override
@@ -340,8 +340,7 @@ OnCompletionListener, OnInfoListener, IPlayer {
                 @Override
                 public void surfaceChanged(SurfaceHolder holder, int format,
                         int width, int height) {
-                    LogUtil.log("Player", "surface changed");
-                    setDisplay(holder);
+                    // nothing to be done here
                 }
             });
             preview.setOnTouchListener(new OnSwipeListener(preview.getContext()) {


### PR DESCRIPTION
We set display when surface is created and hence we don't need to do it again when surface is changed. 
JIRA: https://openedx.atlassian.net/browse/MOB-1359

@nasthagiri @aleffert @shahidtamboli Please review.

