### PR TITLE
Change fill_parent to match_parent in layout files

### DIFF
--- a/android/source/VideoLocker/res/anim/slide_in_from_right.xml
+++ b/android/source/VideoLocker/res/anim/slide_in_from_right.xml
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<set xmlns:android="http://schemas.android.com/apk/res/android"
-     >
+<set xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <!--
-	<translate android:fromXDelta="-100%"
-    	android:toXDelta="0%" android:fromYDelta="0%"
-    	android:toYDelta="0%" android:duration="400">
-	</translate>
-    -->
     <translate
         android:duration="300"
         android:fromXDelta="100%"

--- a/android/source/VideoLocker/res/anim/slide_out_to_left.xml
+++ b/android/source/VideoLocker/res/anim/slide_out_to_left.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<set xmlns:android="http://schemas.android.com/apk/res/android"
-     >
-<!--     <translate
-        android:duration="400"
-        android:fromXDelta="0%"
-        android:fromYDelta="0%"
-        android:toXDelta="100%"
-        android:toYDelta="0%" >
-    </translate>
-   -->
-  
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+
   <translate
     android:fromXDelta="0"
     android:toXDelta="-100%"

--- a/android/source/VideoLocker/res/layout-land/activity_myvideos_tab.xml
+++ b/android/source/VideoLocker/res/layout-land/activity_myvideos_tab.xml
@@ -19,8 +19,8 @@
 
         <TabHost
             android:id="@android:id/tabhost"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" >
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" >
 
             <RelativeLayout
                 android:layout_width="match_parent"

--- a/android/source/VideoLocker/res/layout-land/player_controller.xml
+++ b/android/source/VideoLocker/res/layout-land/player_controller.xml
@@ -65,24 +65,11 @@
             android:paddingTop="4dip"
             android:visibility="gone" >
 
-            <!--
-                 <ImageButton
-                android:id="@+id/prev"
-                style="@android:style/MediaButton.Previous"
-                android:contentDescription="@string/app_name" />
-            -->
-
             <ImageButton
                 android:id="@+id/ffwd"
                 style="@android:style/MediaButton.Ffwd"
                 android:contentDescription="@string/app_name" />
 
-            <!--
-                 <ImageButton
-                android:id="@+id/next"
-                style="@android:style/MediaButton.Next"
-                android:contentDescription="@string/app_name" />
-            -->
         </LinearLayout>
 
         <LinearLayout
@@ -200,17 +187,6 @@
             android:contentDescription="@string/app_name"
              />
 
-        <!--
-             <ImageButton
-            android:id="@+id/previous_btn"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_centerVertical="true"
-            android:background="@drawable/ic_previous_button_selector"
-            android:contentDescription="@string/app_name" />
-        -->
-
         <ImageButton
             android:id="@+id/next"
             android:layout_width="wrap_content"
@@ -220,16 +196,6 @@
             android:background="@drawable/ic_next_button_selector"
             android:contentDescription="@string/app_name" />
 
-        <!--
-             <ImageButton
-            android:id="@+id/next_btn"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
-            android:layout_centerVertical="true"
-            android:background="@drawable/ic_next_button_selector"
-            android:contentDescription="@string/app_name" />
-        -->
     </RelativeLayout>
 
 </RelativeLayout>

--- a/android/source/VideoLocker/res/layout/activity_coursedetail_tab.xml
+++ b/android/source/VideoLocker/res/layout/activity_coursedetail_tab.xml
@@ -1,7 +1,7 @@
 <TabHost xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@android:id/tabhost"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:splitMotionEvents="false" >
 
     <RelativeLayout

--- a/android/source/VideoLocker/res/layout/activity_downloads_list.xml
+++ b/android/source/VideoLocker/res/layout/activity_downloads_list.xml
@@ -34,7 +34,7 @@
     <ListView
         android:id="@+id/my_downloads_list"
         style="@style/list_downloads"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/top_panel" />
 

