### PR TITLE
Fix Illegal State Exception in BaseFragmentActivity at showWebDialog

### DIFF
--- a/android/source/VideoLocker/src/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/base/BaseFragmentActivity.java
@@ -636,9 +636,10 @@ public class BaseFragmentActivity extends FragmentActivity {
     protected void showWebDialog(String fileName, boolean showTitle, String dialogTitle){
         WebViewDialogFragment webViewFragment = new WebViewDialogFragment();
         webViewFragment.setDialogContents(fileName, showTitle, dialogTitle);
-        webViewFragment.show(getSupportFragmentManager(), "dialog");
         webViewFragment.setStyle(DialogFragment.STYLE_NORMAL,
                 android.R.style.Theme_Black_NoTitleBar_Fullscreen);
         webViewFragment.setCancelable(false);
+        webViewFragment.show(getSupportFragmentManager(), "dialog");
+
     }
 }

--- a/android/source/VideoLocker/src/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/base/BaseFragmentActivity.java
@@ -634,14 +634,14 @@ public class BaseFragmentActivity extends FragmentActivity {
     }
 
     protected void showWebDialog(String fileName, boolean showTitle, String dialogTitle){
-        WebViewDialogFragment webViewFragment = new WebViewDialogFragment();
-        webViewFragment.setDialogContents(fileName, showTitle, dialogTitle);
-        webViewFragment.setStyle(DialogFragment.STYLE_NORMAL,
-                android.R.style.Theme_Black_NoTitleBar_Fullscreen);
-        webViewFragment.setCancelable(false);
         //Show the dialog only if the activity is started. This is to avoid Illegal state
         //exceptions if the dialog fragment tries to show even if the application is not in foreground
         if(isActivityStarted()){
+            WebViewDialogFragment webViewFragment = new WebViewDialogFragment();
+            webViewFragment.setDialogContents(fileName, showTitle, dialogTitle);
+            webViewFragment.setStyle(DialogFragment.STYLE_NORMAL,
+                    android.R.style.Theme_Black_NoTitleBar_Fullscreen);
+            webViewFragment.setCancelable(false);
             webViewFragment.show(getSupportFragmentManager(), "dialog");
         }
     }

--- a/android/source/VideoLocker/src/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/base/BaseFragmentActivity.java
@@ -634,11 +634,11 @@ public class BaseFragmentActivity extends FragmentActivity {
     }
 
     protected void showWebDialog(String fileName, boolean showTitle, String dialogTitle){
-        WebViewDialogFragment eulaFragment = new WebViewDialogFragment();
-        eulaFragment.setDialogContents(fileName, showTitle, dialogTitle);
-        eulaFragment.show(getSupportFragmentManager(), "dialog");
-        eulaFragment.setStyle(DialogFragment.STYLE_NORMAL,
+        WebViewDialogFragment webViewFragment = new WebViewDialogFragment();
+        webViewFragment.setDialogContents(fileName, showTitle, dialogTitle);
+        webViewFragment.show(getSupportFragmentManager(), "dialog");
+        webViewFragment.setStyle(DialogFragment.STYLE_NORMAL,
                 android.R.style.Theme_Black_NoTitleBar_Fullscreen);
-        eulaFragment.setCancelable(false);
+        webViewFragment.setCancelable(false);
     }
 }

--- a/android/source/VideoLocker/src/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/base/BaseFragmentActivity.java
@@ -639,7 +639,10 @@ public class BaseFragmentActivity extends FragmentActivity {
         webViewFragment.setStyle(DialogFragment.STYLE_NORMAL,
                 android.R.style.Theme_Black_NoTitleBar_Fullscreen);
         webViewFragment.setCancelable(false);
-        webViewFragment.show(getSupportFragmentManager(), "dialog");
-
+        //Show the dialog only if the activity is started. This is to avoid Illegal state
+        //exceptions if the dialog fragment tries to show even if the application is not in foreground
+        if(isActivityStarted()){
+            webViewFragment.show(getSupportFragmentManager(), "dialog");
+        }
     }
 }


### PR DESCRIPTION
The showWebView dialog was getting illegal state exception in BaseFragment probably because it was trying to call show dialog even when the application was not in foreground.
This has been handled by checking if the activity is started before calling the show function for the dialog.

@nasthagiri @rohan-dhamal-clarice  - Please review.

JIRA: https://openedx.atlassian.net/browse/MOB-1361