### PR TITLE
Factor server API module and use mocked HTTP server for API unit tests

### DIFF
--- a/VideoLocker/build.gradle
+++ b/VideoLocker/build.gradle
@@ -146,6 +146,9 @@ dependencies {
     }
     androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
+    // library for webserver mocking
+    androidTestCompile 'com.squareup.okhttp:mockwebserver:2.0.0'
+    androidTestCompile 'com.squareup.okio:okio:1.1.0'
 }
 
 configurations {

--- a/VideoLocker/default_config/config.yaml
+++ b/VideoLocker/default_config/config.yaml
@@ -1,4 +1,4 @@
-API_HOST_URL: 'http://localhost:8000'
+API_HOST_URL: 'http://localhost:8000/mock/'
 ENVIRONMENT_DISPLAY_NAME: 'Localhost'
 FEEDBACK_EMAIL_ADDRESS: 'support@example.com'
 OAUTH_CLIENT_ID: ''

--- a/VideoLocker/default_config/config.yaml
+++ b/VideoLocker/default_config/config.yaml
@@ -1,4 +1,4 @@
-API_HOST_URL: 'http://localhost:8000/mock/'
+API_HOST_URL: 'http://localhost:8000'
 ENVIRONMENT_DISPLAY_NAME: 'Localhost'
 FEEDBACK_EMAIL_ADDRESS: 'support@example.com'
 OAUTH_CLIENT_ID: ''

--- a/VideoLocker/src/androidTest/java/org/edx/mobile/test/module/MockedApiTests.java
+++ b/VideoLocker/src/androidTest/java/org/edx/mobile/test/module/MockedApiTests.java
@@ -9,7 +9,9 @@ import org.edx.mobile.model.api.AuthResponse;
 import org.edx.mobile.module.serverapi.ApiFactory;
 import org.edx.mobile.module.serverapi.IApi;
 import org.edx.mobile.test.BaseTestCase;
+import org.edx.mobile.util.Config;
 import org.edx.mobile.util.Environment;
+import org.json.JSONObject;
 
 import java.net.URL;
 
@@ -38,6 +40,12 @@ public class MockedApiTests extends BaseTestCase {
 
         Environment env = new Environment();
         env.setupEnvironment(getInstrumentation().getTargetContext());
+
+        // set test configuration
+        JsonObject json = new JsonObject();
+        json.add("API_HOST_URL", new JsonPrimitive(String.format("http://localhost:%d", PORT)));
+        Config config = new Config(json);
+        Config.setInstance(config);
     }
 
     @Override
@@ -46,19 +54,24 @@ public class MockedApiTests extends BaseTestCase {
         server.shutdown();
     }
 
+    private void startServer() throws Exception {
+        server.play(PORT);
+        URL baseUrl = server.getUrl("/mocked");
+        print("mocked URL: " + baseUrl.toString());
+    }
+
     public void testLogin() throws Exception {
         // TODO: mock the response
-        JsonObject json = new JsonObject();
-        json.add("access_token", new JsonPrimitive("fake-token"));
+        JSONObject json = new JSONObject();
+        json.put("access_token", "fake-token");
 
         MockResponse mockResponse = new MockResponse()
                 .setResponseCode(200)
                 .setBody(json.toString());
 
         server.enqueue(mockResponse);
-        server.play(PORT);
-        URL baseUrl = server.getUrl("/mock/");
-        print("mock URL: " + baseUrl.toString());
+
+        startServer();
 
         // run the code
         AuthResponse resp = api.doLogin(EMAIL, PASSWORD);

--- a/VideoLocker/src/androidTest/java/org/edx/mobile/test/module/MockedApiTests.java
+++ b/VideoLocker/src/androidTest/java/org/edx/mobile/test/module/MockedApiTests.java
@@ -1,0 +1,69 @@
+package org.edx.mobile.test.module;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+
+import org.edx.mobile.model.api.AuthResponse;
+import org.edx.mobile.module.serverapi.ApiFactory;
+import org.edx.mobile.module.serverapi.IApi;
+import org.edx.mobile.test.BaseTestCase;
+import org.edx.mobile.util.Environment;
+
+import java.net.URL;
+
+/**
+ * Created by rohan on 2/17/15.
+ *
+ * For each test case, follow these 3 steps,
+ * 1) Mock the response
+ * 2) Run the code
+ * 3) Verify the requests
+ */
+public class MockedApiTests extends BaseTestCase {
+
+    private static final String EMAIL       = "user@example.com";
+    private static final String PASSWORD    = "password";
+    private static final int PORT           = 8000;
+
+    private IApi api;
+    private MockWebServer server;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        api = ApiFactory.getInstance(getInstrumentation().getTargetContext());
+        server = new MockWebServer();
+
+        Environment env = new Environment();
+        env.setupEnvironment(getInstrumentation().getTargetContext());
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        server.shutdown();
+    }
+
+    public void testLogin() throws Exception {
+        // TODO: mock the response
+        JsonObject json = new JsonObject();
+        json.add("access_token", new JsonPrimitive("fake-token"));
+
+        MockResponse mockResponse = new MockResponse()
+                .setResponseCode(200)
+                .setBody(json.toString());
+
+        server.enqueue(mockResponse);
+        server.play(PORT);
+        URL baseUrl = server.getUrl("/mock/");
+        print("mock URL: " + baseUrl.toString());
+
+        // run the code
+        AuthResponse resp = api.doLogin(EMAIL, PASSWORD);
+        assertTrue(resp.isSuccess());
+
+        // TODO: verify the request
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/ApiFactory.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/ApiFactory.java
@@ -1,0 +1,18 @@
+package org.edx.mobile.module.serverapi;
+
+import android.content.Context;
+
+/**
+ * Created by rohan on 2/7/15.
+ */
+public class ApiFactory {
+
+    /**
+     * Returns new instance of {@link org.edx.mobile.module.serverapi.IApi} class.
+     * @param Context
+     * @return
+     */
+    public static IApi getInstance(Context context) {
+        return new IApiImpl(context);
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/Endpoint.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/Endpoint.java
@@ -1,0 +1,85 @@
+package org.edx.mobile.module.serverapi;
+
+import org.edx.mobile.util.Config;
+
+/**
+ * Created by rohan on 2/7/15.
+ */
+class Endpoint {
+    private static String getHost() {
+        return Config.getInstance().getApiHostURL();
+    }
+
+    public static String resetPassword() {
+        return getHost() + "/password_reset/";
+    }
+
+    public static String loginAuth() {
+        return getHost() + "/oauth2/access_token/";
+    }
+
+    public static String profile() {
+        return getHost() + "/api/mobile/v0.5/my_user_info";
+    }
+
+    public static String courseHierarchy(String courseId) {
+        return getHost() + "/api/mobile/v0.5/video_outlines/courses/" + courseId;
+    }
+
+    public static String enrollments(String username) {
+        return getHost() + "/api/mobile/v0.5/users/" + username + "/course_enrollments/";
+    }
+
+    public static String videosByCourseId(String courseId) {
+        return getHost() + "/api/mobile/v0.5/video_outlines/courses/" + courseId;
+    }
+
+    public static String loginWebLink() {
+        return getHost() + "/login";
+    }
+
+    public static String loginBySocial(String backend) {
+        return getHost() + "/login_oauth_token/" + backend + "/";
+    }
+
+    public static String syncLastAccessedSubSection(String username, String courseId) {
+        return getHost() + "/api/mobile/v0.5/users/" + username + "/course_status_info/" + courseId;
+    }
+
+    public static String createAccount() {
+        return getHost() + "/create_account";
+    }
+
+    public static String registration() {
+        return getHost() + "/user_api/v1/account/registration/";
+    }
+
+    public static String enroll() {
+        return getHost() + "/api/enrollment/v1/enrollment";
+    }
+
+    public static String inviteFriendsToGroup(long groupId) {
+        return getHost() + "/api/mobile/v0.5/social/facebook/groups/" + Long.toString(groupId) + "/member/";
+    }
+
+    public static String createGroup() {
+        //String url = getBaseUrl() + "/api/mobile/v0.5/social/facebook/groups/create/";
+        return getHost() + "/api/mobile/v0.5/social/facebook/groups/";
+    }
+
+    public static String friendsCourses() {
+        return getHost() + "/api/mobile/v0.5/social/facebook/courses/friends";
+    }
+
+    public static String friendsInCourses(String courseId) {
+        return getHost() + "/api/mobile/v0.5/social/facebook/friends/course/" + courseId;
+    }
+
+    public static String userCourseShareConsent() {
+        return getHost() + "/api/mobile/v0.5/settings/preferences/";
+    }
+
+    public static String groupMembers(String groupId) {
+        return getHost() + "/api/mobile/v0.5/social/facebook/groups/" + groupId + "/members";
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/IApi.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/IApi.java
@@ -1,0 +1,266 @@
+package org.edx.mobile.module.serverapi;
+
+import android.os.Bundle;
+
+import org.edx.mobile.interfaces.SectionItemInterface;
+import org.edx.mobile.model.api.AnnouncementsModel;
+import org.edx.mobile.model.api.AuthResponse;
+import org.edx.mobile.model.api.CourseEntry;
+import org.edx.mobile.model.api.CourseInfoModel;
+import org.edx.mobile.model.api.EnrolledCoursesResponse;
+import org.edx.mobile.model.api.HandoutModel;
+import org.edx.mobile.model.api.LectureModel;
+import org.edx.mobile.model.api.ProfileModel;
+import org.edx.mobile.model.api.RegisterResponse;
+import org.edx.mobile.model.api.ResetPasswordResponse;
+import org.edx.mobile.model.api.SectionEntry;
+import org.edx.mobile.model.api.SocialLoginResponse;
+import org.edx.mobile.model.api.SyncLastAccessedSubsectionResponse;
+import org.edx.mobile.model.api.TranscriptModel;
+import org.edx.mobile.model.api.VideoResponseModel;
+import org.edx.mobile.module.registration.model.RegistrationDescription;
+import org.edx.mobile.social.SocialMember;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by rohan on 2/6/15.
+ */
+public interface IApi {
+
+    /**
+     * Resets password for the given email address.
+     * @param email
+     * @return
+     * @throws Exception
+     */
+    ResetPasswordResponse doResetPassword(String email) throws Exception;
+
+    /**
+     * Executes HTTP POST for auth call, and returns response.
+     *
+     * @return
+     * @throws Exception
+     */
+    AuthResponse doLogin(String username, String password) throws Exception;
+
+    SocialLoginResponse doLoginByFacebook(String accessToken) throws Exception;
+
+    SocialLoginResponse doLoginByGoogle(String accessToken) throws Exception;
+
+    /**
+     * Downloads transcript file from given url.
+     * @param url
+     * @return
+     * @throws Exception
+     */
+    String doDownloadTranscript(String url) throws Exception;
+
+    /**
+     * Creates new account.
+     * @param parameters
+     * @return
+     * @throws Exception
+     */
+    RegisterResponse doRegister(Bundle parameters) throws Exception;
+
+    boolean doEnrollInACourse(String courseId, boolean email_opt_in) throws Exception;
+
+    String doDownloadRegistrationDescription() throws Exception;
+
+    SyncLastAccessedSubsectionResponse doSyncLastAccessedSubsection(String courseId,
+                                                                    String lastVisitedModuleId) throws Exception;
+
+
+    boolean doInviteFriendsToGroup(long[] toInvite, long groupId, String oauthToken) throws Exception;
+
+    /**
+     *  return of -1 indicates an error
+     */
+    long doCreateGroup(String name, String description, boolean privacy, long adminId, String socialToken) throws Exception;
+
+    /**
+     * Returns user's basic profile information for current active session.
+     * @return
+     * @throws Exception
+     */
+    ProfileModel getProfile() throws Exception;
+
+    /**
+     * Returns entire course hierarchy.
+     *
+     * @param courseId
+     * @return
+     * @throws Exception
+     */
+    Map<String, SectionEntry> getCourseHierarchy(String courseId) throws Exception;
+
+    /**
+     * Returns entire course hierarchy.
+     *
+     * @param courseId
+     * @param preferCache
+     * @return
+     * @throws Exception
+     */
+    Map<String, SectionEntry> getCourseHierarchy(String courseId, boolean preferCache) throws Exception;
+
+    /**
+     * Returns lecture model for given course id, chapter name and lecture name combination.
+     * @param courseId
+     * @param chapterName
+     * @param lectureName
+     * @return
+     * @throws Exception
+     */
+    LectureModel getLecture(String courseId, String chapterName, String lectureName) throws Exception;
+
+    /**
+     * Returns video model for given course id and video id.
+     * @param courseId
+     * @param videoId
+     * @return
+     * @throws Exception
+     */
+    VideoResponseModel getVideoById(String courseId, String videoId) throws Exception;
+
+    /**
+     * Returns any (mostly first video always) one video {@link VideoResponseModel}
+     * object from subsection identified by
+     * given module id (subsectionId).
+     * @param courseId
+     * @param subsectionId
+     * @return
+     * @throws Exception
+     */
+    VideoResponseModel getSubsectionById(String courseId, String subsectionId) throws Exception;
+
+    /**
+     * Returns UnitUrl for given course id and video id.
+     * @param courseId
+     * @param videoId
+     * @return
+     * @throws Exception
+     */
+    String getUnitUrlByVideoById(String courseId, String videoId) throws Exception;
+
+    /**
+     * Returns enrolled courses of given user.
+     *
+     * @return
+     * @throws Exception
+     */
+    List<EnrolledCoursesResponse> getEnrolledCourses() throws Exception;
+
+    /**
+     * Returns course identified by given id from cache, null if not course is found.
+     * @param courseId
+     * @return
+     */
+    CourseEntry getCourseById(String courseId);
+
+    /**
+     * Returns enrolled courses of given user.
+     *
+     * @param fetchFromCache
+     * @return
+     * @throws Exception
+     */
+    List<EnrolledCoursesResponse> getEnrolledCourses(boolean fetchFromCache) throws Exception;
+
+    /**
+     * Returns list of videos in a particular course.
+     * @param courseId
+     * @param preferCache
+     * @return
+     * @throws Exception
+     */
+    List<VideoResponseModel> getVideosByCourseId(String courseId, boolean preferCache) throws Exception;
+
+    /**
+     * Returns handout for the given course id.
+     * @param url
+     * @param preferCache
+     * @return
+     * @throws Exception
+     */
+    HandoutModel getHandout(String url, boolean preferCache) throws Exception;
+
+    /**
+     * Returns course info object from the given URL.
+     * @param url
+     * @param preferCache
+     * @return
+     * @throws Exception
+     */
+    CourseInfoModel getCourseInfo(String url, boolean preferCache) throws Exception;
+
+    /**
+     * Returns list of announcements for the given course id.
+     * @param url
+     * @param preferCache
+     * @return
+     * @throws Exception
+     */
+    List<AnnouncementsModel> getAnnouncement(String url, boolean preferCache)
+            throws Exception;
+
+    /**
+     * Returns Stream object from the given URL.
+     * @param url
+     * @return
+     * @throws Exception
+     */
+    CourseInfoModel getSrtStream(String url) throws Exception;
+
+    /**
+     * Returns Transcript of a given Video.
+     *
+     * @param
+     * @return TranscriptModel
+     * @throws Exception
+     */
+    TranscriptModel getTranscriptsOfVideo(String enrollmentId, String videoId);
+
+    /**
+     * Returns list of videos for a particular URL.
+     * @param courseId
+     * @param preferCache
+     * @return
+     * @throws Exception
+     */
+    List<VideoResponseModel> getVideosByURL(String courseId, String videoUrl, boolean preferCache)
+            throws Exception;
+
+    List<EnrolledCoursesResponse> getFriendsCourses(String oauthToken) throws Exception;
+
+    List<EnrolledCoursesResponse> getFriendsCourses(boolean preferCache, String oauthToken) throws Exception;
+
+    List<SocialMember> getFriendsInCourse(String courseId, String oauthToken) throws Exception;
+
+    List<SocialMember> getFriendsInCourse(boolean preferCache, String courseId, String oauthToken) throws Exception;
+
+    void setUserCourseShareConsent(boolean consent) throws Exception;
+
+    boolean getUserCourseShareConsent() throws Exception;
+
+    List<SocialMember> getGroupMembers(boolean preferCache, long groupId) throws Exception;
+
+    /**
+     * Returns chapter model and the subsequent sections and videos in organized manner from cache.
+     * @param courseId
+     * @param chapter
+     * @return
+     */
+    List<SectionItemInterface> getLiveOrganizedVideosByChapter(String courseId, String chapter);
+
+    SyncLastAccessedSubsectionResponse getLastAccessedSubsection(String courseId) throws Exception;
+
+    /**
+     * Reads registration description from assets and return Model representation of it.
+     * @return
+     * @throws Exception
+     */
+    RegistrationDescription getRegistrationDescription() throws Exception;
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/IApiImpl.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/IApiImpl.java
@@ -1,0 +1,990 @@
+package org.edx.mobile.module.serverapi;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.text.TextUtils;
+
+import com.google.gson.Gson;
+
+import org.edx.mobile.exception.AuthException;
+import org.edx.mobile.http.serialization.JsonBooleanDeserializer;
+import org.edx.mobile.http.serialization.ShareCourseResult;
+import org.edx.mobile.interfaces.SectionItemInterface;
+import org.edx.mobile.logger.Logger;
+import org.edx.mobile.model.api.AnnouncementsModel;
+import org.edx.mobile.model.api.AuthErrorResponse;
+import org.edx.mobile.model.api.AuthResponse;
+import org.edx.mobile.model.api.ChapterModel;
+import org.edx.mobile.model.api.CourseEntry;
+import org.edx.mobile.model.api.CourseInfoModel;
+import org.edx.mobile.model.api.EnrolledCoursesResponse;
+import org.edx.mobile.model.api.HandoutModel;
+import org.edx.mobile.model.api.LectureModel;
+import org.edx.mobile.model.api.ProfileModel;
+import org.edx.mobile.model.api.RegisterResponse;
+import org.edx.mobile.model.api.ResetPasswordResponse;
+import org.edx.mobile.model.api.SectionEntry;
+import org.edx.mobile.model.api.SectionItemModel;
+import org.edx.mobile.model.api.SocialLoginResponse;
+import org.edx.mobile.model.api.SyncLastAccessedSubsectionResponse;
+import org.edx.mobile.model.api.TranscriptModel;
+import org.edx.mobile.model.api.VideoResponseModel;
+import org.edx.mobile.model.json.CreateGroupResponse;
+import org.edx.mobile.model.json.GetFriendsListResponse;
+import org.edx.mobile.model.json.GetGroupMembersResponse;
+import org.edx.mobile.model.json.SuccessResponse;
+import org.edx.mobile.module.analytics.ISegment;
+import org.edx.mobile.module.prefs.PrefManager;
+import org.edx.mobile.module.registration.model.RegistrationDescription;
+import org.edx.mobile.module.serverapi.cache.CacheManager;
+import org.edx.mobile.module.serverapi.http.HttpFactory;
+import org.edx.mobile.module.serverapi.http.IHttp;
+import org.edx.mobile.module.serverapi.parser.IParser;
+import org.edx.mobile.module.serverapi.parser.ParserFactory;
+import org.edx.mobile.social.SocialMember;
+import org.edx.mobile.util.Config;
+import org.edx.mobile.util.DateUtil;
+import org.edx.mobile.util.NetworkUtil;
+import org.json.JSONObject;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by rohan on 2/6/15.
+ */
+class IApiImpl extends Endpoint implements IApi {
+
+    private Context mContext;
+    private IHttp http = HttpFactory.getInstance();
+    private IParser parser = ParserFactory.getInstance();
+    private CacheManager cache;
+    private static final Logger logger = new Logger(IApiImpl.class);
+
+    public IApiImpl(Context context) {
+        this.mContext = context;
+        this.cache = new CacheManager(context);
+    }
+
+    @Override
+    public ResetPasswordResponse doResetPassword(String email) throws Exception {
+        // validate inputs
+        Validate.emailAddress(email);
+
+        // hit login endpoint and get cookies
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.loginWebLink());
+        IResponse response = http.get(request);
+
+        // now prepare another request for reset password
+        request = new IRequestImpl();
+        request.setEndpoint(Endpoint.resetPassword());
+        request.addParameter("email", email);
+        request.addHeader(IHttp.KEY_COOKIE, response.getCookies().getString(IHttp.KEY_COOKIE));
+        request.addHeader(IHttp.KEY_X_CSRFTOKEN, response.getCookies().getString(IHttp.KEY_X_CSRFTOKEN));
+
+        // execute request
+        response = http.post(request);
+
+        // validate response
+        Validate.httpResponse(response.getStatusCode(), 200);
+
+        // parse the response and return
+        return parser.parseObject(response.getResponse(), ResetPasswordResponse.class);
+    }
+
+    @Override
+    public AuthResponse doLogin(String username, String password) throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.loginAuth());
+        request.addParameter("grant_type", "password");
+        request.addParameter("client_id", Config.getInstance().getOAuthClientId());
+        request.addParameter("client_secret", Config.getInstance().getOAuthClientSecret());
+        request.addParameter("username", username);
+        request.addParameter("password", password);
+
+        IResponse response = http.post(request);
+
+        // validate response
+        Validate.httpResponse(response.getStatusCode(), 200);
+
+        // store auth token response
+        PrefManager pref = new PrefManager(mContext, PrefManager.Pref.LOGIN);
+        pref.put(PrefManager.Key.AUTH_JSON, response.getResponse());
+        pref.put(PrefManager.Key.SEGMENT_KEY_BACKEND, ISegment.Values.PASSWORD);
+
+        // parse the response and return
+        return parser.parseObject(response.getResponse(), AuthResponse.class);
+    }
+
+    @Override
+    public SocialLoginResponse doLoginByFacebook(String accessToken) throws Exception {
+        PrefManager pref = new PrefManager(mContext, PrefManager.Pref.LOGIN);
+        pref.put(PrefManager.Key.SEGMENT_KEY_BACKEND, ISegment.Values.FACEBOOK);
+
+        return socialLogin(accessToken, PrefManager.Value.BACKEND_FACEBOOK);
+    }
+
+    @Override
+    public SocialLoginResponse doLoginByGoogle(String accessToken) throws Exception {
+        PrefManager pref = new PrefManager(mContext, PrefManager.Pref.LOGIN);
+        pref.put(PrefManager.Key.SEGMENT_KEY_BACKEND, ISegment.Values.GOOGLE);
+
+        return socialLogin(accessToken, PrefManager.Value.BACKEND_GOOGLE);
+    }
+
+    private SocialLoginResponse socialLogin(String accessToken, String backend)
+            throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.loginBySocial(backend));
+        request.addHeader("Content-Type", "application/x-www-form-urlencoded");
+        request.addParameter("access_token", accessToken);
+
+        IResponse response = http.post(request);
+
+        Validate.httpResponse(response.getStatusCode(), 204);
+
+        String strResponse = response.getResponse();
+        if (TextUtils.isEmpty(strResponse)) {
+            // success gives empty response for this api call
+            strResponse = "{}";
+        }
+
+        logger.debug(backend + " login=" + strResponse);
+
+        SocialLoginResponse res = parser.parseObject(response.getResponse(), SocialLoginResponse.class);
+
+        // hold the json string as it is
+        res.json = strResponse;
+
+        // FIXME: Should not use cookies ?
+        // store cookie into preferences for later use in further API calls
+        PrefManager pref = new PrefManager(mContext, PrefManager.Pref.LOGIN);
+        pref.put(PrefManager.Key.AUTH_TOKEN_SOCIAL_COOKIE, res.cookie);
+
+        return res;
+    }
+
+    @Override
+    public String doDownloadTranscript(String url) throws Exception {
+        if (url != null){
+            try {
+                if (NetworkUtil.isConnected(mContext)) {
+                    IRequest request = new IRequestImpl();
+                    request.setEndpoint(url);
+                    request.setHeaders(getAuthHeaders());
+                    IResponse response = http.get(request);
+                    return response.getResponse();
+                }
+            } catch (Exception ex){
+                logger.error(ex);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public RegisterResponse doRegister(Bundle parameters) throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.createAccount());
+        request.setParameters(parameters);
+
+        IResponse response = http.post(request);
+
+        Validate.httpResponse(response.getStatusCode(), 200);
+
+        logger.debug("Register response= " + response.getResponse());
+
+        return parser.parseObject(response.getResponse(), RegisterResponse.class);
+    }
+
+    @Override
+    public boolean doEnrollInACourse(String courseId, boolean email_opt_in) throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.enroll());
+        request.setHeaders(getAuthHeaders());
+
+        JSONObject postBody = new JSONObject();
+        JSONObject courseIdObject = new JSONObject();
+        courseIdObject.put("email_opt_in", email_opt_in);
+        courseIdObject.put("course_id", courseId);
+        postBody.put("course_details", courseIdObject);
+
+        request.setPostBody(postBody.toString());
+        logger.debug("POST body for Enrolling in a course: " + postBody.toString());
+
+        IResponse response = http.post(request);
+
+        Validate.httpResponse(response.getStatusCode(), 200);
+
+        String json = response.getResponse();
+        if (json != null && !json.isEmpty()) {
+            logger.debug("Response of Enroll in a course= " + json);
+            JSONObject resultJson = new JSONObject(json);
+            if (resultJson.has("error")) {
+                return false;
+            }else {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public String doDownloadRegistrationDescription() throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.registration());
+        IResponse response = http.get(request);
+
+        cache.put(request.getEndpoint(), response.getResponse());
+        return response.getResponse();
+    }
+
+    @Override
+    public SyncLastAccessedSubsectionResponse doSyncLastAccessedSubsection(String courseId, String lastVisitedModuleId) throws Exception {
+        PrefManager pref = new PrefManager(mContext, PrefManager.Pref.LOGIN);
+        String username = pref.getCurrentUserProfile().username;
+
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.syncLastAccessedSubSection(username, courseId));
+
+        String date = DateUtil.getModificationDate();
+
+        JSONObject postBody = new JSONObject();
+        postBody.put("last_visited_module_id", lastVisitedModuleId);
+        postBody.put("modification_date", date);
+        request.setPostBody(postBody.toString());
+        logger.debug("PATCH body for syncLastAccessed Subsection: " + postBody.toString());
+
+        IResponse response = http.patch(request);
+
+        Validate.httpResponse(response.getStatusCode(), 200);
+
+        logger.debug("Response of sync last viewed= " + response.getResponse());
+
+        return parser.parseObject(response.getResponse(), SyncLastAccessedSubsectionResponse.class);
+    }
+
+    @Override
+    public boolean doInviteFriendsToGroup(long[] toInvite, long groupId, String oauthToken) throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.inviteFriendsToGroup(groupId));
+        request.setHeaders(getAuthHeaders());
+        request.addParameter("format", "json");
+        //make a csv of the array
+        StringBuilder csv = new StringBuilder();
+        for (int i = 0; i < toInvite.length; i++) {
+            csv.append(Long.toString(toInvite[i]));
+            if ((i + 1) < toInvite.length) {
+                csv.append(",");
+            }
+        }
+        request.addParameter("member_ids", csv.toString());
+        request.addParameter("oauth_token", oauthToken);
+
+        IResponse response = http.post(request);
+
+        Validate.httpResponse(response.getStatusCode(), 200);
+
+        logger.debug("invite_friends=" + response.getResponse());
+
+        SuccessResponse model = parser.parseObject(response.getResponse(), SuccessResponse.class);
+        return model.isSuccess();
+    }
+
+    @Override
+    public long doCreateGroup(String name, String description, boolean privacy, long adminId, String socialToken) throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.createGroup());
+        request.setHeaders(getAuthHeaders());
+
+        request.addParameter("format", "json");
+        request.addParameter("name", name);
+        request.addParameter("description", description);
+        request.addParameter("privacy", privacy ? "open" : "closed");
+        request.addParameter("admin-id", Long.toString(adminId));
+        request.addParameter("oauth_token", socialToken);
+
+        IResponse response = http.post(request);
+
+        Validate.httpResponse(response.getStatusCode(), 200);
+
+        logger.debug("create_group=" + response.getResponse());
+
+        CreateGroupResponse model = parser.parseObject(response.getResponse(), CreateGroupResponse.class);
+        return Long.valueOf(model.getId());
+    }
+
+    @Override
+    public ProfileModel getProfile() throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.profile());
+        request.setHeaders(getAuthHeaders());
+        request.addParameter("format", "json");
+
+        IResponse response = http.get(request);
+
+        Validate.httpResponse(response.getStatusCode(), 200);
+
+        logger.debug("GetProfile response=" + response.getResponse());
+
+        ProfileModel res = parser.parseObject(response.getResponse(), ProfileModel.class);
+        res.json = response.getResponse();
+
+        // store profile json
+        // FIXME: store the profile only from one place, right now it happens from LoginTask also.
+        PrefManager pref = new PrefManager(mContext, PrefManager.Pref.LOGIN);
+        pref.put(PrefManager.Key.PROFILE_JSON, res.json);
+
+        return res;
+    }
+
+    @Override
+    public Map<String, SectionEntry> getCourseHierarchy(String courseId) throws Exception {
+        return getCourseHierarchy(courseId, false);
+    }
+
+    @Override
+    public Map<String, SectionEntry> getCourseHierarchy(String courseId, boolean preferCache) throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.courseHierarchy(courseId));
+        request.setHeaders(getAuthHeaders());
+        request.addParameter("format", "json");
+
+        String json = null;
+        if (NetworkUtil.isConnected(mContext) && !preferCache) {
+            // get data from server
+            IResponse response = http.get(request);
+
+            // cache the response
+            cache.put(request.getEndpoint(), response.getResponse());
+            json = response.getResponse();
+        } else {
+            json = cache.get(request.getEndpoint());
+        }
+
+        if (json == null) {
+            return null;
+        }
+
+        //Initializing task call
+        logger.debug("Received Data from Server at : "+ DateUtil.getCurrentTimeStamp());
+        logger.debug("course_hierarchy= " + json);
+
+        List<VideoResponseModel> list = parser.parseList(json, VideoResponseModel.class);
+
+        // create hierarchy with chapters, sections and subsections
+        // HashMap<String, SectionEntry> chapterMap = new HashMap<String, SectionEntry>();
+        Map<String, SectionEntry> chapterMap = new LinkedHashMap<String, SectionEntry>();
+        for (VideoResponseModel m : list) {
+            // add each video to its corresponding chapter and section
+
+            // add this as a chapter
+            String cname = m.getChapter().name;
+
+            // carry this courseId with video model
+            m.setCourseId(courseId);
+
+            SectionEntry s = null;
+            if (chapterMap.containsKey(cname)) {
+                s = chapterMap.get(cname);
+            } else {
+                s = new SectionEntry();
+                s.chapter = cname;
+                s.isChapter = true;
+                s.section_url = m.section_url;
+                chapterMap.put(cname, s);
+            }
+
+            // add this video to section inside in this chapter
+            ArrayList<VideoResponseModel> videos = s.sections.get(m.getSection().name);
+            if (videos == null) {
+                s.sections.put(m.getSection().name,
+                        new ArrayList<VideoResponseModel>());
+                videos = s.sections.get(m.getSection().name);
+            }
+
+            //This has been commented out because for some Videos thereare no english srt's and hence returning empty
+            /*try{
+            // FIXME: Utter hack code that should be removed as soon as the server starts
+            // returning default english transcripts.
+            if (m.getSummary().getTranscripts().englishUrl == null) {
+                // Example URL: "http://mobile3.m.sandbox.edx.org/api/mobile/v0.5/video_outlines/transcripts/MITx/6.002x_4x/3T2014/Welcome/en";
+                String usageKeyParts[] = m.getSummary().getId().split("/");
+                String usageKey = usageKeyParts[usageKeyParts.length - 1];
+                String fallbackUrl = getBaseUrl() + "/api/mobile/v0.5/video_outlines/transcripts/" + courseId + "/" + usageKey + "/en";
+                m.getSummary().getTranscripts().englishUrl = fallbackUrl;
+            }
+            }catch(Exception e){
+                logger.error(e);
+            }*/
+            videos.add(m);
+        }
+
+        logger.debug("Finished converting data at "+ DateUtil.getCurrentTimeStamp());
+        return chapterMap;
+    }
+
+    @Override
+    public LectureModel getLecture(String courseId, String chapterName, String lectureName) throws Exception {
+        Map<String, SectionEntry> map = getCourseHierarchy(courseId, true);
+
+        for (Map.Entry<String, SectionEntry> chapterentry : map.entrySet()) {
+
+            // identify required chapter
+            if (chapterName.equals(chapterentry.getKey())) {
+                for (Map.Entry<String, ArrayList<VideoResponseModel>> entry
+                        : chapterentry.getValue().sections.entrySet()) {
+
+                    // identify required lecture
+                    if (entry.getKey().equals(lectureName)) {
+                        LectureModel m = new LectureModel();
+                        m.name = entry.getKey();
+                        m.videos = entry.getValue();
+                        return m;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public VideoResponseModel getVideoById(String courseId, String videoId) throws Exception {
+        Map<String, SectionEntry> map = getCourseHierarchy(courseId, true);
+
+        // iterate chapters
+        for (Map.Entry<String, SectionEntry> chapterentry : map.entrySet()) {
+            // iterate lectures
+            for (Map.Entry<String, ArrayList<VideoResponseModel>> entry :
+                    chapterentry.getValue().sections.entrySet()) {
+                // iterate videos
+                for (VideoResponseModel v : entry.getValue()) {
+
+                    // identify the video
+                    if (videoId.equals(v.getSummary().getId())) {
+                        return v;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public VideoResponseModel getSubsectionById(String courseId, String subsectionId) throws Exception {
+        Map<String, SectionEntry> map = getCourseHierarchy(courseId, true);
+
+        // iterate chapters
+        for (Map.Entry<String, SectionEntry> chapterentry : map.entrySet()) {
+            // iterate lectures
+            for (Map.Entry<String, ArrayList<VideoResponseModel>> entry :
+                    chapterentry.getValue().sections.entrySet()) {
+                // iterate videos
+                for (VideoResponseModel v : entry.getValue()) {
+                    // identify the subsection (module) if id matches
+                    if (subsectionId.equals(v.getSection().id)) {
+                        return v;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public String getUnitUrlByVideoById(String courseId, String videoId) {
+        try {
+            VideoResponseModel vrm = getVideoById(courseId, videoId);
+            if(vrm!=null) {
+                return vrm.unit_url;
+            }
+        } catch(Exception e) {
+            logger.error(e);
+        }
+        return null;
+    }
+
+    @Override
+    public List<EnrolledCoursesResponse> getEnrolledCourses() throws Exception {
+        return getEnrolledCourses(false);
+    }
+
+    @Override
+    public List<EnrolledCoursesResponse> getEnrolledCourses(boolean fetchFromCache) throws Exception {
+        PrefManager pref = new PrefManager(mContext, PrefManager.Pref.LOGIN);
+
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.enrollments(pref.getCurrentUserProfile().username));
+        request.setHeaders(getAuthHeaders());
+        request.addParameter("format", "json");
+
+        String json = null;
+
+        if (NetworkUtil.isConnected(mContext) && !fetchFromCache) {
+            IResponse response = http.get(request);
+            json = response.getResponse();
+
+            // cache the response
+            cache.put(request.getEndpoint(), json);
+        }
+
+        if(json == null) {
+            json = cache.get(request.getEndpoint());
+        }
+
+        if (json == null) {
+            return null;
+        }
+
+        logger.debug("Url "+"enrolled_courses=" + json);
+
+        AuthErrorResponse authError = null;
+        try {
+            // check if auth error
+            authError = parser.parseObject(json, AuthErrorResponse.class);
+        } catch(Exception ex) {
+            // nothing to do here
+        }
+        if (authError != null && authError.detail != null) {
+            throw new AuthException(authError);
+        }
+
+        List<EnrolledCoursesResponse> list = parser.parseList(json, EnrolledCoursesResponse.class);
+        return list;
+    }
+
+    @Override
+    public CourseEntry getCourseById(String courseId) {
+        try {
+            for (EnrolledCoursesResponse r : getEnrolledCourses(true)) {
+                if (r.getCourse().getId().equals(courseId)) {
+                    return r.getCourse();
+                }
+            }
+        } catch(Exception ex) {
+            logger.error(ex);
+        }
+
+        return null;
+    }
+
+    @Override
+    public List<VideoResponseModel> getVideosByCourseId(String courseId, boolean preferCache) throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.videosByCourseId(courseId));
+        request.setHeaders(getAuthHeaders());
+        request.addParameter("format", "json");
+
+        String json = null;
+        if (NetworkUtil.isConnected(mContext) && !preferCache) {
+            IResponse response = http.post(request);
+            json = response.getResponse();
+            cache.put(request.getEndpoint(), json);
+        } else {
+            json = cache.get(request.getEndpoint());
+        }
+        logger.debug("videos_by_course=" + json);
+
+        List<VideoResponseModel> list = parser.parseList(json, VideoResponseModel.class);
+
+        return list;
+    }
+
+    @Override
+    public HandoutModel getHandout(String url, boolean preferCache) throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(url);
+        request.setHeaders(getAuthHeaders());
+        request.addParameter("format", "json");
+
+        String json = null;
+        if (NetworkUtil.isConnected(mContext) && !preferCache) {
+            IResponse response = http.get(request);
+            json = response.getResponse();
+            cache.put(request.getEndpoint(), json);
+        } else {
+            json = cache.get(request.getEndpoint());
+        }
+
+        if (json == null) {
+            return null;
+        }
+        logger.debug("handout=" + json);
+
+        HandoutModel res = parser.parseObject(json, HandoutModel.class);
+        return res;
+    }
+
+    @Override
+    public CourseInfoModel getCourseInfo(String url, boolean preferCache) throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(url);
+        request.setHeaders(getAuthHeaders());
+        request.addParameter("format", "json");
+
+        String json = null;
+        if (NetworkUtil.isConnected(mContext) && !preferCache) {
+            IResponse response = http.get(request);
+            json = response.getResponse();
+            cache.put(request.getEndpoint(), json);
+        } else {
+            json = cache.get(request.getEndpoint());
+        }
+
+        if (json == null) {
+            return null;
+        }
+        logger.debug("Response of course_about= " + json);
+
+        CourseInfoModel res = parser.parseObject(json, CourseInfoModel.class);
+        return res;
+    }
+
+    @Override
+    public List<AnnouncementsModel> getAnnouncement(String url, boolean preferCache) throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(url);
+        request.setHeaders(getAuthHeaders());
+        request.addParameter("format", "json");
+
+        String json = null;
+        if (NetworkUtil.isConnected(mContext) && !preferCache) {
+            IResponse response = http.get(request);
+            json = response.getResponse();
+            // cache the response
+            cache.put(request.getEndpoint(), json);
+        } else {
+            json = cache.get(request.getEndpoint());
+        }
+
+        if (json == null) {
+            return null;
+        }
+
+        List<AnnouncementsModel> list = parser.parseList(json, AnnouncementsModel.class);
+        return list;
+    }
+
+    @Override
+    public CourseInfoModel getSrtStream(String url) throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(url);
+        request.setHeaders(getAuthHeaders());
+        request.addParameter("format", "json");
+
+        IResponse response = http.get(request);
+        String json = response.getResponse();
+
+        if (json == null) {
+            return null;
+        }
+        logger.debug("srt stream= " + json);
+
+        CourseInfoModel res = parser.parseObject(json, CourseInfoModel.class);
+        return res;
+    }
+
+    @Override
+    public TranscriptModel getTranscriptsOfVideo(String enrollmentId, String videoId) {
+        try {
+            TranscriptModel transcript;
+            VideoResponseModel vidModel =  getVideoById(enrollmentId, videoId);
+            if(vidModel!=null){
+                if(vidModel.getSummary()!=null){
+                    transcript = vidModel.getSummary().getTranscripts();
+                    return transcript;
+                }
+            }
+        } catch(Exception e) {
+            logger.error(e);
+        }
+        return null;
+    }
+
+    @Override
+    public List<VideoResponseModel> getVideosByURL(String courseId, String videoUrl, boolean preferCache) throws Exception {
+        if(videoUrl==null){
+            return null;
+        }
+        List<VideoResponseModel> vidList = getVideosByCourseId(courseId, preferCache);
+        List<VideoResponseModel> list = new ArrayList<>();
+        if(vidList!=null && vidList.size()>0){
+            for(VideoResponseModel vrm : vidList){
+                try{
+                    if(vrm.getSummary().getVideo_url().equalsIgnoreCase(videoUrl)){
+                        vrm.setCourseId(courseId);
+                        list.add(vrm);
+                    }
+                }catch(Exception e){
+                    logger.error(e);
+                }
+            }
+        }
+
+        return list;
+    }
+
+    @Override
+    public List<EnrolledCoursesResponse> getFriendsCourses(String oauthToken) throws Exception {
+        return getFriendsCourses(false, oauthToken);
+    }
+
+    @Override
+    public List<EnrolledCoursesResponse> getFriendsCourses(boolean preferCache, String oauthToken) throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.friendsCourses());
+        request.setHeaders(getAuthHeaders());
+        request.addParameter("format", "json");
+        request.addParameter("oauth_token", oauthToken);
+
+        String json;
+
+        if (NetworkUtil.isConnected(mContext) && !preferCache) {
+            IResponse response = http.get(request);
+            json = response.getResponse();
+            cache.put(request.getEndpoint(), json);
+        } else {
+            json = cache.get(request.getEndpoint());
+        }
+
+        if (json == null) {
+            return null;
+        }
+        logger.debug("get_friends_courses=" + json);
+
+        AuthErrorResponse authError = null;
+        try {
+            // check if auth error
+            authError = parser.parseObject(json, AuthErrorResponse.class);
+        } catch(Exception ex) {
+            // nothing to do here
+        }
+        if (authError != null && authError.detail != null) {
+            throw new AuthException(authError);
+        }
+
+        List<EnrolledCoursesResponse> list = parser.parseList(json, EnrolledCoursesResponse.class);
+        return list;
+    }
+
+    @Override
+    public List<SocialMember> getFriendsInCourse(String courseId, String oauthToken) throws Exception {
+        return getFriendsInCourse(false, courseId, oauthToken);
+    }
+
+    @Override
+    public List<SocialMember> getFriendsInCourse(boolean preferCache, String courseId, String oauthToken) throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.friendsInCourses(courseId));
+        request.setHeaders(getAuthHeaders());
+        request.addParameter("format", "json");
+        request.addParameter("oauth_token", oauthToken);
+
+        String json;
+
+        if (NetworkUtil.isConnected(mContext) && !preferCache) {
+            IResponse response = http.get(request);
+            json = response.getResponse();
+            cache.put(request.getEndpoint(), json);
+        } else {
+            json = cache.get(request.getEndpoint());
+        }
+
+        if (json == null) {
+            return null;
+        }
+        logger.debug("friends_in_course=" + json);
+
+        GetFriendsListResponse response = parser.parseObject(json, GetFriendsListResponse.class);
+        return response.getFriends();
+    }
+
+    @Override
+    public void setUserCourseShareConsent(boolean consent) throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.userCourseShareConsent());
+        request.setHeaders(getAuthHeaders());
+        request.addParameter("format", "json");
+        request.addParameter("share_with_facebook_friends", Boolean.toString(consent));
+        IResponse response = http.post(request);
+        logger.debug("course_share_consent=" + response.getResponse());
+        Gson gson = JsonBooleanDeserializer.getCaseInsensitiveBooleanGson();
+        gson.fromJson(response.getResponse(), ShareCourseResult.class);
+    }
+
+    @Override
+    public boolean getUserCourseShareConsent() throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.userCourseShareConsent());
+        request.setHeaders(getAuthHeaders());
+        request.addParameter("format", "json");
+        IResponse response = http.get(request);
+        if (response.getResponse() == null) {
+            return false;
+        }
+        logger.debug("course_share_consent=" + response.getResponse());
+        Gson gson = JsonBooleanDeserializer.getCaseInsensitiveBooleanGson();
+        SuccessResponse model = gson.fromJson(response.getResponse(), ShareCourseResult.class);
+        return model.isSuccess();
+    }
+
+    @Override
+    public List<SocialMember> getGroupMembers(boolean preferCache, long groupId) throws Exception {
+        IRequest request = new IRequestImpl();
+        request.setEndpoint(Endpoint.groupMembers(String.valueOf(groupId)));
+        request.setHeaders(getAuthHeaders());
+        request.addParameter("format", "json");
+
+        String json;
+
+        if (NetworkUtil.isConnected(mContext) && !preferCache) {
+            IResponse response = http.get(request);
+            json = response.getResponse();
+            // cache the response
+            cache.put(request.getEndpoint(), json);
+        } else {
+            json = cache.get(request.getEndpoint());
+        }
+
+        if (json == null) {
+            return null;
+        }
+        logger.debug("get_group_members=" + json);
+
+        GetGroupMembersResponse response = parser.parseObject(json, GetGroupMembersResponse.class);
+        return response.getMembers();
+    }
+
+    @Override
+    public List<SectionItemInterface> getLiveOrganizedVideosByChapter(String courseId, String chapter) {
+        ArrayList<SectionItemInterface> list = new ArrayList<SectionItemInterface>();
+
+        // add chapter to the result
+        ChapterModel c = new ChapterModel();
+        c.name = chapter;
+        list.add(c);
+
+        try {
+            HashMap<String, ArrayList<VideoResponseModel>> sections = new LinkedHashMap<>();
+
+            List<VideoResponseModel> videos = getVideosByCourseId(courseId, true);
+            for (VideoResponseModel v : videos) {
+                // filter videos by chapter
+                if (v.getChapter().name.equals(chapter)) {
+                    // this video is under the specified chapter
+
+                    // sort out the section of this video
+                    if (sections.containsKey(v.getSection().name)) {
+                        ArrayList<VideoResponseModel> sv = sections.get(v.getSection().name);
+                        if (sv == null) {
+                            sv = new ArrayList<>();
+                        }
+                        sv.add(v);
+                    } else {
+                        ArrayList<VideoResponseModel> vlist = new ArrayList<>();
+                        vlist.add(v);
+                        sections.put(v.getSection().name, vlist);
+                    }
+                }
+            }
+
+            // now add sectioned videos to the result
+            for (Map.Entry<String, ArrayList<VideoResponseModel>> entry : sections.entrySet()) {
+                // add section to the result
+                SectionItemModel s = new SectionItemModel();
+                s.name = entry.getKey();
+                list.add(s);
+
+                // add videos to the result
+                if (entry.getValue() != null) {
+                    for (VideoResponseModel v : entry.getValue()) {
+                        list.add(v);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.error(e);
+        }
+
+        return list;
+    }
+
+    @Override
+    public SyncLastAccessedSubsectionResponse getLastAccessedSubsection(String courseId) throws Exception {
+        PrefManager pref = new PrefManager(mContext, PrefManager.Pref.LOGIN);
+        String username = pref.getCurrentUserProfile().username;
+
+        IRequest request = new IRequestImpl();
+        request.setHeaders(getAuthHeaders());
+        request.setEndpoint(Endpoint.syncLastAccessedSubSection(username, courseId));
+        IResponse response = http.get(request);
+
+        if (response.getResponse() == null) {
+            return null;
+        }
+        logger.debug("Response of get last viewed subsection.id = " + response.getResponse());
+
+        SyncLastAccessedSubsectionResponse res = parser.parseObject(response.getResponse(), SyncLastAccessedSubsectionResponse.class);
+        return res;
+    }
+
+    @Override
+    public RegistrationDescription getRegistrationDescription() throws Exception {
+        // check if we have a cached version of registration description
+        try {
+            // TODO: let the form be rendered by JSON in assets for testing, but delete below line for prod
+//            String json = cache.get(Endpoint.registration());
+//            if (json != null) {
+//                RegistrationDescription form = gson.fromJson(json, RegistrationDescription.class);
+//                logger.debug("picking up registration description (form) from cache, not from assets");
+//                return form;
+//            }
+        } catch(Exception ex) {
+            logger.error(ex);
+        }
+
+        // if not cached, read the in-app registration description
+        InputStream in = mContext.getAssets().open("config/registration_form.json");
+        RegistrationDescription form = parser.parseObject(new InputStreamReader(in), RegistrationDescription.class);
+        logger.debug("picking up registration description (form) from assets, not from cache");
+        return form;
+    }
+
+    /**
+     * Returns "Authorization" header with current active access token.
+     * This is not a network call and returns already cached data.
+     * @return
+     */
+    public Bundle getAuthHeaders() {
+        Bundle headers = new Bundle();
+
+        // generate auth headers
+        PrefManager pref = new PrefManager(mContext, PrefManager.Pref.LOGIN);
+        AuthResponse auth = pref.getCurrentAuth();
+
+        if (auth == null || !auth.isSuccess()) {
+            // this might be a login with Facebook or Google
+            String token = pref.getString(PrefManager.Key.AUTH_TOKEN_SOCIAL);
+            if (token != null) {
+                String cookie = pref.getString(PrefManager.Key.AUTH_TOKEN_SOCIAL_COOKIE);
+
+                headers.putString("Authorization", token);
+                headers.putString("Cookie", cookie);
+            } else {
+                logger.warn("Token cannot be null when AUTH_JSON is also null, something is WRONG!");
+            }
+        } else {
+            headers.putString("Authorization", String.format("%s %s", auth.token_type, auth.access_token));
+        }
+        return headers;
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/IRequest.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/IRequest.java
@@ -1,0 +1,23 @@
+package org.edx.mobile.module.serverapi;
+
+import android.os.Bundle;
+
+/**
+ * Created by rohan on 2/6/15.
+ */
+public interface IRequest {
+
+    void setEndpoint(String endpoint);
+    String getEndpoint();
+
+    void setPostBody(String postBody);
+    String getPostBody();
+
+    void addParameter(String key, String value);
+    Bundle getParameters();
+    void setParameters(Bundle parameters);
+
+    void addHeader(String key, String value);
+    Bundle getHeaders();
+    void setHeaders(Bundle headers);
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/IRequest.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/IRequest.java
@@ -20,4 +20,12 @@ public interface IRequest {
     void addHeader(String key, String value);
     Bundle getHeaders();
     void setHeaders(Bundle headers);
+
+    public static final class Method {
+        public static final String GET      = "GET";
+        public static final String POST     = "POST";
+        public static final String PUT      = "PUT";
+        public static final String DELETE   = "DELETE";
+        public static final String PATCH    = "PATCH";
+    }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/IRequestImpl.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/IRequestImpl.java
@@ -67,12 +67,4 @@ class IRequestImpl implements IRequest {
     public void setHeaders(Bundle headers) {
         this.headers = headers;
     }
-
-    public static final class Method {
-        public static final String GET      = "GET";
-        public static final String POST     = "POST";
-        public static final String PUT      = "PUT";
-        public static final String DELETE   = "DELETE";
-        public static final String PATCH    = "PATCH";
-    }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/IRequestImpl.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/IRequestImpl.java
@@ -1,0 +1,78 @@
+package org.edx.mobile.module.serverapi;
+
+import android.os.Bundle;
+
+/**
+ * Created by rohan on 2/6/15.
+ */
+class IRequestImpl implements IRequest {
+
+    private String endpoint;
+    private Bundle params;
+    private Bundle headers;
+    private String postBody;
+
+    @Override
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public String getPostBody() {
+        return postBody;
+    }
+
+    @Override
+    public void setPostBody(String postBody) {
+        this.postBody = postBody;
+    }
+
+    @Override
+    public void addParameter(String key, String value) {
+        if (params == null) {
+            params = new Bundle();
+        }
+        params.putString(key, value);
+    }
+
+    @Override
+    public void addHeader(String key, String value) {
+        if (headers == null) {
+            headers = new Bundle();
+        }
+        headers.putString(key, value);
+    }
+
+    @Override
+    public Bundle getParameters() {
+        return params;
+    }
+
+    @Override
+    public void setParameters(Bundle parameters) {
+        this.params = parameters;
+    }
+
+    @Override
+    public Bundle getHeaders() {
+        return headers;
+    }
+
+    @Override
+    public void setHeaders(Bundle headers) {
+        this.headers = headers;
+    }
+
+    public static final class Method {
+        public static final String GET      = "GET";
+        public static final String POST     = "POST";
+        public static final String PUT      = "PUT";
+        public static final String DELETE   = "DELETE";
+        public static final String PATCH    = "PATCH";
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/IResponse.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/IResponse.java
@@ -1,0 +1,13 @@
+package org.edx.mobile.module.serverapi;
+
+import android.os.Bundle;
+
+/**
+ * Created by rohan on 2/6/15.
+ */
+public interface IResponse {
+
+    String getResponse();
+    int getStatusCode();
+    Bundle getCookies();
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/Validate.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/Validate.java
@@ -1,0 +1,21 @@
+package org.edx.mobile.module.serverapi;
+
+import org.edx.mobile.util.InputValidationUtil;
+
+/**
+ * Created by rohan on 2/17/15.
+ */
+class Validate {
+
+    public static void emailAddress(String email) {
+        if ( !InputValidationUtil.isValidEmail(email)) {
+            throw new IllegalArgumentException("Email address invalid");
+        }
+    }
+
+    public static void httpResponse(int statusCode, int expectedStatusCode) {
+        if (statusCode != expectedStatusCode) {
+            throw new IllegalArgumentException(String.format("Expected HTTP %d, but found HTTP %d", expectedStatusCode, statusCode));
+        }
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/cache/CacheManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/cache/CacheManager.java
@@ -1,0 +1,66 @@
+package org.edx.mobile.module.serverapi.cache;
+
+import android.content.Context;
+
+import org.apache.commons.io.IOUtils;
+import org.edx.mobile.logger.Logger;
+import org.edx.mobile.util.Sha1Util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.security.NoSuchAlgorithmException;
+
+public class CacheManager {
+
+    private File cacheFolder;
+    protected final Logger logger = new Logger(getClass().getName());
+
+    public CacheManager(Context context) {
+        if (context == null) {
+            logger.warn("Context must not be NULL");
+        }
+        cacheFolder = new File(context.getFilesDir(), "http-cache");
+        if (!cacheFolder.exists()) {
+            cacheFolder.mkdirs();
+        }
+    }
+
+    public boolean has(String url) throws NoSuchAlgorithmException,
+            UnsupportedEncodingException {
+        String hash = Sha1Util.SHA1(url);
+        File file = new File(cacheFolder, hash);
+        return file.exists();
+    }
+
+    public void put(String url, String response)
+            throws NoSuchAlgorithmException, UnsupportedEncodingException,
+            IOException {
+        String hash = Sha1Util.SHA1(url);
+        File file = new File(cacheFolder, hash);
+        FileOutputStream out = new FileOutputStream(file);
+        out.write(response.getBytes());
+        out.close();
+        logger.debug("Cache.put = " + hash);
+    }
+
+    public String get(String url) throws IOException, NoSuchAlgorithmException {
+        String hash = Sha1Util.SHA1(url);
+        File file = new File(cacheFolder, hash);
+        
+        if (!file.exists()) {
+            logger.debug("Cache.get failed, not cached");
+            // not in cache
+            return null;
+        }
+        
+        FileInputStream in = new FileInputStream(file);
+        String cache = IOUtils.toString(in, Charset.defaultCharset());
+        in.close();
+        logger.debug("Cache.get = " + hash);
+        return cache;
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/http/HttpFactory.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/http/HttpFactory.java
@@ -1,0 +1,15 @@
+package org.edx.mobile.module.serverapi.http;
+
+/**
+ * Created by rohan on 2/6/15.
+ */
+public class HttpFactory {
+
+    /**
+     * Returns a new instance of {@link org.edx.mobile.module.serverapi.http.IHttp} class.
+     * @return
+     */
+    public static IHttp getInstance() {
+        return new IHttpImpl();
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/http/HttpPatch.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/http/HttpPatch.java
@@ -1,6 +1,7 @@
 package org.edx.mobile.module.serverapi.http;
 
 import org.apache.http.client.methods.HttpPost;
+import org.edx.mobile.module.serverapi.IRequest;
 
 /**
  * This class represents HTTP PATCH request.
@@ -10,14 +11,12 @@ import org.apache.http.client.methods.HttpPost;
  */
 class HttpPatch extends HttpPost {
     
-    public static final String METHOD_PATCH = "PATCH";
-
     public HttpPatch(final String url) {
         super(url);
     }
 
     @Override
     public String getMethod() {
-        return METHOD_PATCH;
+        return IRequest.Method.PATCH;
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/http/HttpPatch.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/http/HttpPatch.java
@@ -1,0 +1,23 @@
+package org.edx.mobile.module.serverapi.http;
+
+import org.apache.http.client.methods.HttpPost;
+
+/**
+ * This class represents HTTP PATCH request.
+ * Instead of {@link org.apache.http.client.methods.HttpPost}, this class can be used to make PATCH requests using {@link org.apache.http.client.HttpClient}.
+ * @author rohan
+ *
+ */
+class HttpPatch extends HttpPost {
+    
+    public static final String METHOD_PATCH = "PATCH";
+
+    public HttpPatch(final String url) {
+        super(url);
+    }
+
+    @Override
+    public String getMethod() {
+        return METHOD_PATCH;
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/http/IHttp.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/http/IHttp.java
@@ -1,0 +1,20 @@
+package org.edx.mobile.module.serverapi.http;
+
+import org.edx.mobile.module.serverapi.IRequest;
+import org.edx.mobile.module.serverapi.IResponse;
+
+import java.io.IOException;
+
+/**
+ * Created by rohan on 2/6/15.
+ */
+public interface IHttp {
+
+    /* Keys for Response headers */
+    static final String KEY_X_CSRFTOKEN     = "X-CSRFToken";
+    static final String KEY_COOKIE          = "Cookie";
+
+    IResponse get(IRequest request) throws IOException;
+    IResponse post(IRequest request) throws IOException;
+    IResponse patch(IRequest request) throws IOException;
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/http/IHttpImpl.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/http/IHttpImpl.java
@@ -1,0 +1,215 @@
+package org.edx.mobile.module.serverapi.http;
+
+import android.net.http.AndroidHttpClient;
+import android.os.Bundle;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.Header;
+import org.apache.http.HeaderElement;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.params.HttpClientParams;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.params.CoreProtocolPNames;
+import org.apache.http.protocol.HTTP;
+import org.edx.mobile.logger.Logger;
+import org.edx.mobile.module.serverapi.IRequest;
+import org.edx.mobile.module.serverapi.IResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by rohan on 2/6/15.
+ */
+class IHttpImpl implements IHttp {
+
+    private static final String KEY_SET_COOKIE      = "Set-Cookie";
+    private static final String KEY_CSRFTOKEN       = "CSRFToken";
+    private static final String CONTENT_TYPE_JSON   = "application/json";
+    public static Logger logger = new Logger(IHttpImpl.class);
+
+    @Override
+    public IResponse get(IRequest request) throws IOException {
+        HttpClient client = getHttpClient();
+
+        HttpGet get = new HttpGet(toGETUrl(request.getEndpoint(), request.getParameters()));
+        // allow GZip
+        AndroidHttpClient.modifyRequestToAcceptGzipResponse(get);
+        // allow redirects
+        HttpClientParams.setRedirecting(get.getParams(), true);
+
+        // set request headers
+        setHeaders(request, get);
+
+        // being a GET, parameters are already appended to the endpoint
+
+        // execute request
+        HttpResponse response = client.execute(get);
+        IResponse result = getResponse(response);
+
+        // shutdown the client
+        client.getConnectionManager().shutdown();
+
+        return result;
+    }
+
+    @Override
+    public IResponse post(IRequest request) throws IOException {
+        HttpPost post = new HttpPost(request.getEndpoint());
+        return executePost(request, post);
+    }
+
+    @Override
+    public IResponse patch(IRequest request) throws IOException {
+        HttpPost patch = new HttpPatch(request.getEndpoint());
+        return executePost(request, patch);
+    }
+
+    /**
+     * Returns GET url with appended parameters.
+     *
+     * @param url
+     * @param params
+     * @return
+     */
+    private static String toGETUrl(String url, Bundle params) {
+        if (params != null) {
+            if (!url.endsWith("?")) {
+                url = url + "?";
+            }
+
+            for (String key : params.keySet()) {
+                url = url + key + "=" + params.getString(key) + "&";
+            }
+        }
+        return url;
+    }
+
+    /**
+     * Returns {@link org.edx.mobile.module.serverapi.IResponse} representation of
+     * the given {@link org.apache.http.HttpResponse} object.
+     * @param response
+     * @return
+     * @throws IOException
+     */
+    private IResponse getResponse(HttpResponse response) throws IOException {
+        int statusCode = response.getStatusLine().getStatusCode();
+        logger.debug("StatusCode for get request= " + statusCode);
+
+        // read cookies
+        Bundle cookies = new Bundle();
+        if(response.containsHeader(KEY_SET_COOKIE)){
+            Header header = response.getFirstHeader(KEY_SET_COOKIE);
+            cookies.putString(header.getName(), header.getValue());
+
+            // prepare for "Cookie" and "X-CSRFToken" elements
+            HeaderElement[] elements = header.getElements();
+            if (elements != null) {
+                for (int i = 0; i < elements.length; i++) {
+                    HeaderElement element = elements[i];
+                    if (element.getName().equalsIgnoreCase(KEY_CSRFTOKEN)) {
+                        cookies.putString(KEY_COOKIE, element.getName()
+                                + "=" + element.getValue());
+                        cookies.putString(KEY_X_CSRFTOKEN, element.getValue());
+                    }
+                }
+            }
+        }
+
+        InputStream inputStream = AndroidHttpClient
+                .getUngzippedContent(response.getEntity());
+        String strResponse = IOUtils.toString(inputStream);
+
+        // prepare response object and return
+        IResponseImpl result = new IResponseImpl();
+        result.setStatusCode(statusCode);
+        result.setResponse(strResponse);
+        result.setCookies(cookies);
+
+        return result;
+    }
+
+    /**
+     * Returns HttpClient instance initialized with HTTP 1.1 and redirects enabled.
+     * @return
+     */
+    private HttpClient getHttpClient() {
+        DefaultHttpClient client = new DefaultHttpClient();
+        client.getParams().setParameter(CoreProtocolPNames.PROTOCOL_VERSION,
+                HttpVersion.HTTP_1_1);
+        HttpClientParams.setRedirecting(client.getParams(), true);
+        return client;
+    }
+
+    /**
+     * Sets headers to the httpRequest.
+     * @param request
+     * @param httpRequest
+     */
+    private void setHeaders(IRequest request, HttpRequest httpRequest) {
+        // set request headers
+        if (request.getHeaders() != null) {
+            Bundle headers = request.getHeaders();
+            for (String key : headers.keySet()) {
+                httpRequest.setHeader(key, headers.getString(key));
+            }
+        }
+    }
+
+    /**
+     * Executes a POST request.
+     * @param request
+     * @param post
+     * @return
+     * @throws IOException
+     */
+    private IResponse executePost(IRequest request, HttpPost post) throws IOException {
+        HttpClient client = getHttpClient();
+
+        // allow GZip
+        AndroidHttpClient.modifyRequestToAcceptGzipResponse(post);
+        // allow redirects
+        HttpClientParams.setRedirecting(post.getParams(), true);
+
+        // set request headers
+        setHeaders(request, post);
+
+        // set request parameters
+        if (request.getParameters() != null) {
+            Bundle params = request.getParameters();
+            List<NameValuePair> pairs = new ArrayList<>();
+            for (String key : params.keySet()) {
+                pairs.add(new BasicNameValuePair(key, params.getString(key)));
+            }
+            post.setEntity(new UrlEncodedFormEntity(pairs));
+        }
+
+        // set request body if provided in request
+        if (request.getPostBody() != null) {
+            StringEntity se = new StringEntity(request.getPostBody());
+            se.setContentEncoding(new BasicHeader(HTTP.CONTENT_TYPE, CONTENT_TYPE_JSON));
+            post.setEntity(se);
+        }
+
+        // execute request
+        HttpResponse httpResponse = client.execute(post);
+        IResponse response = getResponse(httpResponse);
+
+        // shutdown the client
+        client.getConnectionManager().shutdown();
+
+        return response;
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/http/IResponseImpl.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/http/IResponseImpl.java
@@ -1,0 +1,42 @@
+package org.edx.mobile.module.serverapi.http;
+
+import android.os.Bundle;
+
+import org.edx.mobile.module.serverapi.IResponse;
+
+/**
+ * Created by rohan on 2/6/15.
+ */
+class IResponseImpl implements IResponse {
+
+    private String response;
+    private int statusCode;
+    private Bundle headers;
+
+    @Override
+    public Bundle getCookies() {
+        return headers;
+    }
+
+    public void setCookies(Bundle headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    public String getResponse() {
+        return response;
+    }
+
+    public void setResponse(String response) {
+        this.response = response;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/parser/GsonParser.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/parser/GsonParser.java
@@ -1,0 +1,34 @@
+package org.edx.mobile.module.serverapi.parser;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * Created by rohan on 2/6/15.
+ */
+class GsonParser implements IParser {
+
+    private Gson gson = new GsonBuilder().create();
+
+    @Override
+    public <T> T parseObject(String json, Class<T> cls) throws Exception {
+        return gson.fromJson(json, cls);
+    }
+
+    @Override
+    public <T> T parseObject(Reader reader, Class<T> cls) throws Exception {
+        return gson.fromJson(reader, cls);
+    }
+
+    @Override
+    public <T> List<T> parseList(String json, final Class<T> cls) throws Exception {
+        Type listType = new TypeToken<List<T>>() {}.getType();
+        List<T> list = gson.fromJson(json, listType);
+        return list;
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/parser/IParser.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/parser/IParser.java
@@ -1,0 +1,11 @@
+package org.edx.mobile.module.serverapi.parser;
+
+import java.io.Reader;
+import java.util.List;
+
+public interface IParser {
+
+	public <T> T parseObject(String data, Class<T> cls) throws Exception;
+    public <T> T parseObject(Reader reader, Class<T> cls) throws Exception;
+	public <T> List<T> parseList(String data, Class<T> cls) throws Exception;
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/parser/IParser.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/parser/IParser.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public interface IParser {
 
-	public <T> T parseObject(String data, Class<T> cls) throws Exception;
+	public <T> T parseObject(String jsonObject, Class<T> cls) throws Exception;
     public <T> T parseObject(Reader reader, Class<T> cls) throws Exception;
-	public <T> List<T> parseList(String data, Class<T> cls) throws Exception;
+	public <T> List<T> parseList(String jsonArray, Class<T> cls) throws Exception;
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/parser/ParserFactory.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/parser/ParserFactory.java
@@ -2,16 +2,11 @@ package org.edx.mobile.module.serverapi.parser;
 
 public class ParserFactory {
 	
-    private static IParser instance;
-
     /**
-     * Returns singleton instance of {@link IParser} interface.
+     * Returns new instance of {@link IParser} interface.
      * @return
      */
     public static IParser getInstance() {
-        if (instance == null) {
-            instance = new GsonParser();
-        }
-        return instance;
+        return new GsonParser();
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/parser/ParserFactory.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/serverapi/parser/ParserFactory.java
@@ -1,0 +1,17 @@
+package org.edx.mobile.module.serverapi.parser;
+
+public class ParserFactory {
+	
+    private static IParser instance;
+
+    /**
+     * Returns singleton instance of {@link IParser} interface.
+     * @return
+     */
+    public static IParser getInstance() {
+        if (instance == null) {
+            instance = new GsonParser();
+        }
+        return instance;
+    }
+}


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/MOB-1646

This decouples HTTP implementation and JSON response parser implementation from the server API calls. Also, with our own <code>IResponse</code> class, we get an opportunity to have headers, statusCode as well as the response string to validate on, before we convert the server response into a model object. 

All these are completely new classes and I have not yet deleted any old classes from the app. I would like to do that as a last commit on this PR. So, you will see similar classes already there in the app, but please ignore for now.

I just have started mocking API calls. Tested just one endpoint that is login endpoint and it worked. Though it's an incomplete test case, but ensures that the mocking library works for us.

If these changes look good, I would like to continue mocking all the API calls and get rid of existing API implementation.

@aleffert  Please review. 
cc @shahidtamboli @nasthagiri 