--- a/android/source/VideoLocker/res/layout/activity_login.xml
+++ b/android/source/VideoLocker/res/layout/activity_login.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -166,18 +165,7 @@
                     android:text="@string/new_user"
                     android:textColor="@color/new_user_txt_color"
                     android:textSize="13sp" />
-                <!--
-                 <ETextView
-                    android:id="@+id/signup_text"
-                    style="@style/regular_text"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_below="@+id/new_user_tv"
-                    android:gravity="center"
-                    android:text="@string/sign_up"
-                    android:textColor="@color/grey_redirected_txt"
-                    android:textSize="10sp" /> 
-                -->
+
             </RelativeLayout>
         </RelativeLayout>
     </ScrollView>

--- a/android/source/VideoLocker/res/layout/activity_myvideos_tab.xml
+++ b/android/source/VideoLocker/res/layout/activity_myvideos_tab.xml
@@ -14,8 +14,8 @@
 
         <TabHost
             android:id="@android:id/tabhost"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" >
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" >
 
             <RelativeLayout
                 android:layout_width="match_parent"

--- a/android/source/VideoLocker/res/layout/activity_splash.xml
+++ b/android/source/VideoLocker/res/layout/activity_splash.xml
@@ -6,7 +6,7 @@
  
     <ImageView android:contentDescription="@string/app_name"
         android:id="@+id/backgroundLogo"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
         android:src="@drawable/edx_map" />

--- a/android/source/VideoLocker/res/layout/delete_successful_dialog.xml
+++ b/android/source/VideoLocker/res/layout/delete_successful_dialog.xml
@@ -11,7 +11,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/tv_dialog_title"
         style="@style/bold_grey_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="20dp"
         android:gravity="center"
@@ -20,7 +20,7 @@
         android:textSize="17sp" />
 
     <View
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="2dp"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"
@@ -36,7 +36,7 @@
         <org.edx.mobile.view.custom.ETextView
             android:id="@+id/tv_dialog_message1"
             style="@style/regular_grey_text"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="15dp"
             android:layout_marginLeft="20dp"
@@ -48,7 +48,7 @@
 
     <LinearLayout
         android:id="@+id/button_layout"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/grey_act_background"
         android:orientation="horizontal"

--- a/android/source/VideoLocker/res/layout/delete_video_dialog.xml
+++ b/android/source/VideoLocker/res/layout/delete_video_dialog.xml
@@ -11,7 +11,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/tv_dialog_title"
         style="@style/bold_grey_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="10dp"
         android:layout_marginLeft="10dp"
@@ -22,7 +22,7 @@
         android:textSize="17sp" />
 
     <View
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="2dp"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"
@@ -38,7 +38,7 @@
         <org.edx.mobile.view.custom.ETextView
             android:id="@+id/tv_dialog_message1"
             style="@style/regular_grey_text"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="10dp"
             android:layout_marginLeft="20dp"
@@ -50,7 +50,7 @@
 
     <LinearLayout
         android:id="@+id/button_layout"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/grey_act_background"
         android:orientation="horizontal"

--- a/android/source/VideoLocker/res/layout/drawer_navigation.xml
+++ b/android/source/VideoLocker/res/layout/drawer_navigation.xml
@@ -63,7 +63,7 @@
             android:textSize="14sp" />
 
         <View
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="1dp"
             android:layout_marginLeft="15dp"
             android:layout_marginRight="15dp"
@@ -72,7 +72,7 @@
         <org.edx.mobile.view.custom.ETextView
             android:id="@+id/my_assets"
             style="@style/regular_white_text"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="@dimen/height_drawer_menu"
             android:background="@drawable/nav_bg_selector"
             android:gravity="center_vertical"
@@ -85,7 +85,7 @@
             android:textSize="14sp" />
 
         <View
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="1dp"
             android:layout_marginLeft="15dp"
             android:layout_marginRight="15dp"
