### PR TITLE
Allow third party services to be enabled if there is NO configuration provided

### DIFF
--- a/android/source/VideoLocker/androidTest/java/org/edx/mobile/test/ConfigTests.java
+++ b/android/source/VideoLocker/androidTest/java/org/edx/mobile/test/ConfigTests.java
@@ -1,7 +1,6 @@
 package org.edx.mobile.test;
 
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
@@ -24,6 +23,13 @@ public class ConfigTests extends BaseTestCase {
     private static final String COURSE_ENROLLMENT = "COURSE_ENROLLMENT";
     private static final String SEARCH_URL = "SEARCH_URL";
     private static final String COURSE_INFO_URL_TEMPLATE = "COURSE_INFO_URL_TEMPLATE";
+
+    private static final String THIRD_PARTY_TRAFFIC = "THIRD_PARTY_TRAFFIC";
+    private static final String GOOGLE_ENABLED = "GOOGLE_ENABLED";
+    private static final String FACEBOOK_ENABLED = "FACEBOOK_ENABLED";
+    private static final String NEW_RELIC_ENABLED = "NEW_RELIC_ENABLED";
+    private static final String FABRIC_ENABLED = "FABRIC_ENABLED";
+    private static final String SEGMENTIO_ENABLED = "SEGMENTIO_ENABLED";
 
     public void testSocialSharingNoConfig() {
         JsonObject configBase = new JsonObject();
@@ -125,5 +131,45 @@ public class ConfigTests extends BaseTestCase {
         assertTrue(config.getEnrollment().getEnabled());
         assertEquals(config.getEnrollment().getSearchUrl(), "fake-url");
         assertEquals(config.getEnrollment().getCourseInfoUrlTemplate(), "fake-url-template");
+    }
+
+    public void testThirdPartyNoConfig() {
+        JsonObject configBase = new JsonObject();
+        Config config = new Config(configBase);
+        assertTrue(config.getThirdPartyTraffic().isFabricEnabled());
+        assertTrue(config.getThirdPartyTraffic().isFacebookEnabled());
+        assertTrue(config.getThirdPartyTraffic().isGoogleEnabled());
+        assertTrue(config.getThirdPartyTraffic().isNewRelicEnabled());
+        assertTrue(config.getThirdPartyTraffic().isSegmentEnabled());
+    }
+
+    public void testThirdPartyEmptyConfig() {
+        JsonObject configBase = new JsonObject();
+        JsonObject thirdPartyConfig = new JsonObject();
+        configBase.add(THIRD_PARTY_TRAFFIC, thirdPartyConfig);
+        Config config = new Config(configBase);
+        assertFalse(config.getThirdPartyTraffic().isFabricEnabled());
+        assertFalse(config.getThirdPartyTraffic().isFacebookEnabled());
+        assertFalse(config.getThirdPartyTraffic().isGoogleEnabled());
+        assertFalse(config.getThirdPartyTraffic().isNewRelicEnabled());
+        assertFalse(config.getThirdPartyTraffic().isSegmentEnabled());
+    }
+
+    public void testThirdPartyConfig() {
+        JsonObject configBase = new JsonObject();
+        JsonObject thirdPartyConfig = new JsonObject();
+        thirdPartyConfig.add(GOOGLE_ENABLED, new JsonPrimitive(false));
+        thirdPartyConfig.add(FABRIC_ENABLED, new JsonPrimitive(false));
+        thirdPartyConfig.add(NEW_RELIC_ENABLED, new JsonPrimitive(false));
+        thirdPartyConfig.add(FABRIC_ENABLED, new JsonPrimitive(false));
+        thirdPartyConfig.add(SEGMENTIO_ENABLED, new JsonPrimitive(false));
+        configBase.add(THIRD_PARTY_TRAFFIC, thirdPartyConfig);
+
+        Config config = new Config(configBase);
+        assertFalse(config.getThirdPartyTraffic().isFabricEnabled());
+        assertFalse(config.getThirdPartyTraffic().isFacebookEnabled());
+        assertFalse(config.getThirdPartyTraffic().isGoogleEnabled());
+        assertFalse(config.getThirdPartyTraffic().isNewRelicEnabled());
+        assertFalse(config.getThirdPartyTraffic().isSegmentEnabled());
     }
 }

--- a/android/source/VideoLocker/src/org/edx/mobile/module/db/impl/DbOperationExists.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/module/db/impl/DbOperationExists.java
@@ -13,9 +13,9 @@ class DbOperationExists extends DbOperationSelect<Boolean> {
     @Override
     public Boolean execute(SQLiteDatabase db) {
         Cursor c = getCursor(db);
-        boolean exists = (c.getCount() > 0);
+        Boolean exists = (c.getCount() > 0);
         c.close();
-        return exists;
+        return (exists != null && exists);
     }
     
 }

--- a/android/source/VideoLocker/src/org/edx/mobile/module/facebook/FacebookSessionUtil.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/module/facebook/FacebookSessionUtil.java
@@ -1,0 +1,23 @@
+package org.edx.mobile.module.facebook;
+
+import com.facebook.Session;
+
+/**
+ * Created by rohan on 2/12/15.
+ */
+public class FacebookSessionUtil {
+
+    /**
+     * Returns Facebook session accessToken if available, null otherwise.
+     * @return
+     */
+    public static String getAccessToken() {
+        Session session = Session.getActiveSession();
+        if (session != null) {
+            return session.getAccessToken();
+        }
+        else {
+            return null;
+        }
+    }
+}

--- a/android/source/VideoLocker/src/org/edx/mobile/module/facebook/IUiLifecycleHelper.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/module/facebook/IUiLifecycleHelper.java
@@ -1,0 +1,46 @@
+package org.edx.mobile.module.facebook;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.facebook.Session;
+import com.facebook.widget.FacebookDialog;
+
+/**
+ * Created by rohan on 2/12/15.
+ */
+public interface IUiLifecycleHelper {
+
+
+    void onCreate(Bundle savedInstanceState);
+
+    void onActivityResult(int requestCode, int resultCode, Intent data);
+
+    void onResume();
+
+    void onPause();
+
+    void onStop();
+
+    void onDestroy();
+
+    void trackPendingDialogCall(FacebookDialog.PendingCall present);
+
+    void onActivityResult(int requestCode, int resultCode, Intent data, FacebookDialog.Callback callback);
+
+    void onSaveInstanceState(Bundle outState);
+
+    public static class Factory {
+
+        /**
+         * Returns instance of {@link org.edx.mobile.module.facebook.IUiLifecycleHelperImpl} class.
+         * @param activity
+         * @param statusCallback
+         * @return
+         */
+        public static IUiLifecycleHelper getInstance(Activity activity, Session.StatusCallback statusCallback) {
+            return new IUiLifecycleHelperImpl(activity, statusCallback);
+        }
+    }
+}

--- a/android/source/VideoLocker/src/org/edx/mobile/module/facebook/IUiLifecycleHelperImpl.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/module/facebook/IUiLifecycleHelperImpl.java
@@ -1,0 +1,83 @@
+package org.edx.mobile.module.facebook;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.facebook.Session;
+import com.facebook.UiLifecycleHelper;
+import com.facebook.widget.FacebookDialog;
+
+/**
+ * Created by rohan on 2/12/15.
+ *
+ * This class forwards all the methods calls to {@link com.facebook.UiLifecycleHelper}.
+ * However, if during object creation of this class, if Facebook applicationId was not configured, then
+ * this class doesn't forward any calls to {@link com.facebook.UiLifecycleHelper}, meaning it does nothing in this case.
+ */
+class IUiLifecycleHelperImpl implements IUiLifecycleHelper {
+
+    private UiLifecycleHelper uiLifecycleHelper;
+
+    public IUiLifecycleHelperImpl(Activity activity, Session.StatusCallback statusCallback) {
+        if (com.facebook.Settings.getApplicationId() != null) {
+            // make this initialization only if there is an applicationId already configured
+
+            uiLifecycleHelper = new UiLifecycleHelper(activity, statusCallback);
+        }
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        if (uiLifecycleHelper != null)
+            uiLifecycleHelper.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (uiLifecycleHelper != null)
+            uiLifecycleHelper.onActivityResult(requestCode, resultCode, data);
+    }
+
+    @Override
+    public void onResume() {
+        if (uiLifecycleHelper != null)
+            uiLifecycleHelper.onResume();
+    }
+
+    @Override
+    public void onPause() {
+        if (uiLifecycleHelper != null)
+            uiLifecycleHelper.onPause();
+    }
+
+    @Override
+    public void onStop() {
+        if (uiLifecycleHelper != null)
+            uiLifecycleHelper.onStop();
+    }
+
+    @Override
+    public void onDestroy() {
+        if (uiLifecycleHelper != null)
+            uiLifecycleHelper.onDestroy();
+    }
+
+    @Override
+    public void trackPendingDialogCall(FacebookDialog.PendingCall present) {
+        if (uiLifecycleHelper != null)
+            uiLifecycleHelper.trackPendingDialogCall(present);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data, FacebookDialog.Callback callback) {
+        if (uiLifecycleHelper != null)
+            uiLifecycleHelper.onActivityResult(requestCode, resultCode, data, callback);
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        if (uiLifecycleHelper != null)
+            uiLifecycleHelper.onSaveInstanceState(outState);
+    }
+}

--- a/android/source/VideoLocker/src/org/edx/mobile/player/PlayerFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/player/PlayerFragment.java
@@ -40,6 +40,7 @@ import org.edx.mobile.model.api.TranscriptModel;
 import org.edx.mobile.model.db.DownloadEntry;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.analytics.SegmentFactory;
+import org.edx.mobile.module.facebook.IUiLifecycleHelper;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.social.facebook.FacebookProvider;
 import org.edx.mobile.util.AppConstants;
@@ -97,7 +98,7 @@ public class PlayerFragment extends Fragment implements IPlayerListener, Seriali
 
     private final Logger logger = new Logger(getClass().getName());
 
-    private UiLifecycleHelper uiHelper;
+    private IUiLifecycleHelper uiHelper;
     private boolean pauseDueToDialog;
 
     private final transient Handler handler = new Handler() {
@@ -162,7 +163,7 @@ public class PlayerFragment extends Fragment implements IPlayerListener, Seriali
         View view = inflater.inflate(R.layout.panel_player, null);
         this.layoutInflater = inflater;
 
-        uiHelper = new UiLifecycleHelper(getActivity(), null);
+        uiHelper = IUiLifecycleHelper.Factory.getInstance(getActivity(), null);
         uiHelper.onCreate(savedInstanceState);
 
         return view;

--- a/android/source/VideoLocker/src/org/edx/mobile/social/facebook/FacebookAuth.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/social/facebook/FacebookAuth.java
@@ -1,11 +1,5 @@
 package org.edx.mobile.social.facebook;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
-
-import org.edx.mobile.social.ISocialImpl;
-
 import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
@@ -17,11 +11,17 @@ import android.util.Base64;
 
 import com.facebook.Session;
 import com.facebook.SessionState;
-import com.facebook.UiLifecycleHelper;
+
+import org.edx.mobile.module.facebook.IUiLifecycleHelper;
+import org.edx.mobile.social.ISocialImpl;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 
 public class FacebookAuth extends ISocialImpl {
 
-    private UiLifecycleHelper uiHelper;
+    private IUiLifecycleHelper uiHelper;
 
     private Session.StatusCallback statusCallback = new Session.StatusCallback() {
         @Override
@@ -54,7 +54,7 @@ public class FacebookAuth extends ISocialImpl {
 
     @Override
     public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-        uiHelper = new UiLifecycleHelper(activity, statusCallback);
+        uiHelper = IUiLifecycleHelper.Factory.getInstance(activity, statusCallback);
         uiHelper.onCreate(savedInstanceState);
 
         keyHash();

--- a/android/source/VideoLocker/src/org/edx/mobile/social/facebook/FacebookProvider.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/social/facebook/FacebookProvider.java
@@ -27,6 +27,7 @@ import org.edx.mobile.social.SocialMember;
 import org.edx.mobile.social.SocialProvider;
 import org.edx.mobile.task.social.CreateGroupTask;
 import org.edx.mobile.task.social.InviteFriendsListToGroupTask;
+import org.edx.mobile.module.facebook.FacebookSessionUtil;
 import org.edx.mobile.util.SocialUtils;
 
 import java.util.ArrayList;
@@ -143,7 +144,7 @@ public class FacebookProvider implements SocialProvider {
     @Override
     public void inviteFriendsListToGroup(Context context, long groupID, List<SocialMember> friendList, final Callback<Void> callback) {
 
-        String token = Session.getActiveSession().getAccessToken();
+        String token = FacebookSessionUtil.getAccessToken();
 
         Long[] friendIDs = new Long[friendList.size()];
         for (int i = 0; i < friendList.size(); i++){
@@ -168,7 +169,7 @@ public class FacebookProvider implements SocialProvider {
     @Override
     public void createNewGroup(Context context, String name, String description, String admin, final Callback<Long> callback) {
 
-        String token = Session.getActiveSession().getAccessToken();
+        String token = FacebookSessionUtil.getAccessToken();
 
         CreateGroupTask createGroupTask = new CreateGroupTask(context) {
 

--- a/android/source/VideoLocker/src/org/edx/mobile/task/social/CreateGroupTask.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/task/social/CreateGroupTask.java
@@ -2,10 +2,9 @@ package org.edx.mobile.task.social;
 
 import android.content.Context;
 
-import com.facebook.Session;
-
 import org.edx.mobile.http.Api;
 import org.edx.mobile.task.Task;
+import org.edx.mobile.module.facebook.FacebookSessionUtil;
 
 public abstract class CreateGroupTask extends Task<Long> {
 
@@ -22,7 +21,7 @@ public abstract class CreateGroupTask extends Task<Long> {
         String description = (String) params[1];
         long adminID = Long.parseLong((String)params[2]);
         Boolean privacy = (Boolean) params[3];
-        String oauthToken = Session.getActiveSession().getAccessToken();
+        String oauthToken = FacebookSessionUtil.getAccessToken();
         //
         Api api = new Api(context);
         try {

--- a/android/source/VideoLocker/src/org/edx/mobile/util/Config.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/util/Config.java
@@ -95,12 +95,17 @@ public class Config {
         }
     }
 
+    /**
+     * Third party service calls are enabled by default, if no configuration is provided.
+     * Providing empty configuration disables all the services.
+     * Providing complete configuration allows to enable or disable the calls to individual service.
+     */
     public class ThirdPartyTrafficConfig {
-        private @SerializedName("GOOGLE_ENABLED") boolean googleEnabled;
-        private @SerializedName("FACEBOOK_ENABLED") boolean facebookEnabled;
-        private @SerializedName("NEW_RELIC_ENABLED") boolean newRelicEnabled;
-        private @SerializedName("FABRIC_ENABLED") boolean fabricEnabled;
-        private @SerializedName("SEGMENTIO_ENABLED") boolean segmentEnabled;
+        private @SerializedName("GOOGLE_ENABLED") boolean googleEnabled = true;
+        private @SerializedName("FACEBOOK_ENABLED") boolean facebookEnabled = true;
+        private @SerializedName("NEW_RELIC_ENABLED") boolean newRelicEnabled = true;
+        private @SerializedName("FABRIC_ENABLED") boolean fabricEnabled = true;
+        private @SerializedName("SEGMENTIO_ENABLED") boolean segmentEnabled = true;
 
         public boolean isGoogleEnabled() {
             return googleEnabled;

--- a/android/source/VideoLocker/src/org/edx/mobile/view/CourseCombinedInfoFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/CourseCombinedInfoFragment.java
@@ -16,9 +16,7 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import com.facebook.Session;
 import com.facebook.Settings;
-import com.facebook.UiLifecycleHelper;
 import com.facebook.widget.FacebookDialog;
 import com.facebook.widget.LikeView;
 
@@ -30,11 +28,13 @@ import org.edx.mobile.loader.FriendsInCourseLoader;
 import org.edx.mobile.model.api.AnnouncementsModel;
 import org.edx.mobile.model.api.CourseEntry;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
+import org.edx.mobile.module.facebook.IUiLifecycleHelper;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.social.SocialMember;
 import org.edx.mobile.social.facebook.FacebookProvider;
 import org.edx.mobile.task.GetAnnouncementTask;
 import org.edx.mobile.util.DateUtil;
+import org.edx.mobile.module.facebook.FacebookSessionUtil;
 import org.edx.mobile.util.SocialUtils;
 import org.edx.mobile.util.images.ImageCacheManager;
 import org.edx.mobile.view.custom.CourseImageHeader;
@@ -68,7 +68,7 @@ public class CourseCombinedInfoFragment extends CourseDetailBaseFragment impleme
     private List<AnnouncementsModel> savedAnnouncements;
     private SocialAffirmView likeButton;
     private SocialShareView shareButton;
-    private UiLifecycleHelper uiHelper;
+    private IUiLifecycleHelper uiHelper;
 
     private ArrayList<SocialMember> courseFriends;
 
@@ -82,7 +82,7 @@ public class CourseCombinedInfoFragment extends CourseDetailBaseFragment impleme
 
         Settings.sdkInitialize(getActivity());
 
-        uiHelper = new UiLifecycleHelper(getActivity(), null);
+        uiHelper = IUiLifecycleHelper.Factory.getInstance(getActivity(), null);
         uiHelper.onCreate(savedInstanceState);
 
     }
@@ -323,7 +323,7 @@ public class CourseCombinedInfoFragment extends CourseDetailBaseFragment impleme
         Bundle args = new Bundle();
 
         args.putString(FriendsInCourseLoader.TAG_COURSE_ID, courseData.getCourse().getId());
-        args.putString(FriendsInCourseLoader.TAG_COURSE_OAUTH, Session.getActiveSession().getAccessToken());
+        args.putString(FriendsInCourseLoader.TAG_COURSE_OAUTH, FacebookSessionUtil.getAccessToken());
 
         getLoaderManager().restartLoader(LOADER_ID, args, this);
 

--- a/android/source/VideoLocker/src/org/edx/mobile/view/CourseListTabFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/CourseListTabFragment.java
@@ -21,7 +21,6 @@ import android.widget.ProgressBar;
 
 import com.facebook.Session;
 import com.facebook.SessionState;
-import com.facebook.UiLifecycleHelper;
 
 import org.edx.mobile.R;
 import org.edx.mobile.base.BaseFragmentActivity;
@@ -32,6 +31,7 @@ import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.analytics.SegmentFactory;
+import org.edx.mobile.module.facebook.IUiLifecycleHelper;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.services.FetchCourseFriendsService;
 import org.edx.mobile.social.SocialMember;
@@ -39,6 +39,7 @@ import org.edx.mobile.social.SocialProvider;
 import org.edx.mobile.social.facebook.FacebookProvider;
 import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.Config;
+import org.edx.mobile.module.facebook.FacebookSessionUtil;
 import org.edx.mobile.util.UiUtil;
 import org.edx.mobile.view.adapters.MyCourseAdapter;
 import org.edx.mobile.view.custom.ETextView;
@@ -59,7 +60,7 @@ public abstract class CourseListTabFragment extends Fragment implements NetworkO
 
     protected ISegment segIO;
 
-    protected UiLifecycleHelper uiHelper;
+    protected IUiLifecycleHelper uiHelper;
     protected ListView myCourseList;
 
     FetchFriendsReceiver fetchFriendsObserver;
@@ -119,11 +120,11 @@ public abstract class CourseListTabFragment extends Fragment implements NetworkO
             }
         };
 
-        uiHelper = new UiLifecycleHelper(getActivity(), new Session.StatusCallback() {
+        uiHelper = IUiLifecycleHelper.Factory.getInstance(getActivity(), new Session.StatusCallback() {
             @Override
             public void call(Session session, SessionState state, Exception exception) {
 
-                if (state.isOpened()){
+                if (state.isOpened()) {
                     adapter.notifyDataSetChanged();
                 }
 
@@ -350,7 +351,7 @@ public abstract class CourseListTabFragment extends Fragment implements NetworkO
         Intent fetchFriends = new Intent(getActivity(), FetchCourseFriendsService.class);
 
         fetchFriends.putExtra(FetchCourseFriendsService.TAG_COURSE_ID, course.getCourse().getId());
-        fetchFriends.putExtra(FetchCourseFriendsService.TAG_COURSE_OAUTH, Session.getActiveSession().getAccessToken());
+        fetchFriends.putExtra(FetchCourseFriendsService.TAG_COURSE_OAUTH, FacebookSessionUtil.getAccessToken());
 
         getActivity().startService(fetchFriends);
     }

--- a/android/source/VideoLocker/src/org/edx/mobile/view/CreateGroupFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/CreateGroupFragment.java
@@ -25,6 +25,7 @@ import org.edx.mobile.R;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.analytics.SegmentFactory;
+import org.edx.mobile.module.facebook.IUiLifecycleHelper;
 import org.edx.mobile.social.SocialMember;
 import org.edx.mobile.social.SocialProvider;
 import org.edx.mobile.social.facebook.FacebookProvider;
@@ -56,7 +57,7 @@ public class CreateGroupFragment extends Fragment implements View.OnClickListene
 
     private List<SocialMember> friendsConnectedToEdx;
 
-    private UiLifecycleHelper uiHelper;
+    private IUiLifecycleHelper uiHelper;
 
     private SocialProvider.Callback<List<SocialMember>> getFriendsCallback = new SocialProvider.Callback<List<SocialMember>>() {
         @Override
@@ -190,7 +191,7 @@ public class CreateGroupFragment extends Fragment implements View.OnClickListene
 
         refreshVisibility();
 
-        uiHelper = new UiLifecycleHelper(getActivity(), null);
+        uiHelper = IUiLifecycleHelper.Factory.getInstance(getActivity(), null);
         uiHelper.onCreate(savedInstanceState);
 
         return rootView;

--- a/android/source/VideoLocker/src/org/edx/mobile/view/FriendsInCourseFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/FriendsInCourseFragment.java
@@ -13,8 +13,6 @@ import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import com.facebook.Session;
-
 import org.edx.mobile.R;
 import org.edx.mobile.loader.AsyncTaskResult;
 import org.edx.mobile.loader.FriendsInCourseLoader;
@@ -24,6 +22,7 @@ import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.analytics.SegmentFactory;
 import org.edx.mobile.social.SocialMember;
 import org.edx.mobile.util.BrowserUtil;
+import org.edx.mobile.module.facebook.FacebookSessionUtil;
 import org.edx.mobile.util.UiUtil;
 import org.edx.mobile.view.adapters.FriendsInCourseAdapter;
 import org.edx.mobile.view.adapters.SimpleAdapter;
@@ -122,7 +121,7 @@ public class FriendsInCourseFragment extends Fragment implements LoaderManager.L
 
         Bundle args = new Bundle();
         args.putString(FriendsInCourseLoader.TAG_COURSE_ID, courseData.getId());
-        args.putString(FriendsInCourseLoader.TAG_COURSE_OAUTH, Session.getActiveSession().getAccessToken());
+        args.putString(FriendsInCourseLoader.TAG_COURSE_OAUTH, FacebookSessionUtil.getAccessToken());
 
         getLoaderManager().restartLoader(LOADER_ID, args, this);
 

--- a/android/source/VideoLocker/src/org/edx/mobile/view/GroupsListFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/GroupsListFragment.java
@@ -18,7 +18,6 @@ import android.widget.ProgressBar;
 import android.widget.Toast;
 
 import com.facebook.Session;
-import com.facebook.UiLifecycleHelper;
 import com.facebook.widget.LoginButton;
 import com.getbase.floatingactionbutton.AddFloatingActionButton;
 
@@ -26,6 +25,7 @@ import org.edx.mobile.R;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.analytics.SegmentFactory;
+import org.edx.mobile.module.facebook.IUiLifecycleHelper;
 import org.edx.mobile.social.SocialGroup;
 import org.edx.mobile.social.SocialMember;
 import org.edx.mobile.social.SocialProvider;
@@ -61,7 +61,7 @@ public class GroupsListFragment extends Fragment implements SocialProvider.Callb
     private View facebookConnectLayout;
     private View errorLayout;
 
-    private UiLifecycleHelper uiLifecycleHelper;
+    private IUiLifecycleHelper uiLifecycleHelper;
     private GroupListAdapter groupListAdapter;
     private SocialProvider groupProvider;
 
@@ -89,7 +89,7 @@ public class GroupsListFragment extends Fragment implements SocialProvider.Callb
             lastGroupToInvite = savedInstanceState.getParcelable(GROUP_BRING_INVITED);
         }
 
-        uiLifecycleHelper = new UiLifecycleHelper(getActivity(), null);
+        uiLifecycleHelper = IUiLifecycleHelper.Factory.getInstance(getActivity(), null);
         uiLifecycleHelper.onCreate(savedInstanceState);
 
         segIO = SegmentFactory.getInstance();

--- a/android/source/VideoLocker/src/org/edx/mobile/view/MyCourseListTabFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/MyCourseListTabFragment.java
@@ -8,8 +8,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import com.facebook.Session;
-
 import org.edx.mobile.R;
 import org.edx.mobile.exception.AuthException;
 import org.edx.mobile.http.Api;
@@ -18,6 +16,7 @@ import org.edx.mobile.loader.CoursesAsyncLoader;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.services.FetchCourseFriendsService;
+import org.edx.mobile.module.facebook.FacebookSessionUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -78,7 +77,7 @@ public class MyCourseListTabFragment extends CourseListTabFragment {
         }
 
         Bundle args = new Bundle();
-        args.putString(CoursesAsyncLoader.TAG_COURSE_OAUTH, Session.getActiveSession().getAccessToken());
+        args.putString(CoursesAsyncLoader.TAG_COURSE_OAUTH, FacebookSessionUtil.getAccessToken());
 
         getLoaderManager().restartLoader(MY_COURSE_LOADER_ID, args, this);
     }
@@ -104,6 +103,11 @@ public class MyCourseListTabFragment extends CourseListTabFragment {
     public void onLoadFinished(Loader<AsyncTaskResult<List<EnrolledCoursesResponse>>> asyncTaskResultLoader, AsyncTaskResult<List<EnrolledCoursesResponse>> result) {
 
         if (progressBar != null) progressBar.setVisibility(View.GONE);
+
+        if (result == null) {
+            logger.warn("result is found null, was expecting non-null");
+            return;
+        }
 
         if(result.getEx() != null)
         {

--- a/android/source/VideoLocker/src/org/edx/mobile/view/MyCoursesListActivity.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/MyCoursesListActivity.java
@@ -13,6 +13,7 @@ import org.edx.mobile.R;
 import org.edx.mobile.interfaces.NetworkObserver;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.module.db.DataCallback;
+import org.edx.mobile.module.facebook.IUiLifecycleHelper;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.social.facebook.FacebookProvider;
 import org.edx.mobile.util.AppConstants;
@@ -22,7 +23,7 @@ import java.util.List;
 
 public class MyCoursesListActivity extends BaseTabActivity implements NetworkObserver{
 
-    private UiLifecycleHelper uiLifecycleHelper;
+    private IUiLifecycleHelper uiLifecycleHelper;
     private PrefManager featuresPref;
 
     @Override
@@ -56,9 +57,8 @@ public class MyCoursesListActivity extends BaseTabActivity implements NetworkObs
             }
 
         };
-        uiLifecycleHelper = new UiLifecycleHelper(this, statusCallback);
+        uiLifecycleHelper = IUiLifecycleHelper.Factory.getInstance(this, statusCallback);
         uiLifecycleHelper.onCreate(savedInstanceState);
-
     }
 
     private void changeSocialMode(boolean socialEnabled) {

--- a/android/source/VideoLocker/src/org/edx/mobile/view/MyFriendsCoursesTabFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/MyFriendsCoursesTabFragment.java
@@ -9,7 +9,6 @@ import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import com.facebook.Session;
 import com.facebook.widget.FacebookDialog;
 
 import org.edx.mobile.R;
@@ -20,6 +19,7 @@ import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.services.FetchCourseFriendsService;
 import org.edx.mobile.social.facebook.FacebookProvider;
+import org.edx.mobile.module.facebook.FacebookSessionUtil;
 import org.edx.mobile.view.dialog.InstallFacebookDialog;
 
 import java.util.ArrayList;
@@ -89,7 +89,7 @@ public class MyFriendsCoursesTabFragment extends CourseListTabFragment implement
         }
 
         Bundle args = new Bundle();
-        args.putString(CoursesAsyncLoader.TAG_COURSE_OAUTH, Session.getActiveSession().getAccessToken());
+        args.putString(CoursesAsyncLoader.TAG_COURSE_OAUTH, FacebookSessionUtil.getAccessToken());
 
         getLoaderManager().restartLoader(FREINDS_COURSES_LOADER_ID, args, this);
 

--- a/android/source/VideoLocker/src/org/edx/mobile/view/NavigationFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/NavigationFragment.java
@@ -25,6 +25,7 @@ import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.api.ProfileModel;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.analytics.SegmentFactory;
+import org.edx.mobile.module.facebook.IUiLifecycleHelper;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.Config;
@@ -43,7 +44,7 @@ public class NavigationFragment extends Fragment {
     private PrefManager socialPref;
     private NetworkCheckDialogFragment newFragment;
 
-    private UiLifecycleHelper uiLifecycleHelper;
+    private IUiLifecycleHelper uiLifecycleHelper;
     private Session.StatusCallback callback = new Session.StatusCallback() {
         @Override
         public void call(Session session, SessionState state, Exception exception) {
@@ -53,7 +54,7 @@ public class NavigationFragment extends Fragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        uiLifecycleHelper = new UiLifecycleHelper(getActivity(), callback);
+        uiLifecycleHelper = IUiLifecycleHelper.Factory.getInstance(getActivity(), callback);
         uiLifecycleHelper.onCreate(savedInstanceState);
     }
 

--- a/android/source/VideoLocker/src/org/edx/mobile/view/SettingsFragment.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/SettingsFragment.java
@@ -24,6 +24,7 @@ import org.edx.mobile.loader.CoursesVisibleLoader;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.analytics.SegmentFactory;
+import org.edx.mobile.module.facebook.IUiLifecycleHelper;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.social.SocialMember;
 import org.edx.mobile.social.SocialProvider;
@@ -43,7 +44,7 @@ public class SettingsFragment extends Fragment implements LoaderManager.LoaderCa
     private final Logger logger = new Logger(SettingsFragment.class);
 
     private NetworkCheckDialogFragment newFragment;
-    private UiLifecycleHelper uiHelper;
+    private IUiLifecycleHelper uiHelper;
     private Switch wifiSwitch;
     private Switch visibilitySwitch;
     protected ISegment segIO;
@@ -66,7 +67,7 @@ public class SettingsFragment extends Fragment implements LoaderManager.LoaderCa
         PrefManager featurePrefManager = new PrefManager(getActivity(), PrefManager.Pref.FEATURES);
         showSocialFeatures = featurePrefManager.getBoolean(PrefManager.Key.ALLOW_SOCIAL_FEATURES, true);
 
-        uiHelper = new UiLifecycleHelper(getActivity(), new Session.StatusCallback() {
+        uiHelper = IUiLifecycleHelper.Factory.getInstance(getActivity(), new Session.StatusCallback() {
             @Override
             public void call(Session session, SessionState state, Exception exception) {
                 if (showSocialFeatures) {


### PR DESCRIPTION
We must provide configuration if we want to individually disable some of the calls.
Providing no configuration enables all the calls, by default.