### PR TITLE
Removed getActionBar from onCreate

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
@@ -170,6 +170,8 @@ public class BaseFragmentActivity extends FragmentActivity implements NetworkSub
             //If activity is in landscape, hide the Action bar
             if (isLandscape()) {
                 bar.hide();
+            }else{
+                bar.show();
             }
         }
     }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/BaseTabActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/BaseTabActivity.java
@@ -112,5 +112,4 @@ public abstract class BaseTabActivity extends BaseFragmentActivity {
 
     protected  abstract int getDefaultTab();
 
-
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CertificateActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CertificateActivity.java
@@ -10,16 +10,9 @@ import org.edx.mobile.model.api.EnrolledCoursesResponse;
 public class CertificateActivity extends BaseSingleFragmentActivity {
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-
-        super.onCreate(savedInstanceState);
-
-        getActionBar().show();
-        getActionBar().setDisplayHomeAsUpEnabled(true);
-        getActionBar().setHomeButtonEnabled(true);
-        getActionBar().setIcon(android.R.color.transparent);
+    protected void onStart() {
+        super.onStart();
         setTitle(getString(R.string.tab_label_certificate));
-
     }
 
     @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDetailTabActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDetailTabActivity.java
@@ -34,10 +34,6 @@ public class CourseDetailTabActivity extends BaseTabActivity {
             selectedTab = savedInstanceState.getInt(TAB_ID);
         }
 
-        getActionBar().setDisplayHomeAsUpEnabled(true);
-        getActionBar().setHomeButtonEnabled(true);
-        getActionBar().setIcon(android.R.color.transparent);
-
         setApplyPrevTransitionOnRestart(true);
         
         bundle = getIntent().getBundleExtra("bundle");

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseHandoutActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseHandoutActivity.java
@@ -10,16 +10,9 @@ import org.edx.mobile.model.api.EnrolledCoursesResponse;
 public class CourseHandoutActivity extends BaseSingleFragmentActivity {
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-
-        super.onCreate(savedInstanceState);
-
-        getActionBar().show();
-        getActionBar().setDisplayHomeAsUpEnabled(true);
-        getActionBar().setHomeButtonEnabled(true);
-        getActionBar().setIcon(android.R.color.transparent);
+    protected void onStart() {
+        super.onStart();
         setTitle(getString(R.string.tab_label_handouts));
-
     }
 
     @Override
@@ -29,16 +22,12 @@ public class CourseHandoutActivity extends BaseSingleFragmentActivity {
 
         EnrolledCoursesResponse courseData = (EnrolledCoursesResponse) getIntent().getSerializableExtra(CourseHandoutFragment.ENROLLMENT);
         if (courseData != null) {
-
             Bundle bundle = new Bundle();
             bundle.putSerializable(CourseHandoutFragment.ENROLLMENT, courseData);
             frag.setArguments(bundle);
-
         }
-
         return frag;
     }
-
 }
 
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CreateGroupActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CreateGroupActivity.java
@@ -13,14 +13,14 @@ public class CreateGroupActivity extends BaseSingleFragmentActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        getActionBar().show();
-        getActionBar().setDisplayHomeAsUpEnabled(true);
-        getActionBar().setHomeButtonEnabled(true);
-        getActionBar().setIcon(android.R.color.transparent);
-        setTitle(getString(R.string.label_new_group));
 
         overridePendingTransition(R.anim.slide_in_bottom, R.anim.stay_put);
+    }
 
+    @Override
+    protected void onStart() {
+        super.onStart();
+        setTitle(getString(R.string.label_new_group));
     }
 
     @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/view/FriendsInCourseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/FriendsInCourseActivity.java
@@ -12,27 +12,26 @@ public class FriendsInCourseActivity extends BaseSingleFragmentActivity {
     private static final String TAG = FriendsInCourseActivity.class.getCanonicalName();
     public static final String EXTRA_COURSE = TAG + ".course";
     public static final String EXTRA_FRIENDS_TAB_LINK = TAG + ".showLink";
+    private CourseEntry course;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        CourseEntry course = (CourseEntry) getIntent().getSerializableExtra(FriendsInCourseActivity.EXTRA_COURSE);
+        course = (CourseEntry) getIntent().getSerializableExtra(FriendsInCourseActivity.EXTRA_COURSE);
         if (course == null) {
             throw new IllegalArgumentException("missing course");
         }
+    }
 
-        getActionBar().show();
-        getActionBar().setDisplayHomeAsUpEnabled(true);
-        getActionBar().setHomeButtonEnabled(true);
-        getActionBar().setIcon(android.R.color.transparent);
+    @Override
+    protected void onStart() {
+        super.onStart();
         if (getIntent().getBooleanExtra(FriendsInCourseActivity.EXTRA_FRIENDS_TAB_LINK, false)) {
             setTitle(course.getName());
         } else {
             setTitle(getString(R.string.friends_in_this_course));
         }
-
-
     }
 
     @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/view/GroupSummaryActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/GroupSummaryActivity.java
@@ -18,20 +18,22 @@ public class GroupSummaryActivity extends BaseSingleFragmentActivity {
 
     private static final String TAG = GroupSummaryFragment.class.getCanonicalName();
     public static final String EXTRA_GROUP = TAG + ".group";
+    private SocialGroup group;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        SocialGroup group = getIntent().getParcelableExtra(EXTRA_GROUP);
+        group = getIntent().getParcelableExtra(EXTRA_GROUP);
         if (group == null) {
             throw new IllegalArgumentException("missing group");
         }
 
-        getActionBar().show();
-        getActionBar().setDisplayHomeAsUpEnabled(true);
-        getActionBar().setHomeButtonEnabled(true);
-        getActionBar().setIcon(android.R.color.transparent);
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
         setTitle(group.getName());
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/SocialFriendPickerActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/SocialFriendPickerActivity.java
@@ -25,21 +25,12 @@ public class SocialFriendPickerActivity extends BaseSingleFragmentActivity {
     protected void onCreate(Bundle savedInstanceState) {
 
         super.onCreate(savedInstanceState);
-        getActionBar().show();
-        getActionBar().setDisplayHomeAsUpEnabled(true);
-        getActionBar().setHomeButtonEnabled(true);
-        getActionBar().setIcon(android.R.color.transparent);
 
         addState = getIntent().getBooleanExtra(ADD_TO_GROUP, false);
 
         if (addState) {
             overridePendingTransition(R.anim.slide_in_bottom, R.anim.stay_put);
-            setTitle(getString(R.string.label_add_new_group_friends));
-        } else {
-            setTitle(getString(R.string.label_add_group_friends));
         }
-
-
 
         try{
             String analyticsID = addState ? "Social Friend Picker - existing group" : "Social Friend Picker - new group";
@@ -47,7 +38,16 @@ public class SocialFriendPickerActivity extends BaseSingleFragmentActivity {
         }catch(Exception e){
             logger.error(e);
         }
+    }
 
+    @Override
+    protected void onStart() {
+        super.onStart();
+        if (addState) {
+            setTitle(getString(R.string.label_add_new_group_friends));
+        } else {
+            setTitle(getString(R.string.label_add_group_friends));
+        }
     }
 
     @Override


### PR DESCRIPTION
There a few commits in bNotions merge which were using getActionbar in the onCreate. Previously we had crashes and this issue has occured in devices with OS version below 4.2. 

@rohan-dhamal-clarice @aleffert - Please review