@@ -94,7 +94,7 @@
         <org.edx.mobile.view.custom.ETextView
             android:id="@+id/my_email"
             style="@style/regular_white_text"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="@dimen/height_drawer_menu"
             android:background="@drawable/nav_bg_selector"
             android:gravity="center_vertical"
@@ -107,7 +107,7 @@
             android:textSize="14sp" />
 
         <View
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="1dp"
             android:layout_marginBottom="10dp"
             android:layout_marginLeft="15dp"
@@ -163,7 +163,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/tv_version_no"
         style="@style/regular_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:layout_marginBottom="15dp"

--- a/android/source/VideoLocker/res/layout/fragment_course_info.xml
+++ b/android/source/VideoLocker/res/layout/fragment_course_info.xml
@@ -8,8 +8,8 @@
 
     <WebView
         android:id="@+id/webview"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:background="@color/grey_act_background" />
     
       <ProgressBar

--- a/android/source/VideoLocker/res/layout/fragment_dialog.xml
+++ b/android/source/VideoLocker/res/layout/fragment_dialog.xml
@@ -10,7 +10,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/tv_dialog_title"
         style="@style/bold_grey_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="10dp"
         android:layout_marginTop="20dp"
@@ -21,7 +21,7 @@
         android:paddingRight="5dp" />
 
     <View
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="2dp"
         android:layout_marginLeft="30dp"
         android:layout_marginRight="30dp"
@@ -37,7 +37,7 @@
         <org.edx.mobile.view.custom.ETextView
             android:id="@+id/tv_dialog_message1"
             style="@style/regular_grey_text"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginLeft="20dp"
             android:layout_marginRight="20dp"
@@ -59,7 +59,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/dialog_error_message"
         style="@style/regular_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="10dp"
         android:gravity="center"
@@ -97,7 +97,7 @@
 
     <LinearLayout
         android:id="@+id/button_layout"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/grey_act_background"
         android:orientation="horizontal"

--- a/android/source/VideoLocker/res/layout/fragment_find_courses_dialog.xml
+++ b/android/source/VideoLocker/res/layout/fragment_find_courses_dialog.xml
@@ -45,7 +45,7 @@
 
     <LinearLayout
         android:id="@+id/button_layout"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/grey_act_background"
         android:orientation="horizontal"

--- a/android/source/VideoLocker/res/layout/fragment_handout.xml
+++ b/android/source/VideoLocker/res/layout/fragment_handout.xml
@@ -8,8 +8,8 @@
 
     <WebView
         android:id="@+id/webview"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:background="@color/grey_act_background" />
 
     <ProgressBar

--- a/android/source/VideoLocker/res/layout/fragment_my_all_videos.xml
+++ b/android/source/VideoLocker/res/layout/fragment_my_all_videos.xml
@@ -29,7 +29,7 @@
 
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/empty_list_view"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
         android:gravity="center"

--- a/android/source/VideoLocker/res/layout/fragment_panel_network_slow_dialog.xml
+++ b/android/source/VideoLocker/res/layout/fragment_panel_network_slow_dialog.xml
@@ -8,7 +8,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/tv_dialog_message"
         style="@style/regular_grey_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="20dp"
         android:layout_marginRight="20dp"
@@ -20,7 +20,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/tv_small_dialog_message"
         style="@style/regular_grey_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="25dp"
         android:layout_marginRight="25dp"

--- a/android/source/VideoLocker/res/layout/fragment_reset_successful_dialog.xml
+++ b/android/source/VideoLocker/res/layout/fragment_reset_successful_dialog.xml
@@ -10,7 +10,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/tv_dialog_title"
         style="@style/bold_grey_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="20dp"
         android:gravity="center"
@@ -20,7 +20,7 @@
         android:textSize="17sp" />
 
     <View
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="2dp"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"
@@ -36,7 +36,7 @@
         <org.edx.mobile.view.custom.ETextView
             android:id="@+id/tv_dialog_message1"
             style="@style/regular_grey_text"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="15dp"
             android:layout_marginLeft="20dp"
