### PR TITLE
TravisCI - Specify required android components and enable caching to speed up build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: android
 jdk: oraclejdk7
 env:
   matrix:
-    - ANDROID_TARGET=android-21 ANDROID_ABI=armeabi-v7a
+    - ANDROID_TARGET=android-16 ANDROID_ABI=armeabi-v7a
 
 android:
   components:
@@ -14,11 +14,12 @@ android:
     - build-tools-21.1.1
 
     # The SDK version used to compile the project
-    - android-21
+    # Android 21 (5.0) Emulator fails to launch many times, so go for Android 16
+    - android-16
 
     # Specify at least one system image,
     # if you need to run emulator(s) during your tests
-    - sys-img-armeabi-v7a-android-21
+    - sys-img-armeabi-v7a-android-16
 
 # Disable travis email notifications until builds work properly
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,19 @@ env:
 
 android:
   components:
+    # use the latest revision of Android SDK Tools
+    - platform-tools
+    - tools
+
+    # The BuildTools version used
     - build-tools-21.1.1
+
+    # The SDK version used to compile the project
+    - android-21
+
+    # Specify at least one system image,
+    # if you need to run emulator(s) during your tests
+    - sys-img-armeabi-v7a-android-21
 
 # Disable travis email notifications until builds work properly
 notifications:
@@ -21,4 +33,10 @@ before_script:
   - chmod +x travis-build.sh
   - chmod +x android/source/gradlew
 
-script: ./travis-build.sh
+script: 
+  - ./travis-build.sh
+
+# Enable caching to speed up the build
+cache:
+  directories:
+    - $HOME/.gradle

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -8,5 +8,5 @@ pwd
 
 # run tests
 echo "[INFO] running uninstallAll createProdDebugCoverageReport ..."
-./gradlew createProdDebugCoverageReport
+./gradlew uninstallAll createProdDebugCoverageReport
 echo "[INFO] finished all tests"

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -6,17 +6,7 @@ cd android/source
 echo "[INFO] Changed directory to : " 
 pwd
 
-# generate build
-#echo "[INFO] Running assembleProdDebug ..."
-#./gradlew clean assembleProdDebug
-
 # run tests
-clear
-echo "[INFO] logs cleared up to this point"
-#echo "[INFO] running connectedAndroidTestProdDebug with -i option ..."
-#./gradlew connectedAndroidTestProdDebug -i
-#echo "[INFO] finished all tests"
 echo "[INFO] running uninstallAll createProdDebugCoverageReport ..."
-# remove any existing installation to avoid install failures due to different signatures
-./gradlew uninstallAll createProdDebugCoverageReport
+./gradlew createProdDebugCoverageReport
 echo "[INFO] finished all tests"


### PR DESCRIPTION
I will use this branch to setup CI. Some of the builds are failed because of emulator taking long time to start.
I have explicitly specified some components, emulator image and version of build tools and android SDK.

cc @aleffert @nasthagiri @shahidtamboli 