### PR TITLE
Fix for setting segment IO key from code

### DIFF
--- a/android/source/VideoLocker/res/values/analytics.xml
+++ b/android/source/VideoLocker/res/values/analytics.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- This file is created for segment IO analytics-->
+    <!-- Debug flag for Segment IO -->
+    <string name="analytics_debug">false</string>
+    <!-- The number of events in the disk queue before sending events to the server. -->
+    <integer name="analytics_queue_size">20</integer>
+</resources>

--- a/android/source/VideoLocker/src/org/edx/mobile/module/analytics/SegmentTracker.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/module/analytics/SegmentTracker.java
@@ -19,22 +19,17 @@ public class SegmentTracker {
     public SegmentTracker(Context context) {
         try {
             String writeKey = Environment.getInstance().getConfig().getSegmentIOWriteKey();
-            /*
             String debugging = context.getString(R.string.analytics_debug);
             int queueSize = context.getResources().getInteger(R.integer.analytics_queue_size);
-            
-            analytics = new Analytics.Builder(context, writeKey)
-                .debugging(Boolean.parseBoolean(debugging))
-                .queueSize(queueSize)
-                .build();
-            */
-            
-            analytics = Analytics.with(context);
-            
-            // Must be called before any calls to Analytics.with(context)
-            // Now Analytics.with will return the custom instance
 
-            LogUtil.log(getClass().getName(), "SegmentTracker created with write key: " + writeKey);
+            if(writeKey!=null) {
+                LogUtil.log(getClass().getName(), "SegmentTracker created with write key: " + writeKey);
+                // Now Analytics.with will return the custom instance
+                analytics = new Analytics.Builder(context, writeKey)
+                        .debugging(Boolean.parseBoolean(debugging))
+                        .queueSize(queueSize)
+                        .build();
+            }
         } catch(RuntimeException ex) {
             ex.printStackTrace();
         } catch(Exception ex) {


### PR DESCRIPTION
There was an error of write key for segment cannot be null. This error was because previously we had segment IO keys in the analytics.xml file. But as the key is not in that file, we need to set the write key in the code.
I have updated the code for setting the segment write key.

@nasthagiri @rohan-dhamal-clarice - Please review

