### PR TITLE
Change activity launch flag to avoid activity re-creation

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/Router.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/Router.java
@@ -76,7 +76,12 @@ public class Router {
 
     public void showMyCourses(Activity sourceActivity) {
         Intent intent = new Intent(sourceActivity, MyCoursesListActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        /*
+        using CLEAR_TOP flags, causes the activity to be re-created every time.
+        This reloads the list of courses. We don't want that.
+        Using REORDER_TO_FRONT solves this problem
+         */
+        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
         sourceActivity.startActivity(intent);
 
         // let login screens be ended

--- a/VideoLocker/src/main/java/org/edx/mobile/view/Router.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/Router.java
@@ -77,7 +77,7 @@ public class Router {
     public void showMyCourses(Activity sourceActivity) {
         Intent intent = new Intent(sourceActivity, MyCoursesListActivity.class);
         /*
-        using CLEAR_TOP flags, causes the activity to be re-created every time.
+        Using CLEAR_TOP flag, causes the activity to be re-created every time.
         This reloads the list of courses. We don't want that.
         Using REORDER_TO_FRONT solves this problem
          */


### PR DESCRIPTION
This makes the MyCourses screen not to be re-created when "My Courses" from the drawer options is clicked by user.

JIRA: https://openedx.atlassian.net/browse/MOB-1519

cc @aleffert @shahidtamboli 