### PR TITLE
Disable Facebook and Google login for zero rated network

### DIFF
--- a/android/source/VideoLocker/src/org/edx/mobile/base/MainApplication.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/base/MainApplication.java
@@ -48,25 +48,20 @@ public class MainApplication extends Application {
         // setup image cache
         createImageCache();
 
-        boolean isThirdPartyTrafficAllowed = NetworkUtil.isAllowedThirdPartyTraffic(getApplicationContext());
-
         // initialize SegmentIO
-        if (isThirdPartyTrafficAllowed
-                && Config.getInstance().getThirdPartyTraffic().isSegmentEnabled()
+        if (Config.getInstance().getThirdPartyTraffic().isSegmentEnabled()
                 && Config.getInstance().getSegmentIOWriteKey() != null) {
             SegmentFactory.makeInstance(this);
         }
 
         // initialize Fabric
-        if (isThirdPartyTrafficAllowed
-                && Config.getInstance().getThirdPartyTraffic().isFabricEnabled()
+        if (Config.getInstance().getThirdPartyTraffic().isFabricEnabled()
                 && Config.getInstance().getFabricKey() != null) {
             Fabric.with(this, new Crashlytics());
         }
 
         // initialize NewRelic with crash reporting disabled
-        if (isThirdPartyTrafficAllowed
-                && Config.getInstance().getThirdPartyTraffic().isNewRelicEnabled()
+        if (Config.getInstance().getThirdPartyTraffic().isNewRelicEnabled()
                 && Config.getInstance().getNewRelicKey() != null) {
             //Crash reporting for new relic has been disabled
             NewRelic.withApplicationToken(Config.getInstance().getNewRelicKey())
@@ -75,7 +70,8 @@ public class MainApplication extends Application {
         }
 
         // initialize Facebook SDK
-        if (isThirdPartyTrafficAllowed
+        boolean isOnZeroRatedNetwork = NetworkUtil.isOnZeroRatedNetwork(getApplicationContext());
+        if ( !isOnZeroRatedNetwork
                 && Config.getInstance().getThirdPartyTraffic().isFacebookEnabled()
                 && Config.getInstance().getFacebookAppId() != null) {
             com.facebook.Settings.setApplicationId(Config.getInstance().getFacebookAppId());

--- a/android/source/VideoLocker/src/org/edx/mobile/module/analytics/SegmentFactory.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/module/analytics/SegmentFactory.java
@@ -3,7 +3,6 @@ package org.edx.mobile.module.analytics;
 import android.content.Context;
 
 import org.edx.mobile.util.Config;
-import org.edx.mobile.util.NetworkUtil;
 
 public class SegmentFactory {
 
@@ -33,8 +32,7 @@ public class SegmentFactory {
      */
     public static void makeInstance(Context context) {
         if (sInstance == null) {
-            if (NetworkUtil.isAllowedThirdPartyTraffic(context)
-                && Config.getInstance().getThirdPartyTraffic().isSegmentEnabled()) {
+            if (Config.getInstance().getThirdPartyTraffic().isSegmentEnabled()) {
                 sInstance = new ISegmentImpl(context);
             }
             else {

--- a/android/source/VideoLocker/src/org/edx/mobile/social/SocialFactory.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/social/SocialFactory.java
@@ -5,7 +5,6 @@ import android.app.Activity;
 import org.edx.mobile.social.facebook.FacebookAuth;
 import org.edx.mobile.social.google.GoogleOauth2;
 import org.edx.mobile.util.Config;
-import org.edx.mobile.util.NetworkUtil;
 
 public class SocialFactory {
 
@@ -14,16 +13,14 @@ public class SocialFactory {
     
     public static ISocial getInstance(Activity activity, int type) {
         if (type == TYPE_GOOGLE) {
-            if (NetworkUtil.isAllowedThirdPartyTraffic(activity)
-                && Config.getInstance().getThirdPartyTraffic().isGoogleEnabled()) {
+            if (Config.getInstance().getThirdPartyTraffic().isGoogleEnabled()) {
                 return new GoogleOauth2(activity);
             }
             else {
                 return new ISocialEmptyImpl();
             }
         } else if (type == TYPE_FACEBOOK) {
-            if (NetworkUtil.isAllowedThirdPartyTraffic(activity)
-                    && Config.getInstance().getThirdPartyTraffic().isFacebookEnabled()) {
+            if (Config.getInstance().getThirdPartyTraffic().isFacebookEnabled()) {
                 return new FacebookAuth(activity);
             }
             else {

--- a/android/source/VideoLocker/src/org/edx/mobile/util/NetworkUtil.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/util/NetworkUtil.java
@@ -116,7 +116,13 @@ public class NetworkUtil {
         }
         return ipAddress;
     }
-    
+
+    /**
+     * Returns true if app is running on a carrier id mentioned in zero-rated configuration,
+     * false otherwise.
+     * @param context
+     * @return
+     */
     public static boolean isOnZeroRatedNetwork(Context context){
         TelephonyManager manager = (TelephonyManager)context.getSystemService(Context.TELEPHONY_SERVICE);
         String carrierId = manager.getNetworkOperator();
@@ -159,9 +165,5 @@ public class NetworkUtil {
 
         return isSocialEnabled && (NetworkUtil.isConnectedWifi(context) || !NetworkUtil.isOnSocialDisabledNetwork(context));
 
-    }
-
-    public static boolean isAllowedThirdPartyTraffic(Context context) {
-        return (!isOnZeroRatedNetwork(context) || isConnectedWifi(context));
     }
 }

--- a/android/source/VideoLocker/src/org/edx/mobile/view/LoginActivity.java
+++ b/android/source/VideoLocker/src/org/edx/mobile/view/LoginActivity.java
@@ -139,10 +139,10 @@ public class LoginActivity extends BaseFragmentActivity {
         setLoginBtnEnabled();
 
         // check if third party traffic is enabled
-        boolean isAllowedThirdPartyTraffic = NetworkUtil.isAllowedThirdPartyTraffic(getApplicationContext());
+        boolean isOnZeroRatedNetwork = NetworkUtil.isOnZeroRatedNetwork(getApplicationContext());
         Config.ThirdPartyTrafficConfig thirdPartyTrafficConfig = Config.getInstance().getThirdPartyTraffic();
 
-        if ( !isAllowedThirdPartyTraffic) {
+        if (isOnZeroRatedNetwork) {
             findViewById(R.id.panel_login_social).setVisibility(View.GONE);
         } else {
             if (!thirdPartyTrafficConfig.isFacebookEnabled()


### PR DESCRIPTION
These changes disable Google and Facebook login when app runs on a Zero-Rated network.
However, all the third party services remain enabled depending on individual flags.

cc @shahidtamboli @aleffert 