### PR TITLE
Do not reload Courseware and CourseInfo tabs while switching the tabs

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
@@ -58,6 +58,8 @@ import java.util.List;
 
 public class BaseFragmentActivity extends FragmentActivity implements NetworkSubject {
 
+    public static final String EXTRA_ENROLLMENT = "enrollment";
+
     public static final String ACTION_SHOW_MESSAGE_INFO = "ACTION_SHOW_MESSAGE_INFO";
     public static final String ACTION_SHOW_MESSAGE_ERROR = "ACTION_SHOW_MESSAGE_ERROR";
     // per second callback

--- a/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
@@ -15,6 +15,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 import org.edx.mobile.R;
+import org.edx.mobile.base.BaseFragmentActivity;
 import org.edx.mobile.http.Api;
 import org.edx.mobile.interfaces.SectionItemInterface;
 import org.edx.mobile.logger.Logger;
@@ -35,7 +36,6 @@ import org.edx.mobile.module.storage.Storage;
 import org.edx.mobile.task.CircularProgressTask;
 import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.BrowserUtil;
-
 import org.edx.mobile.util.MediaConsentUtils;
 import org.edx.mobile.util.MemoryUtil;
 import org.edx.mobile.util.NetworkUtil;
@@ -119,7 +119,7 @@ public class VideoListFragment extends Fragment {
             // read incoming enrollment model
             if (enrollment == null) {
                 enrollment = (EnrolledCoursesResponse) extraIntent
-                        .getSerializableExtra("enrollment");
+                        .getSerializableExtra(BaseFragmentActivity.EXTRA_ENROLLMENT);
             }
         }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/BaseTabActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/BaseTabActivity.java
@@ -4,6 +4,8 @@ import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTabHost;
+import android.support.v4.app.FragmentTransaction;
+import android.widget.TabHost;
 import android.widget.TabWidget;
 import android.widget.TextView;
 
@@ -45,8 +47,7 @@ public abstract class BaseTabActivity extends BaseFragmentActivity {
         for (int i = 0; i < tabs.size(); i ++){
             TabModel tab = tabs.get(i);
             tabHost.addTab(
-                    tabHost.newTabSpec(tab.getTag())
-                            .setIndicator(tab.getName(), null),
+                    tabHost.newTabSpec(tab.getTag()).setIndicator(tab.getName(), null),
                     tab.getFragmentClass(),
                     tab.getFragmentArgs());
         }
@@ -61,6 +62,8 @@ public abstract class BaseTabActivity extends BaseFragmentActivity {
             tv.setSingleLine(true);
             tv.setAllCaps(true);
         }
+
+        tabHost.setOnTabChangedListener(tabChangeListener);
     }
 
     protected Fragment getFragmentByTag(String tag) {
@@ -108,8 +111,26 @@ public abstract class BaseTabActivity extends BaseFragmentActivity {
         }
     }
 
+    private TabHost.OnTabChangeListener tabChangeListener = new TabHost.OnTabChangeListener() {
+        @Override
+        public void onTabChanged(String tabId) {
+            if (tabId != null) {
+                Fragment fragment = getFragmentByTag(tabId);
+                if (fragment != null) {
+                    displayFragment(tabId, fragment);
+                }
+            }
+        }
+    };
+
+    private void displayFragment(String tag, Fragment fragment) {
+        FragmentManager   manager         =   getSupportFragmentManager();
+        FragmentTransaction ft            =   manager.beginTransaction();
+        ft.replace(android.R.id.tabcontent, fragment, tag);
+        ft.commit();
+    }
+
     protected abstract List<TabModel> tabsToAdd();
 
     protected  abstract int getDefaultTab();
-
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/BaseTabActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/BaseTabActivity.java
@@ -4,8 +4,6 @@ import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTabHost;
-import android.support.v4.app.FragmentTransaction;
-import android.widget.TabHost;
 import android.widget.TabWidget;
 import android.widget.TextView;
 
@@ -62,8 +60,6 @@ public abstract class BaseTabActivity extends BaseFragmentActivity {
             tv.setSingleLine(true);
             tv.setAllCaps(true);
         }
-
-        tabHost.setOnTabChangedListener(tabChangeListener);
     }
 
     protected Fragment getFragmentByTag(String tag) {
@@ -109,25 +105,6 @@ public abstract class BaseTabActivity extends BaseFragmentActivity {
         public NoTabLayoutElementsException(String detailMessage) {
             super(detailMessage);
         }
-    }
-
-    private TabHost.OnTabChangeListener tabChangeListener = new TabHost.OnTabChangeListener() {
-        @Override
-        public void onTabChanged(String tabId) {
-            if (tabId != null) {
-                Fragment fragment = getFragmentByTag(tabId);
-                if (fragment != null) {
-                    displayFragment(tabId, fragment);
-                }
-            }
-        }
-    };
-
-    private void displayFragment(String tag, Fragment fragment) {
-        FragmentManager   manager         =   getSupportFragmentManager();
-        FragmentTransaction ft            =   manager.beginTransaction();
-        ft.replace(android.R.id.tabcontent, fragment, tag);
-        ft.commit();
     }
 
     protected abstract List<TabModel> tabsToAdd();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseAnnouncementFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseAnnouncementFragment.java
@@ -57,7 +57,7 @@ public class CourseAnnouncementFragment extends CourseDetailBaseFragment {
         try {
             final Bundle bundle = getArguments();
             EnrolledCoursesResponse courseData = (EnrolledCoursesResponse) bundle
-                    .getSerializable("enrollment");
+                    .getSerializable(BaseFragmentActivity.EXTRA_ENROLLMENT);
             if(courseData!=null){
                 loadData(courseData);
             }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseChapterListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseChapterListFragment.java
@@ -1,6 +1,5 @@
 package org.edx.mobile.view;
 
-import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
@@ -20,32 +19,32 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import org.edx.mobile.R;
+import org.edx.mobile.base.BaseFragmentActivity;
 import org.edx.mobile.base.CourseDetailBaseFragment;
 import org.edx.mobile.http.Api;
-import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.interfaces.NetworkObserver;
-import org.edx.mobile.model.IVideoModel;
+import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.model.api.LectureModel;
 import org.edx.mobile.model.api.SectionEntry;
 import org.edx.mobile.model.api.SyncLastAccessedSubsectionResponse;
 import org.edx.mobile.model.api.VideoResponseModel;
 import org.edx.mobile.model.db.DownloadEntry;
 import org.edx.mobile.module.prefs.PrefManager;
-import org.edx.mobile.task.GetLastAccessedTask;
-import org.edx.mobile.util.DateUtil;
-import org.edx.mobile.util.MediaConsentUtils;
-import org.edx.mobile.util.NetworkUtil;
-import org.edx.mobile.view.custom.ETextView;
-import org.edx.mobile.util.UiUtil;
-import org.edx.mobile.view.dialog.DownloadSizeExceedDialog;
-import org.edx.mobile.view.dialog.ProgressDialogFragment;
 import org.edx.mobile.task.EnqueueDownloadTask;
 import org.edx.mobile.task.GetCourseHierarchyTask;
+import org.edx.mobile.task.GetLastAccessedTask;
 import org.edx.mobile.task.SyncLastAccessedTask;
 import org.edx.mobile.util.AppConstants;
+import org.edx.mobile.util.DateUtil;
+import org.edx.mobile.util.MediaConsentUtils;
 import org.edx.mobile.util.MemoryUtil;
+import org.edx.mobile.util.NetworkUtil;
+import org.edx.mobile.util.UiUtil;
 import org.edx.mobile.view.adapters.ChapterAdapter;
+import org.edx.mobile.view.custom.ETextView;
+import org.edx.mobile.view.dialog.DownloadSizeExceedDialog;
 import org.edx.mobile.view.dialog.IDialogCallback;
+import org.edx.mobile.view.dialog.ProgressDialogFragment;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -70,14 +69,17 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
     private EnrolledCoursesResponse enrollment;
     private ETextView courseScheduleTv;
     private String startDate;
+    private boolean isTaskRunning = false;
 
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        logger.debug("created: " + getClass().getName());
+
         final Bundle bundle = getArguments();
         if(bundle!=null){
             enrollment = (EnrolledCoursesResponse) bundle
-                    .getSerializable("enrollment");
+                    .getSerializable(BaseFragmentActivity.EXTRA_ENROLLMENT);
             if(enrollment!=null) {
                 courseId = enrollment.getCourse().getId();
                 try {
@@ -127,7 +129,6 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
         initializeAdapter();
         chapterListView.setAdapter(adapter);
         chapterListView.setOnItemClickListener(adapter);
-        loadData(view);
         lastClickTime = 0;
 
         return view;
@@ -139,9 +140,8 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
         isActivityStarted = true;
         adapter.setStore(db, storage);
         handler.sendEmptyMessage(MSG_UPDATE_PROGRESS);
-        if (!adapter.isEmpty()) {
-            fetchLastAccessed(getView());
-        }
+
+        fetchLastAccessed(getView());
     }
 
     @Override
@@ -151,89 +151,89 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
         //We need to cancel the getLastAccessed task if the fragment is stopped
         if(getLastAccessedTask!=null){
             getLastAccessedTask.cancel(true);
+            isFetchingLastAccessed = false;
         }
     }
 
     private void initializeAdapter(){
-        adapter = new ChapterAdapter(getActivity(), courseId) {
+        if (adapter == null) {
+            // creating adapter just once
 
-            @Override
-            public void onItemClicked(final SectionEntry model) {
-                // handle click
-                try{
-                    if (AppConstants.offline_flag) {
-                        boolean isVideoDownloaded = db.isVideoDownloadedInChapter(courseId,
-                                model.chapter, null);
-                        if(isVideoDownloaded){
-                            Intent videoIntent = new Intent(getActivity(),
-                                    VideoListActivity.class);
-                            videoIntent.putExtra("enrollment", enrollment);
-                            videoIntent.putExtra("chapter", model.chapter);
-                            videoIntent.putExtra("FromMyVideos", false);
-                            startActivity(videoIntent);
+            adapter = new ChapterAdapter(getActivity(), courseId) {
+
+                @Override
+                public void onItemClicked(final SectionEntry model) {
+                    // handle click
+                    try {
+                        if (AppConstants.offline_flag) {
+                            boolean isVideoDownloaded = db.isVideoDownloadedInChapter(courseId,
+                                    model.chapter, null);
+                            if (isVideoDownloaded) {
+                                Intent videoIntent = new Intent(getActivity(),
+                                        VideoListActivity.class);
+                                videoIntent.putExtra(BaseFragmentActivity.EXTRA_ENROLLMENT, enrollment);
+                                videoIntent.putExtra("chapter", model.chapter);
+                                videoIntent.putExtra("FromMyVideos", false);
+                                startActivity(videoIntent);
+                            } else {
+                                UiUtil.showMessage(CourseChapterListFragment.this.getView(),
+                                        getString(R.string.section_offline_header));
+                            }
                         } else {
-                            UiUtil.showMessage(CourseChapterListFragment.this.getView(),
-                                    getString(R.string.section_offline_header));
+                            Intent lectureIntent = new Intent(getActivity(),
+                                    CourseLectureListActivity.class);
+                            lectureIntent.putExtra(BaseFragmentActivity.EXTRA_ENROLLMENT, enrollment);
+                            lectureIntent.putExtra("lecture", model);
+                            getActivity().startActivity(lectureIntent);
                         }
-                    } else {
-                        Intent lectureIntent = new Intent(getActivity(),
-                                CourseLectureListActivity.class);
-                        lectureIntent.putExtra("enrollment", enrollment);
-                        lectureIntent.putExtra("lecture", model);
-                        getActivity().startActivity(lectureIntent);
+                    } catch (Exception ex) {
+                        logger.error(ex);
                     }
-                }catch(Exception ex){
-                    logger.error(ex);
-                }
-            }
-
-            @Override
-            public void download(final SectionEntry model) {
-                try{
-                    IDialogCallback dialogCallback = new IDialogCallback() {
-                        @Override
-                        public void onPositiveClicked() {
-                            startChapterDownload(model);
-                        }
-
-                        @Override
-                        public void onNegativeClicked() {
-                            //
-                        }
-                    };
-                    MediaConsentUtils.consentToMediaDownload(getActivity(), dialogCallback);
-
-                } catch (Exception e) {
-                    logger.error(e);
                 }
 
-            }
-        };
+                @Override
+                public void download(final SectionEntry model) {
+                    try {
+                        IDialogCallback dialogCallback = new IDialogCallback() {
+                            @Override
+                            public void onPositiveClicked() {
+                                startChapterDownload(model);
+                            }
+
+                            @Override
+                            public void onNegativeClicked() {
+                                //
+                            }
+                        };
+                        MediaConsentUtils.consentToMediaDownload(getActivity(), dialogCallback);
+
+                    } catch (Exception e) {
+                        logger.error(e);
+                    }
+
+                }
+            };
+        }
 
         if (!(NetworkUtil.isConnected(getActivity()))) {
             AppConstants.offline_flag = true;
         } else {
             AppConstants.offline_flag = false;
         }
-
     }
 
     @Override
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        updateOpenInBrowserPanel();
 
-        refreshShowInWebPanel();
-
-        if (adapter.getCount() == 0) {
-
-            loadData(view);
-
+        if (adapter.isEmpty()) {
+            logger.debug("adapter is empty, loading data ...");
+            loadData(getView());
         }
-
     }
 
     private void startChapterDownload(SectionEntry model) {
-
         long downloadSize = 0;
         ArrayList<DownloadEntry> downloadList = new ArrayList<DownloadEntry>();
         int downloadCount = 0;
@@ -277,7 +277,12 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
 
     //Loading data to the Adapter
     private void loadData(final View view) {
+        if (isTaskRunning) {
+            return;
+        }
+
         GetCourseHierarchyTask task = new GetCourseHierarchyTask(getActivity()) {
+
             @Override
             public void onFinish(Map<String, SectionEntry> chapterMap) {
                 // display these chapters
@@ -297,13 +302,10 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
                         chapterListView.setEmptyView(view.findViewById(R.id.no_chapter_tv));
                     }
                     adapter.notifyDataSetChanged();
-                    refreshShowInWebPanel();
+                    updateOpenInBrowserPanel();
 
-                    if (AppConstants.offline_flag) {
-                        hideOpenInBrowserPanel();
-                    } else {
+                    if ( !AppConstants.offline_flag) {
                         fetchLastAccessed(getView());
-                        showOpenInBrowserPanel(openInBrowserUrl);
                     }
                 }
 
@@ -320,6 +322,7 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
                 }
 
                 logger.debug("Completed displaying data on UI "+ DateUtil.getCurrentTimeStamp());
+                isTaskRunning = false;
             }
 
             @Override
@@ -330,6 +333,8 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
                     view.findViewById(R.id.no_chapter_tv).setVisibility(View.VISIBLE);
                     chapterListView.setEmptyView(view.findViewById(R.id.no_chapter_tv));
                 }
+
+                isTaskRunning = false;
             }
         };
 
@@ -338,15 +343,14 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
         task.setProgressDialog(progressBar);
         //Initializing task call
         logger.debug("Initializing Chapter Task"+ DateUtil.getCurrentTimeStamp());
+        isTaskRunning = true;
         task.execute(courseId);
-
     }
 
-    private void refreshShowInWebPanel() {
-        if (AppConstants.offline_flag) {
+    private void updateOpenInBrowserPanel() {
+        if (AppConstants.offline_flag || adapter.isEmpty()) {
             hideOpenInBrowserPanel();
         } else {
-            fetchLastAccessed(getView());
             showOpenInBrowserPanel(openInBrowserUrl);
         }
     }
@@ -358,7 +362,7 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
         }
         hideLastAccessedView(getView());
         if (chapterListView != null) {
-            hideOpenInBrowserPanel();
+            updateOpenInBrowserPanel();
         }
     }
 
@@ -369,7 +373,7 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
         }
         if (chapterListView != null && openInBrowserUrl != null) {
             fetchLastAccessed(getView());
-            showOpenInBrowserPanel(openInBrowserUrl);
+            updateOpenInBrowserPanel();
         }
     }
 
@@ -455,15 +459,13 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
     @Override
     public void onHiddenChanged(boolean hidden) {
         super.onHiddenChanged(hidden);
-        if(!hidden){
+        if(!hidden) {
+            updateOpenInBrowserPanel();
+
             if(AppConstants.offline_flag){
                 hideLastAccessedView(getView());
-                hideOpenInBrowserPanel();
             }else{
                 fetchLastAccessed(getView());
-                if(chapterListView!=null && openInBrowserUrl!=null){
-                    showOpenInBrowserPanel(openInBrowserUrl);
-                }
             }
         }
     }
@@ -558,7 +560,7 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
                                         lastClickTime = currentTime;
                                         Bundle bundle = getArguments();
                                         EnrolledCoursesResponse enrollment = (EnrolledCoursesResponse) 
-                                                bundle.getSerializable("enrollment");
+                                                bundle.getSerializable(BaseFragmentActivity.EXTRA_ENROLLMENT);
                                         try {
                                             LectureModel lecture = api.getLecture(courseId,
                                                     videoModel.getChapterName(), 
@@ -569,7 +571,7 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
                                             Intent videoIntent = new Intent(
                                                     getActivity(),
                                                     VideoListActivity.class);
-                                            videoIntent.putExtra("enrollment", enrollment);
+                                            videoIntent.putExtra(BaseFragmentActivity.EXTRA_ENROLLMENT, enrollment);
                                             videoIntent.putExtra("lecture", lecture);
                                             videoIntent.putExtra("FromMyVideos", false);
                                             
@@ -606,12 +608,9 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
         }
     }
 
-
-
     private void fetchLastAccessed(final View view){
         try{
-            if(!isFetchingLastAccessed){
-                isFetchingLastAccessed = true;
+            if(!isFetchingLastAccessed) {
                 if(courseId!=null && getProfile()!=null && getProfile().username!=null){
                     String prefName = PrefManager.getPrefNameForLastAccessedBy(getProfile()
                             .username, courseId);
@@ -659,6 +658,8 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
                             logger.error(ex);
                         }
                     };
+
+                    isFetchingLastAccessed = true;
                     getLastAccessedTask.execute(courseId);
                 }   
             }
@@ -681,12 +682,11 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
                         lastAccessed_subSectionId = result.getLastVisitedModuleId();
                         showLastAccessedView(view);
                     }
-                    isFetchingLastAccessed = false;
                 }
+
                 @Override
                 public void onException(Exception ex) {
                     logger.error(ex);
-                    isFetchingLastAccessed = false;
                 }
             };
             syncLastAccessTask.execute(courseId, prefModuleId);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseCombinedInfoFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseCombinedInfoFragment.java
@@ -21,6 +21,7 @@ import com.facebook.widget.FacebookDialog;
 import com.facebook.widget.LikeView;
 
 import org.edx.mobile.R;
+import org.edx.mobile.base.BaseFragmentActivity;
 import org.edx.mobile.base.CourseDetailBaseFragment;
 import org.edx.mobile.http.OutboundUrlSpan;
 import org.edx.mobile.loader.AsyncTaskResult;
@@ -28,13 +29,13 @@ import org.edx.mobile.loader.FriendsInCourseLoader;
 import org.edx.mobile.model.api.AnnouncementsModel;
 import org.edx.mobile.model.api.CourseEntry;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
+import org.edx.mobile.module.facebook.FacebookSessionUtil;
 import org.edx.mobile.module.facebook.IUiLifecycleHelper;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.social.SocialMember;
 import org.edx.mobile.social.facebook.FacebookProvider;
 import org.edx.mobile.task.GetAnnouncementTask;
 import org.edx.mobile.util.DateUtil;
-import org.edx.mobile.module.facebook.FacebookSessionUtil;
 import org.edx.mobile.util.SocialUtils;
 import org.edx.mobile.util.images.ImageCacheManager;
 import org.edx.mobile.view.custom.CourseImageHeader;
@@ -78,13 +79,14 @@ public class CourseCombinedInfoFragment extends CourseDetailBaseFragment impleme
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        logger.debug("created: " + getClass().getName());
+
         featuresPref = new PrefManager(getActivity(), PrefManager.Pref.FEATURES);
 
         Settings.sdkInitialize(getActivity());
 
         uiHelper = IUiLifecycleHelper.Factory.getInstance(getActivity(), null);
         uiHelper.onCreate(savedInstanceState);
-
     }
 
     @Override