@@ -48,7 +48,7 @@
 
     <LinearLayout
         android:id="@+id/button_layout"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/grey_act_background"
         android:orientation="horizontal"

--- a/android/source/VideoLocker/res/layout/fragment_video_list.xml
+++ b/android/source/VideoLocker/res/layout/fragment_video_list.xml
@@ -53,39 +53,4 @@
         android:layout_alignParentTop="true"
 />
 
-    <!--
-         <ETextView
-        android:id="@+id/empty_list_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:gravity="center"
-        android:text="@string/no_videos_to_display"
-        android:textSize="23sp"
-        android:visibility="gone"
-        android:textColor="@color/empty_list_text"
-        style="@style/bold_text" />
-    -->
-
-    <!-- <LinearLayout
-        android:id="@+id/offline_access_panel"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/transparent_download_bg"
-        android:orientation="vertical"
-        android:paddingBottom="15dp"
-        android:paddingTop="10dp"
-        android:visibility="gone" >
-
-        <ETextView
-            android:id="@+id/offline_access_header"
-            style="@style/offline_access_header"
-            android:text="@string/video_offline_header" />
-
-        <ETextView
-            android:id="@+id/offline_access_message"
-            style="@style/offline_access_message"
-            android:text="@string/video_offline_message" />
-    </LinearLayout> -->
-
 </RelativeLayout>

--- a/android/source/VideoLocker/res/layout/fragment_video_list.xml
+++ b/android/source/VideoLocker/res/layout/fragment_video_list.xml
@@ -8,7 +8,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/empty_list_view"
         style="@style/bold_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
         android:gravity="center"
@@ -56,7 +56,7 @@
     <!--
          <ETextView
         android:id="@+id/empty_list_view"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
         android:gravity="center"

--- a/android/source/VideoLocker/res/layout/fragment_video_list_with_player_container.xml
+++ b/android/source/VideoLocker/res/layout/fragment_video_list_with_player_container.xml
@@ -8,7 +8,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/empty_list_view"
         style="@style/bold_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
         android:gravity="center"
@@ -85,7 +85,7 @@
     <!--
          <ETextView
         android:id="@+id/empty_list_view"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
         android:gravity="center"

--- a/android/source/VideoLocker/res/layout/fragment_video_list_with_player_container.xml
+++ b/android/source/VideoLocker/res/layout/fragment_video_list_with_player_container.xml
@@ -82,39 +82,4 @@
         style="@style/default_list"
         android:transcriptMode="disabled"/>
 
-    <!--
-         <ETextView
-        android:id="@+id/empty_list_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:gravity="center"
-        android:text="@string/no_videos_to_display"
-        android:textSize="23sp"
-        android:visibility="gone"
-        android:textColor="@color/empty_list_text"
-        style="@style/bold_text" />
-    -->
-
-    <!-- <LinearLayout
-        android:id="@+id/offline_access_panel"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/transparent_download_bg"
-        android:orientation="vertical"
-        android:paddingBottom="15dp"
-        android:paddingTop="10dp"
-        android:visibility="gone" >
-
-        <ETextView
-            android:id="@+id/offline_access_header"
-            style="@style/offline_access_header"
-            android:text="@string/video_offline_header" />
-
-        <ETextView
-            android:id="@+id/offline_access_message"
-            style="@style/offline_access_message"
-            android:text="@string/video_offline_message" />
-    </LinearLayout> -->
-
 </RelativeLayout>

--- a/android/source/VideoLocker/res/layout/fragment_videosize_exceeds_dialog.xml
+++ b/android/source/VideoLocker/res/layout/fragment_videosize_exceeds_dialog.xml
@@ -11,7 +11,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/tv_dialog_title"
         style="@style/bold_grey_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="10dp"
         android:layout_marginLeft="10dp"
