### PR TITLE
Fix notify adapter issue in CourseChapterList

### DIFF
--- a/android/source/VideoLocker/src/org/edx/mobile/view/CourseChapterListFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/CourseChapterListFragment.java
@@ -220,6 +220,8 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment {
                         if(openInBrowserUrl==null||openInBrowserUrl.equalsIgnoreCase(""))
                             openInBrowserUrl = entry.getValue().section_url;
                     }
+                    //Notify the adapter as contents of the adapter have changed.
+                    adapter.notifyDataSetChanged();
                     if(adapter.getCount()==0){
                         view.findViewById(R.id.no_chapter_tv).setVisibility(View.VISIBLE);
                         chapterListView.setEmptyView(view.findViewById(R.id.no_chapter_tv));
@@ -232,12 +234,12 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment {
                     }
                 }else{
                     if(adapter.getCount()==0){
+                        //Notify the adapter to reload because the chapter map is null.
+                        adapter.notifyDataSetChanged();
                         view.findViewById(R.id.no_chapter_tv).setVisibility(View.VISIBLE);
                         chapterListView.setEmptyView(view.findViewById(R.id.no_chapter_tv));
                     }
                 }
-                //Notify the adapter to reload because the chapter map is null.
-                adapter.notifyDataSetChanged();
                 LogUtil.log("Completed displaying data on UI", DateUtil.getCurrentTimeStamp());
             }
 

--- a/android/source/VideoLocker/src/org/edx/mobile/view/CourseChapterListFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/CourseChapterListFragment.java
@@ -224,7 +224,6 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment {
                         view.findViewById(R.id.no_chapter_tv).setVisibility(View.VISIBLE);
                         chapterListView.setEmptyView(view.findViewById(R.id.no_chapter_tv));
                     }
-                    adapter.notifyDataSetChanged();
                     if (AppConstants.offline_flag) {
                         hideOpenInBrowserPanel();
                     } else {
@@ -237,6 +236,8 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment {
                         chapterListView.setEmptyView(view.findViewById(R.id.no_chapter_tv));
                     }
                 }
+                //Notify the adapter to reload because the chapter map is null.
+                adapter.notifyDataSetChanged();
                 LogUtil.log("Completed displaying data on UI", DateUtil.getCurrentTimeStamp());
             }
 

--- a/android/source/VideoLocker/src/org/edx/mobile/view/CourseChapterListFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/CourseChapterListFragment.java
@@ -217,37 +217,36 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment {
                     for (Entry<String, SectionEntry> entry : chapterMap
                             .entrySet()) {
                         adapter.add(entry.getValue());
-                        if(openInBrowserUrl==null||openInBrowserUrl.equalsIgnoreCase(""))
+                        if(openInBrowserUrl==null||openInBrowserUrl.equalsIgnoreCase("")) {
+                            // pick up browser link
                             openInBrowserUrl = entry.getValue().section_url;
+                        }
                     }
-                    //Notify the adapter as contents of the adapter have changed.
-                    adapter.notifyDataSetChanged();
-                    if(adapter.getCount()==0){
-                        view.findViewById(R.id.no_chapter_tv).setVisibility(View.VISIBLE);
-                        chapterListView.setEmptyView(view.findViewById(R.id.no_chapter_tv));
-                    }
+
                     if (AppConstants.offline_flag) {
                         hideOpenInBrowserPanel();
                     } else {
                         fetchLastAccessed(getView());
                         showOpenInBrowserPanel(openInBrowserUrl);
                     }
-                }else{
-                    if(adapter.getCount()==0){
-                        //Notify the adapter to reload because the chapter map is null.
-                        adapter.notifyDataSetChanged();
-                        view.findViewById(R.id.no_chapter_tv).setVisibility(View.VISIBLE);
-                        chapterListView.setEmptyView(view.findViewById(R.id.no_chapter_tv));
-                    }
                 }
+
+                //Notify the adapter as contents of the adapter might have changed.
+                adapter.notifyDataSetChanged();
+
+                if(adapter.getCount()==0){
+                    view.findViewById(R.id.no_chapter_tv).setVisibility(View.VISIBLE);
+                    chapterListView.setEmptyView(view.findViewById(R.id.no_chapter_tv));
+                }
+
                 LogUtil.log("Completed displaying data on UI", DateUtil.getCurrentTimeStamp());
             }
 
             @Override
             public void onException(Exception ex) {
-                // TODO Handle Exception if Data is not loaded or error comes
-                // while fetching data from the server
-                if(adapter.getCount()==0){
+                if(adapter.getCount()==0) {
+                    // calling setEmptyView requires adapter to be notified
+                    adapter.notifyDataSetChanged();
                     view.findViewById(R.id.no_chapter_tv).setVisibility(View.VISIBLE);
                     chapterListView.setEmptyView(view.findViewById(R.id.no_chapter_tv));
                 }


### PR DESCRIPTION
This issue could not be reproduced. 
As per logs, List adapter in CourseChapterListFragment was not getting notified if the contents in chapterMap is empty. The adaptor had to be notified if the list view was getting modified. 
Thus have called the notify adapter function after fetching the data.

@nasthagiri , @rohan-dhamal-clarice - Please review.

JIRA: https://openedx.atlassian.net/browse/MOB-1362