### PR TITLE
Get rid of assets/config.properties file

### DIFF
--- a/android/source/VideoLocker/androidTest/java/org/edx/mobile/test/PropertyTests.java
+++ b/android/source/VideoLocker/androidTest/java/org/edx/mobile/test/PropertyTests.java
@@ -5,8 +5,8 @@ import org.edx.mobile.util.PropertyUtil;
 public class PropertyTests extends BaseTestCase {
 
     public void testGetDisplayVersionName() throws Exception {
-        String name = PropertyUtil.getDisplayVersionName(getInstrumentation().getTargetContext());
-        assertTrue("failed to read property file", name != null);
-        print("display name = " + name);
+        String name = PropertyUtil.getManifestVersionName(getInstrumentation().getTargetContext());
+        assertTrue("failed to read versionName, found=" + name,
+                name != null && !name.isEmpty());
     }
 }

--- a/android/source/VideoLocker/assets/config/config.properties
+++ b/android/source/VideoLocker/assets/config/config.properties
@@ -1,6 +1,0 @@
-#Tue, 16 Dec 2014 16:25:55 +0530
-# This information is also used to display on left side drawer in the app.
-versionCode=40
-versionName=1.0
-versionNameSuffix=03
-buildConfig=prod

--- a/android/source/VideoLocker/src/org/edx/mobile/util/Config.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/util/Config.java
@@ -94,4 +94,8 @@ public class Config {
     public String getFacebookAppId() {
         return getString(FACEBOOK_APP_ID);
     }
+
+    public String getEnvironmentDisplayName() {
+        return getString(ENVIRONMENT_DISPLAY_NAME);
+    }
 }

--- a/android/source/VideoLocker/src/org/edx/mobile/util/PropertyUtil.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/util/PropertyUtil.java
@@ -1,6 +1,9 @@
 package org.edx.mobile.util;
 
 import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+
 import java.io.InputStream;
 import java.util.Properties;
 import org.edx.mobile.logger.Logger;
@@ -9,25 +12,11 @@ public class PropertyUtil {
 
     private static final Logger logger = new Logger(PropertyUtil.class.getName());
 
-    public static String getDisplayVersionName(Context context) {
+    public static String getManifestVersionName(Context context) {
         try {
-            Properties props=new Properties();
-            InputStream inputStream = context.getAssets().open("config/config.properties");
-            props.load(inputStream);
-            
-            String versionName = props.getProperty("versionName");
-            String versionNameSuffix = props.getProperty("versionNameSuffix");
-            String buildConfig = props.getProperty("buildConfig");
-            if (buildConfig != null && buildConfig.equalsIgnoreCase("prod")) {
-                buildConfig = "";
-            }
-            
-            if (buildConfig != null && buildConfig.length() > 1) {
-                // init capital for the config name
-                buildConfig = Character.toUpperCase(buildConfig.charAt(0)) + buildConfig.substring(1);
-            }
-            
-            return versionName + "." + versionNameSuffix + " " + buildConfig;
+            PackageInfo pInfo = context.getPackageManager()
+                    .getPackageInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+            return pInfo.versionName;
         } catch(Exception ex) {
             logger.error(ex);
         }

--- a/android/source/VideoLocker/src/org/edx/mobile/view/NavigationFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/NavigationFragment.java
@@ -20,7 +20,6 @@ import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.api.ProfileModel;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.analytics.SegmentFactory;
-import org.edx.mobile.module.analytics.SegmentTracker;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.Emailutill;
@@ -142,18 +141,19 @@ public class NavigationFragment extends Fragment {
         
 
         TextView version_tv = (TextView) layout.findViewById(R.id.tv_version_no);
-        String version_name;
         try{
-            version_name = PropertyUtil.getDisplayVersionName(getActivity());
-            if(version_name!=null){
-                version_tv.setText(getString(R.string.label_version)+" "+version_name);
+            String versionName = PropertyUtil.getManifestVersionName(getActivity());
+
+            if(versionName != null) {
+                String envDisplayName = Environment.getInstance().getConfig().getEnvironmentDisplayName();
+                String text = String.format("%s %s %s",
+                        getString(R.string.label_version), versionName, envDisplayName);
+                version_tv.setText(text);
             }
-        }catch(Exception e){
+        }catch(Exception e) {
             logger.error(e);
         }
-        
-        
-        
+
         return layout;
     }
 


### PR DESCRIPTION
We were using <code>config.properties</code> file with ant tool earlier.
Now we don't need it. We can pick <code>versionName</code> from <code>AndroidManifest</code> and <code>ENVIRONMENT_DISPLAY_NAME</code> from the configuration to show in the app navigation drawer.

cc @aleffert @nasthagiri @shahidtamboli 