@@ -22,7 +22,7 @@
         android:textSize="17sp" />
 
     <View
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="2dp"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"
@@ -38,7 +38,7 @@
         <org.edx.mobile.view.custom.ETextView
             android:id="@+id/tv_dialog_message1"
             style="@style/regular_grey_text"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="10dp"
             android:layout_marginLeft="20dp"
@@ -50,7 +50,7 @@
 
     <LinearLayout
         android:id="@+id/button_layout"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/grey_act_background"
         android:orientation="horizontal"

--- a/android/source/VideoLocker/res/layout/fragment_web_dialog.xml
+++ b/android/source/VideoLocker/res/layout/fragment_web_dialog.xml
@@ -9,7 +9,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/tv_dialog_title"
         style="@style/bold_grey_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"
         android:singleLine="false"
@@ -20,7 +20,7 @@
         android:padding="10dp" />
 
     <View android:id="@+id/view_seperator"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="2dp"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"
@@ -30,7 +30,7 @@
     
     <LinearLayout
         android:id="@+id/button_layout"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/grey_act_background"
         android:orientation="horizontal"

--- a/android/source/VideoLocker/res/layout/fragment_wifiswitchoff_dialog.xml
+++ b/android/source/VideoLocker/res/layout/fragment_wifiswitchoff_dialog.xml
@@ -10,7 +10,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/tv_dialog_title"
         style="@style/bold_grey_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="10dp"
         android:layout_marginLeft="10dp"
@@ -21,7 +21,7 @@
         android:textSize="17sp" />
 
     <View
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="2dp"
         android:layout_marginLeft="20dp"
         android:layout_marginRight="20dp"
@@ -37,7 +37,7 @@
         <org.edx.mobile.view.custom.ETextView
             android:id="@+id/tv_dialog_message1"
             style="@style/regular_grey_text"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginLeft="20dp"
             android:layout_marginRight="20dp"
@@ -49,7 +49,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/error_message"
         style="@style/regular_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="5dp"
         android:gravity="center"
@@ -60,7 +60,7 @@
 
     <LinearLayout
         android:id="@+id/button_layout"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/grey_act_background"
         android:orientation="horizontal"

--- a/android/source/VideoLocker/res/layout/panel_download_msg.xml
+++ b/android/source/VideoLocker/res/layout/panel_download_msg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/include_layout"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="70dp"
     android:background="@color/include_msg_color" >
 

--- a/android/source/VideoLocker/res/layout/panel_external_component.xml
+++ b/android/source/VideoLocker/res/layout/panel_external_component.xml
@@ -38,17 +38,4 @@
         android:drawablePadding="8dp"
         /> 
     
-<!--     <EButton
-        android:id="@+id/open_in_browser_btn"
-        style="@style/semibold_white_text"
-        android:layout_width="wrap_content"
-        android:layout_height="35dp"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="12dp"
-        android:background="@drawable/logout_bg_selector"
-        android:gravity="center"
-        android:text="@string/lbl_open_in_browser"
-        android:textAllCaps="true"
-        android:textSize="14sp" /> -->
-
 </RelativeLayout>

--- a/android/source/VideoLocker/res/layout/panel_find_course.xml
+++ b/android/source/VideoLocker/res/layout/panel_find_course.xml
@@ -6,7 +6,7 @@
 
     <RelativeLayout
         android:id="@+id/panel_course_layout"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/white"
         android:descendantFocusability="blocksDescendants"
@@ -15,7 +15,7 @@
         <org.edx.mobile.view.custom.ETextView
             android:id="@+id/findcourse_tv"
             style="@style/semibold_text"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_centerHorizontal="true"
             android:layout_marginBottom="18dp"

--- a/android/source/VideoLocker/res/layout/panel_login_social.xml
+++ b/android/source/VideoLocker/res/layout/panel_login_social.xml
@@ -92,16 +92,6 @@
             </LinearLayout>
         </RelativeLayout>
 
