### PR TITLE
Handle array index out of bound exception in base list adapter 

### DIFF
--- a/android/source/VideoLocker/src/org/edx/mobile/player/VideoListFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/player/VideoListFragment.java
@@ -864,7 +864,7 @@ public class VideoListFragment extends Fragment {
                 v = (DownloadEntry) adapter.getItem(playingVideoIndex);
             }
 
-            if (v.watched == DownloadEntry.WatchedState.PARTIALLY_WATCHED) {
+            if (v!=null && v.watched == DownloadEntry.WatchedState.PARTIALLY_WATCHED) {
                 videoModel.watched = DownloadEntry.WatchedState.WATCHED;
                 // mark this as partially watches, as playing has started
                 db.updateVideoWatchedState(v.videoId, DownloadEntry.WatchedState.WATCHED,
@@ -1098,7 +1098,7 @@ public class VideoListFragment extends Fragment {
                 videoPos++;
                 while (videoPos < adapter.getCount()) {
                     SectionItemInterface i = adapter.getItem(videoPos);
-                    if (i instanceof DownloadEntry) {
+                    if (i!=null && i instanceof DownloadEntry) {
                         if(AppConstants.offline_flag){
                             DownloadEntry de = (DownloadEntry) i;
                             if(de.isDownloaded()){
@@ -1139,7 +1139,7 @@ public class VideoListFragment extends Fragment {
                 if(videoPos!=-1){
                     for (int i=(videoPos+1) ; i<adapter.getCount(); i++) {
                         SectionItemInterface d = adapter.getItem(i);
-                        if (d instanceof DownloadEntry) {
+                        if (d!=null && d instanceof DownloadEntry) {
                             DownloadEntry de = (DownloadEntry) d;
                             if(AppConstants.offline_flag){
                                 if(de.isDownloaded()){
@@ -1167,7 +1167,7 @@ public class VideoListFragment extends Fragment {
                 videoPos--;
                 while (videoPos >= 0) {
                     SectionItemInterface i = adapter.getItem(videoPos);
-                    if (i instanceof DownloadEntry) {
+                    if (i!=null && i instanceof DownloadEntry) {
                         if(AppConstants.offline_flag){
                             DownloadEntry de = (DownloadEntry) i;
                             if(de.isDownloaded()){
@@ -1206,7 +1206,7 @@ public class VideoListFragment extends Fragment {
                 if(videoPos!=-1){
                     for (int i=(videoPos-1) ; i>=0; i--) {
                         SectionItemInterface d = adapter.getItem(i);
-                        if (d instanceof DownloadEntry) {
+                        if (d!=null && d instanceof DownloadEntry) {
                             DownloadEntry de = (DownloadEntry) d;
                             if(AppConstants.offline_flag){
                                 if(de.isDownloaded()){

--- a/android/source/VideoLocker/src/org/edx/mobile/view/MyRecentVideosFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/MyRecentVideosFragment.java
@@ -623,7 +623,7 @@ public class MyRecentVideosFragment extends Fragment {
             // check next playable video entry
             while (playingVideoIndex < adapter.getCount()) {
                 SectionItemInterface i = adapter.getItem(playingVideoIndex);
-                if (i instanceof DownloadEntry) {
+                if (i!=null && i instanceof DownloadEntry) {
                     videoModel = (DownloadEntry) i;
                     if (callback != null) {
                         adapter.setSelectedPosition(playingVideoIndex);
@@ -647,7 +647,7 @@ public class MyRecentVideosFragment extends Fragment {
             }
             for (int i=(index+1) ; i<adapter.getCount(); i++) {
                 SectionItemInterface d = adapter.getItem(i);
-                if (d instanceof DownloadEntry) {
+                if (d!=null && d instanceof DownloadEntry) {
                     return true;
                 }
             }
@@ -664,7 +664,7 @@ public class MyRecentVideosFragment extends Fragment {
             // check next playable video entry
             while (playingVideoIndex >= 0) {
                 SectionItemInterface i = adapter.getItem(playingVideoIndex);
-                if (i instanceof DownloadEntry) {
+                if (i!=null && i instanceof DownloadEntry) {
                     videoModel = (DownloadEntry) i;
                     if (callback != null) {
                         adapter.setSelectedPosition(playingVideoIndex);
@@ -685,7 +685,7 @@ public class MyRecentVideosFragment extends Fragment {
         try{
             for (int i=(playingIndex-1) ; i>=0; i--) {
                 SectionItemInterface d = adapter.getItem(i);
-                if (d instanceof DownloadEntry) {
+                if (d!=null && d instanceof DownloadEntry) {
                     return true;
                 }
             }

--- a/android/source/VideoLocker/src/org/edx/mobile/view/adapters/BaseListAdapter.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/adapters/BaseListAdapter.java
@@ -129,7 +129,10 @@ public abstract class BaseListAdapter<T> extends BaseAdapter implements OnItemCl
 
     @Override
     public T getItem(int index) {
-        return items.get(index);
+        //Check if the size of items is greater than the index
+        if(index >= 0 && items.size()>index)
+            return items.get(index);
+        return null;
     }
 
     public int getPosition(T item) {

--- a/android/source/VideoLocker/src/org/edx/mobile/view/adapters/ChapterAdapter.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/adapters/ChapterAdapter.java
@@ -160,7 +160,7 @@ public abstract class ChapterAdapter extends BaseListAdapter<SectionEntry> {
         if (currentTime - lastClickTime > MIN_CLICK_INTERVAL) {
             lastClickTime = currentTime;
             SectionEntry model = getItem(position);
-            onItemClicked(model);
+            if(model!=null) onItemClicked(model);
         }
     }
 

--- a/android/source/VideoLocker/src/org/edx/mobile/view/adapters/ClosedCaptionAdapter.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/adapters/ClosedCaptionAdapter.java
@@ -58,7 +58,7 @@ public abstract class ClosedCaptionAdapter extends BaseListAdapter<HashMap<Strin
     public void onItemClick(AdapterView<?> arg0, View arg1, int position,
             long arg3) {
         HashMap<String, String> language = getItem(position);
-        onItemClicked(language);
+        if(language!=null) onItemClicked(language);
     }
 
     public abstract void onItemClicked(HashMap<String, String> language);

--- a/android/source/VideoLocker/src/org/edx/mobile/view/adapters/DownloadEntryAdapter.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/adapters/DownloadEntryAdapter.java
@@ -114,7 +114,7 @@ public abstract class DownloadEntryAdapter extends BaseListAdapter<DownloadEntry
     @Override
     public void onItemClick(AdapterView<?> arg0, View arg1, int position, long arg3) {
         DownloadEntry model = getItem(position);
-        onItemClicked(model);
+        if(model!=null) onItemClicked(model);
     }
 
     public abstract void onItemClicked(DownloadEntry model);

--- a/android/source/VideoLocker/src/org/edx/mobile/view/adapters/LectureAdapter.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/adapters/LectureAdapter.java
@@ -131,7 +131,7 @@ public abstract class LectureAdapter extends BaseListAdapter<LectureModel> {
         if (currentTime - lastClickTime > MIN_CLICK_INTERVAL) {
             lastClickTime = currentTime;
             LectureModel model = getItem(position);
-            onItemClicked(model);
+            if(model!=null) onItemClicked(model);
         }
     }
 

--- a/android/source/VideoLocker/src/org/edx/mobile/view/adapters/MyAllVideoAdapter.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/adapters/MyAllVideoAdapter.java
@@ -158,7 +158,7 @@ public abstract class MyAllVideoAdapter extends VideoBaseAdapter<SectionItemInte
     public void onItemClick(AdapterView<?> arg0, View arg1, int position, long arg3) {
         selectedPosition=position;
         SectionItemInterface model = getItem(position);
-        onItemClicked(model, position);
+        if(model!=null) onItemClicked(model, position);
     }
 
     public abstract void onItemClicked(SectionItemInterface model, int position);

--- a/android/source/VideoLocker/src/org/edx/mobile/view/adapters/MyAllVideoCourseAdapter.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/adapters/MyAllVideoCourseAdapter.java
@@ -77,7 +77,7 @@ public abstract class MyAllVideoCourseAdapter extends BaseListAdapter<EnrolledCo
         if (currentTime - lastClickTime > MIN_CLICK_INTERVAL) {
             lastClickTime = currentTime;
             EnrolledCoursesResponse model = getItem(position);
-            onItemClicked(model);
+            if(model!=null) onItemClicked(model);
         }
     }
 

--- a/android/source/VideoLocker/src/org/edx/mobile/view/adapters/MyCourseAdapter.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/adapters/MyCourseAdapter.java
@@ -164,7 +164,7 @@ BaseListAdapter<EnrolledCoursesResponse> {
         if (currentTime - lastClickTime > MIN_CLICK_INTERVAL) {
             lastClickTime = currentTime;
             EnrolledCoursesResponse model = getItem(position);
-            onItemClicked(model);
+            if(model!=null) onItemClicked(model);
         }
     }
 

--- a/android/source/VideoLocker/src/org/edx/mobile/view/adapters/MyRecentVideoAdapter.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/adapters/MyRecentVideoAdapter.java
@@ -141,7 +141,7 @@ public abstract class MyRecentVideoAdapter extends VideoBaseAdapter<SectionItemI
     public void onItemClick(AdapterView<?> arg0, View arg1, int position, long arg3) {
         selectedPosition=position;
         SectionItemInterface model = getItem(position);
-        onItemClicked(model, position);
+        if(model!=null) onItemClicked(model, position);
     }
 
     public abstract void onItemClicked(SectionItemInterface model, int position);

--- a/android/source/VideoLocker/src/org/edx/mobile/view/adapters/OfflineVideoAdapter.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/adapters/OfflineVideoAdapter.java
@@ -192,14 +192,16 @@ public abstract class OfflineVideoAdapter extends VideoBaseAdapter<SectionItemIn
     public void onItemClick(AdapterView<?> arg0, View arg1, int position,
             long arg3) {
         SectionItemInterface model = getItem(position);
-        if (model.isDownload()) {
-            DownloadEntry downloadEntry = (DownloadEntry) model;
-            if (downloadEntry.isDownloaded()) {
-                selectedPosition = position;
+        if(model!=null) {
+            if (model.isDownload()) {
+                DownloadEntry downloadEntry = (DownloadEntry) model;
+                if (downloadEntry.isDownloaded()) {
+                    selectedPosition = position;
+                }
             }
-        }
-        if(!AppConstants.videoListDeleteMode){
-            onItemClicked(model, position);
+            if (!AppConstants.videoListDeleteMode) {
+                onItemClicked(model, position);
+            }
         }
     }
 

--- a/android/source/VideoLocker/src/org/edx/mobile/view/adapters/OnlineVideoAdapter.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/adapters/OnlineVideoAdapter.java
@@ -201,7 +201,7 @@ public abstract class OnlineVideoAdapter extends VideoBaseAdapter<SectionItemInt
     public void onItemClick(AdapterView<?> arg0, View arg1, int position, long arg3) {
         selectedPosition = position;
         SectionItemInterface model = getItem(position);
-        onItemClicked(model, position);
+        if(model!=null) onItemClicked(model, position);
     }
 
     public abstract void onItemClicked(SectionItemInterface model, int position);


### PR DESCRIPTION
There was crash logged in crashlytics of array index out of bound exception in BaseFragmentAdaptor at getItems. This has been handled by checking if the size of the items added to the adapter is greater than than the index position.
I have added null checks from where ever this function is being called

@nasthagiri @rohan-dhamal-clarice -  Please review

Jira Issue - https://openedx.atlassian.net/browse/MOB-1354