### PR TITLE
Fix for Illegal state exception at onDismiss in WebViewDialogFragment

### DIFF
--- a/android/source/VideoLocker/src/org/edx/mobile/view/dialog/WebViewDialogFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/dialog/WebViewDialogFragment.java
@@ -58,7 +58,10 @@ public class WebViewDialogFragment extends DialogFragment {
         Button button = (Button) v.findViewById(R.id.positiveButton);
         button.setOnClickListener(new OnClickListener() {
             public void onClick(View v) {
-                dismiss();
+                //Check if the dialog is not removing(dismissing)
+                // or is visible before dismissing the dialog
+                if(!isRemoving() && isVisible())
+                    dismiss();
             }
         });
 


### PR DESCRIPTION
There was an illegal state exception when dismissing the WebViewDialogFragment. It was not reproducible.
This error is generally created because the app is not in frontend. Thus I have added checks to confirm if the dialog is visible before dismissing it.

@nasthagiri @rohan-dhamal-clarice - Please review

JIRA: https://openedx.atlassian.net/browse/MOB-1363