-        <!-- <TextView android:background="@drawable/bt_facebook"
-            android:drawableLeft="@drawable/ic_facebook"
-            android:layout_width="140dp"
-            android:layout_height="40dp"
-            android:text="@string/facebook_text"
-            android:gravity="left|center_vertical"
-            android:textColor="@android:color/white"
-            android:drawablePadding="20dp"
-            /> -->
-        
         <RelativeLayout
             android:id="@+id/google_layout"
             android:layout_width="0dp"

--- a/android/source/VideoLocker/res/layout/panel_login_social.xml
+++ b/android/source/VideoLocker/res/layout/panel_login_social.xml
@@ -37,7 +37,7 @@
 
     <LinearLayout
         android:id="@+id/layout"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:layout_marginBottom="10dp"

--- a/android/source/VideoLocker/res/layout/panel_player.xml
+++ b/android/source/VideoLocker/res/layout/panel_player.xml
@@ -36,18 +36,6 @@
             layout="@layout/panel_video_not_available"
             android:visibility="gone" />
 
-        <!--
-             <ETextView
-            android:id="@+id/txtSubtitles"
-            style="@style/regular_white_text"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginLeft="15dp"
-            android:layout_marginRight="15dp"
-            android:gravity="bottom|center_horizontal"
-            android:textSize="12sp"
-            android:visibility="visible" />
-        -->
     </FrameLayout>
 
     <ProgressBar
@@ -55,22 +43,6 @@
         style="@style/player_progress_style"
         android:layout_centerInParent="true"
         android:visibility="invisible" />
-
-    <!--
-         <ETextView
-        android:id="@+id/txtSubtitles"
-        style="@style/regular_white_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_centerHorizontal="true"
-        android:layout_marginBottom="20dp"
-        android:layout_marginLeft="15dp"
-        android:layout_marginRight="15dp"
-        android:gravity="center"
-        android:textSize="12sp"
-        android:visibility="visible" />
-    -->
 
     <ImageView
         android:id="@+id/iv_transparent_bg"

--- a/android/source/VideoLocker/res/layout/panel_player_no_network.xml
+++ b/android/source/VideoLocker/res/layout/panel_player_no_network.xml
@@ -10,7 +10,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/tv_dialog_message"
         style="@style/regular_white_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="20dp"
         android:layout_marginRight="20dp"
@@ -22,7 +22,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/tv_small_dialog_message"
         style="@style/regular_white_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="20dp"
         android:layout_marginRight="20dp"

--- a/android/source/VideoLocker/res/layout/panel_settings_popup.xml
+++ b/android/source/VideoLocker/res/layout/panel_settings_popup.xml
@@ -16,20 +16,4 @@
         android:text="@string/lbl_closed_caption"
         android:background="@drawable/white_rounded_selector" />
 
-<!--      <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/grey_act_background" /> 
-
-    <ETextView
-        android:id="@+id/tv_speedcontrol"
-        style="@style/regular_text"
-        android:layout_width="match_parent"
-        android:layout_height="40dp"
-        android:gravity="left|center_vertical"
-        android:padding="10dp"
-        android:text="@string/lbl_video_speed"
-        android:background="@drawable/grey_rounded_bottom"
-        android:textColor="@color/grey_text_mycourse" />
- -->
 </LinearLayout>

--- a/android/source/VideoLocker/res/layout/panel_video_not_available.xml
+++ b/android/source/VideoLocker/res/layout/panel_video_not_available.xml
@@ -13,9 +13,4 @@
         android:text="@string/msg_video_not_available"
         android:textSize="15sp" />
 
-   <!--  <ETextView
-        style="@style/text_network_error"
-        android:text="@string/network_error_message"
-        android:layout_marginTop="5dp" /> -->
-
 </LinearLayout>