@@ -139,7 +141,7 @@ public class CourseCombinedInfoFragment extends CourseDetailBaseFragment impleme
 
         try {
             final Bundle bundle = getArguments();
-            courseData = (EnrolledCoursesResponse) bundle.getSerializable("enrollment");
+            courseData = (EnrolledCoursesResponse) bundle.getSerializable(BaseFragmentActivity.EXTRA_ENROLLMENT);
             FacebookProvider fbProvider = new FacebookProvider();
 
             if(courseData != null) {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDetailTabActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDetailTabActivity.java
@@ -6,6 +6,7 @@ import android.view.Menu;
 import android.view.View;
 
 import org.edx.mobile.R;
+import org.edx.mobile.base.BaseFragmentActivity;
 import org.edx.mobile.interfaces.NetworkObserver;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.util.AppConstants;
@@ -16,6 +17,8 @@ import java.util.List;
 
 public class CourseDetailTabActivity extends BaseTabActivity {
 
+    public static final String EXTRA_ANNOUNCEMENTS = "announcemnts";
+    public static final String EXTRA_BUNDLE = "bundle";
     public static String TAG = CourseDetailTabActivity.class.getCanonicalName();
     static final String TAB_ID = TAG + ".tabID";
 
@@ -36,7 +39,7 @@ public class CourseDetailTabActivity extends BaseTabActivity {
 
         setApplyPrevTransitionOnRestart(true);
         
-        bundle = getIntent().getBundleExtra("bundle");
+        bundle = getIntent().getBundleExtra(EXTRA_BUNDLE);
         offlineBar = findViewById(R.id.offline_bar);
         if (!(NetworkUtil.isConnected(this))) {
             AppConstants.offline_flag = true;
@@ -48,7 +51,7 @@ public class CourseDetailTabActivity extends BaseTabActivity {
 
         try{
             EnrolledCoursesResponse courseData = (EnrolledCoursesResponse) bundle
-                    .getSerializable("enrollment");
+                    .getSerializable(BaseFragmentActivity.EXTRA_ENROLLMENT);
             activityTitle = courseData.getCourse().getName();
             try{
                 segIO.screenViewsTracking(courseData.getCourse().getName());

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseInfoFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseInfoFragment.java
@@ -12,6 +12,7 @@ import android.webkit.WebViewClient;
 import android.widget.ProgressBar;
 
 import org.edx.mobile.R;
+import org.edx.mobile.base.BaseFragmentActivity;
 import org.edx.mobile.base.CourseDetailBaseFragment;
 import org.edx.mobile.http.Api;
 import org.edx.mobile.model.api.CourseInfoModel;
@@ -71,7 +72,7 @@ public class CourseInfoFragment extends CourseDetailBaseFragment {
         try {
             final Bundle bundle = getArguments();
             EnrolledCoursesResponse courseData = (EnrolledCoursesResponse) bundle
-                    .getSerializable("enrollment");
+                    .getSerializable(BaseFragmentActivity.EXTRA_ENROLLMENT);
             if(courseData!=null){
                 loadData(courseData);
             }else{

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseLectureListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseLectureListActivity.java
@@ -9,8 +9,6 @@ import android.os.Handler;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
-import android.view.Menu;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.ListView;
@@ -18,8 +16,7 @@ import android.widget.TextView;
 
 import org.edx.mobile.R;
 import org.edx.mobile.base.BaseFragmentActivity;
-
-import org.edx.mobile.model.IVideoModel;
+import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.model.api.LectureModel;
 import org.edx.mobile.model.api.SectionEntry;
 import org.edx.mobile.model.api.VideoResponseModel;
@@ -29,13 +26,12 @@ import org.edx.mobile.task.EnqueueDownloadTask;
 import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.BrowserUtil;
 import org.edx.mobile.util.MediaConsentUtils;
+import org.edx.mobile.util.MemoryUtil;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.view.adapters.LectureAdapter;
 import org.edx.mobile.view.dialog.DownloadSizeExceedDialog;
-import org.edx.mobile.view.dialog.ProgressDialogFragment;
-import org.edx.mobile.model.api.EnrolledCoursesResponse;
-import org.edx.mobile.util.MemoryUtil;
 import org.edx.mobile.view.dialog.IDialogCallback;
+import org.edx.mobile.view.dialog.ProgressDialogFragment;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -67,7 +63,7 @@ public class CourseLectureListActivity extends BaseFragmentActivity {
         }
 
 
-        enrollment = (EnrolledCoursesResponse) getIntent().getSerializableExtra("enrollment");
+        enrollment = (EnrolledCoursesResponse) getIntent().getSerializableExtra(BaseFragmentActivity.EXTRA_ENROLLMENT);
 
         ArrayList<LectureModel> lectureList = new ArrayList<LectureModel>();
 
@@ -102,7 +98,7 @@ public class CourseLectureListActivity extends BaseFragmentActivity {
 
                     Intent videoIntent = new Intent(CourseLectureListActivity.this,
                             VideoListActivity.class);
-                    videoIntent.putExtra("enrollment", enrollment);
+                    videoIntent.putExtra(BaseFragmentActivity.EXTRA_ENROLLMENT, enrollment);
                     videoIntent.putExtra("lecture", model);
                     videoIntent.putExtra("FromMyVideos", false);
                     startActivity(videoIntent);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseListTabFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseListTabFragment.java
@@ -110,13 +110,7 @@ public abstract class CourseListTabFragment extends Fragment implements NetworkO
 
             @Override
             public void onAnnouncementClicked(EnrolledCoursesResponse model) {
-                Bundle courseBundle = new Bundle();
-                courseBundle.putBoolean("announcemnts", true);
-                courseBundle.putSerializable("CourseDetail", model);
-
-                Intent courseDetail = new Intent(getContext(), CourseDetailTabActivity.class);
-                courseDetail.putExtra("CourseDetail", courseBundle);
-                getContext().startActivity(courseDetail);
+                Router.getInstance().showCourseDetailTabs(getActivity(), model, true);
             }
         };
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyAllVideosFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyAllVideosFragment.java
@@ -8,6 +8,7 @@ import android.view.ViewGroup;
 import android.widget.ListView;
 
 import org.edx.mobile.R;
+import org.edx.mobile.base.BaseFragmentActivity;
 import org.edx.mobile.base.MyVideosBaseFragment;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.util.AppConstants;
@@ -42,7 +43,7 @@ public class MyAllVideosFragment extends MyVideosBaseFragment {
                 AppConstants.myVideosDeleteMode = false;
                 
                 Intent videoIntent = new Intent(getActivity(), VideoListActivity.class);
-                videoIntent.putExtra("enrollment", model);
+                videoIntent.putExtra(BaseFragmentActivity.EXTRA_ENROLLMENT, model);
                 videoIntent.putExtra("FromMyVideos", true);
                 //videoIntent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
                 startActivity(videoIntent);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyCourseListTabFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyCourseListTabFragment.java
@@ -40,31 +40,15 @@ public class MyCourseListTabFragment extends CourseListTabFragment {
 
     @Override
     public void handleCourseClick(EnrolledCoursesResponse model) {
-        try {
-            Bundle courseBundle = new Bundle();
-            courseBundle.putSerializable("enrollment", model);
-            courseBundle.putBoolean("announcemnts", false);
-
-            Intent courseDetail = new Intent(getActivity(),
-                    CourseDetailTabActivity.class);
-            courseDetail.putExtra("bundle", courseBundle);
-            startActivity(courseDetail);
-
-        } catch(Exception ex) {
-            logger.error(ex);
-        }
+        Router.getInstance().showCourseDetailTabs(getActivity(), model, false);
     }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-
         View view = super.onCreateView(inflater, container, savedInstanceState);
         noCourseText = (TextView) view.findViewById(R.id.no_course_tv);
-
         return view;
-
     }
-
 
     protected void loadData(boolean forceRefresh) {
         if(forceRefresh){

--- a/VideoLocker/src/main/java/org/edx/mobile/view/Router.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/Router.java
@@ -2,7 +2,9 @@ package org.edx.mobile.view;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Bundle;
 
+import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.util.AppConstants;
 
 /**
@@ -88,5 +90,17 @@ public class Router {
         Intent loginIntent = new Intent();
         loginIntent.setAction(AppConstants.USER_LOG_IN);
         sourceActivity.sendBroadcast(loginIntent);
+    }
+
+    public void showCourseDetailTabs(Activity activity, EnrolledCoursesResponse model,
+                                     boolean announcements) {
+        Bundle courseBundle = new Bundle();
+        courseBundle.putSerializable(CourseDetailTabActivity.EXTRA_ENROLLMENT, model);
+        courseBundle.putBoolean(CourseDetailTabActivity.EXTRA_ANNOUNCEMENTS, announcements);
+
+        Intent courseDetail = new Intent(activity, CourseDetailTabActivity.class);
+        courseDetail.putExtra(CourseDetailTabActivity.EXTRA_BUNDLE, courseBundle);
+        courseDetail.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+        activity.startActivity(courseDetail);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/ChapterAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/ChapterAdapter.java
@@ -45,9 +45,7 @@ public abstract class ChapterAdapter extends BaseListAdapter<SectionEntry> {
         holder.no_of_videos.setVisibility(View.VISIBLE);
         holder.no_of_videos.setText("" + totalCount);
         int inProcessCount = dbStore.getVideosCountByChapter(courseId, model.chapter, null);
-        logger.debug("In Process Count" + inProcessCount);
         int videoCount = totalCount - inProcessCount;
-        logger.debug("Video Count"+videoCount);
         if (videoCount > 0) {
             holder.progresslayout.setVisibility(View.GONE);
             holder.bulk_download_videos.setVisibility(View.VISIBLE);


### PR DESCRIPTION
This prevents reloading the tabs. Tabs were reloading on every switch.
With these changes, only last accessed information refreshes and not the entire fragment.

cc @aleffert @shahidtamboli 