--- a/android/source/VideoLocker/res/layout/player_controller.xml
+++ b/android/source/VideoLocker/res/layout/player_controller.xml
@@ -63,20 +63,11 @@
             android:paddingTop="4dip"
             android:visibility="gone" >
 
-<!--             <ImageButton
-                android:id="@+id/prev"
-                style="@android:style/MediaButton.Previous"
-                android:contentDescription="@string/app_name" /> -->
-
             <ImageButton
                 android:id="@+id/ffwd"
                 style="@android:style/MediaButton.Ffwd"
                 android:contentDescription="@string/app_name" />
 
-        <!--     <ImageButton
-                android:id="@+id/next"
-                style="@android:style/MediaButton.Next"
-                android:contentDescription="@string/app_name" /> -->
         </LinearLayout>
 
         <LinearLayout
@@ -185,27 +176,6 @@
             android:layout_centerInParent="true"
             android:background="@drawable/ic_pause_button_selector"
             android:contentDescription="@string/app_name" />
-
-        
-     <!--    <ImageButton
-            android:id="@+id/prev"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_centerVertical="true"
-            android:background="@drawable/ic_previous_button_selector"
-            android:contentDescription="@string/app_name"
-             />
-
-        <ImageButton
-            android:id="@+id/next"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
-            android:layout_centerVertical="true"
-            android:background="@drawable/ic_next_button_selector"
-            android:contentDescription="@string/app_name"/> -->
-
 
     </RelativeLayout>
 

--- a/android/source/VideoLocker/res/layout/resetpassword_no_network_dialog.xml
+++ b/android/source/VideoLocker/res/layout/resetpassword_no_network_dialog.xml
@@ -10,7 +10,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/tv_dialog_title"
         style="@style/bold_grey_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="10dp"
         android:layout_marginLeft="10dp"
@@ -21,7 +21,7 @@
         android:textSize="17sp" />
 
     <View
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="2dp"
         android:layout_marginLeft="20dp"
         android:layout_marginRight="20dp"
@@ -37,7 +37,7 @@
         <org.edx.mobile.view.custom.ETextView
             android:id="@+id/tv_dialog_message1"
             style="@style/regular_grey_text"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginLeft="20dp"
             android:layout_marginRight="20dp"
@@ -48,7 +48,7 @@
 
     <LinearLayout
         android:id="@+id/button_layout"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/grey_act_background"
         android:orientation="horizontal"

--- a/android/source/VideoLocker/res/layout/row_announcement_list.xml
+++ b/android/source/VideoLocker/res/layout/row_announcement_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/announcement_row_layout"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@drawable/list_selector"
     android:orientation="vertical"

--- a/android/source/VideoLocker/res/layout/row_chapter_list.xml
+++ b/android/source/VideoLocker/res/layout/row_chapter_list.xml
@@ -1,6 +1,6 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/chapter_row_layout"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@drawable/list_selector"
     android:paddingLeft="12dp"

--- a/android/source/VideoLocker/res/layout/row_course_list.xml
+++ b/android/source/VideoLocker/res/layout/row_course_list.xml
@@ -5,7 +5,7 @@
 
     <RelativeLayout
         android:id="@+id/course_row_layout"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/white"
         android:descendantFocusability="blocksDescendants"
@@ -37,8 +37,8 @@
         <org.edx.mobile.view.custom.ETextView
             android:id="@+id/course_name"
             style="@style/bold_grey_text"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:layout_below="@id/course_image"
             android:layout_marginBottom="8dp"
             android:layout_marginLeft="10dp"

--- a/android/source/VideoLocker/res/layout/row_course_list.xml
+++ b/android/source/VideoLocker/res/layout/row_course_list.xml
@@ -20,20 +20,6 @@
             android:contentDescription="@string/course_image"
             android:scaleType="centerCrop" />
 
-        <!--
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="125dp"
-        android:layout_alignParentTop="true" >
-
-        <ImageView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:contentDescription="@string/course_image"
-            android:src="@drawable/transparent_bg" />
-    </FrameLayout>
-        -->
-
         <org.edx.mobile.view.custom.ETextView
             android:id="@+id/course_name"
             style="@style/bold_grey_text"
@@ -46,21 +32,6 @@
             android:layout_marginTop="10dp"
             android:text="@string/course_name"
             android:textSize="16sp" />
-        <!--
-    <ETextView
-        android:id="@+id/school_code"
-        style="@style/regular_grey_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/course_name"
-        android:layout_marginLeft="10dp"
-        android:layout_marginRight="10dp"
-        android:ellipsize="end"
-        android:maxWidth="120dp"
-        android:singleLine="true"
-        android:text="@string/school_code"
-        android:textSize="12sp" />
-        -->
 
         <LinearLayout
             android:id="@+id/schoolcode_layout"
@@ -155,23 +126,6 @@
         </LinearLayout>
     </RelativeLayout>
 
-  <!--   <LinearLayout
-        android:id="@+id/layout"
-        android:layout_width="wrap_content"
-        android:layout_height="130dp"
-        android:layout_alignParentBottom="true"
-        android:layout_below="@+id/course_row_layout"
-        android:orientation="vertical" >
-
-        <TextView
-            android:id="@+id/tv"
-            style="@style/semibold_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Looking for a new challenge"
-            android:textColor="#454951"
-            android:textSize="12sp" />
-    </LinearLayout> -->
     <!-- put a frame over this cell, so that corners look rounded -->
 
     <ImageView

--- a/android/source/VideoLocker/res/layout/row_download_list.xml
+++ b/android/source/VideoLocker/res/layout/row_download_list.xml
@@ -1,6 +1,6 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/downloads_row_layout"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@android:color/white"
     android:padding="10dp" >
@@ -71,7 +71,7 @@
     <ProgressBar
         android:id="@+id/progressBar"
         style="@style/CustomProgressBar"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/download_time"
         android:layout_marginBottom="4dp"
@@ -84,7 +84,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/txtDownloadFailed"
         style="@style/semibold_text"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/progressBar"
         android:layout_marginBottom="5dp"

--- a/android/source/VideoLocker/res/layout/row_myvideo_course_list.xml
+++ b/android/source/VideoLocker/res/layout/row_myvideo_course_list.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content" >
 
     <LinearLayout
         android:id="@+id/course_row_layout"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/white"
         android:descendantFocusability="blocksDescendants"
@@ -14,7 +14,7 @@
 
         <com.android.volley.toolbox.NetworkImageView
             android:id="@+id/course_image"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="120dp"
             android:adjustViewBounds="true"
             android:contentDescription="@string/course_image"
@@ -22,7 +22,7 @@
 
         <RelativeLayout
             android:id="@+id/course_data"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginLeft="10dp"
             android:layout_marginRight="10dp"
@@ -31,8 +31,8 @@
             <org.edx.mobile.view.custom.ETextView
                 android:id="@+id/course_name"
                 style="@style/bold_grey_text"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
                 android:layout_alignParentTop="true"
                 android:layout_marginBottom="10dp"
                 android:lineSpacingExtra="-1.5dp"

--- a/android/source/VideoLocker/res/layout/row_video_list.xml
+++ b/android/source/VideoLocker/res/layout/row_video_list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@drawable/list_selector"
     android:orientation="vertical" >
@@ -34,7 +34,7 @@
 
     <RelativeLayout
         android:id="@+id/video_row_layout"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:padding="10dp" >
 


### PR DESCRIPTION
We had previously used <code>fill_parent</code> at a few places in the layout files for setting height and width. The attribute <code>fill_parent</code> has been deprecated and has been replaced by <code>match_parent</code>. 
I have also removed commented out code from the layout files.

@rohan-dhamal-clarice @nasthagiri - Please review.