### PR TITLE
Do not define properties in AndroidManifest.xml if already defined in gradle

### DIFF
--- a/VideoLocker/AndroidManifest.xml
+++ b/VideoLocker/AndroidManifest.xml
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.edx.mobile"
-    android:versionCode="44"
-    android:versionName="1.0.04"
     android:installLocation="auto" >
-
-    <uses-sdk
-        android:minSdkVersion="14"
-        android:targetSdkVersion="21" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/VideoLocker/build.gradle
+++ b/VideoLocker/build.gradle
@@ -172,7 +172,7 @@ android {
         // minimum version is Android 4.0
         minSdkVersion 14
         targetSdkVersion 21
-        versionCode 44
+        versionCode 46
         versionName "1.0.04"
 
         renderscriptTargetApi 18


### PR DESCRIPTION
There are a few properties which gradle takes care of and AndroidManifest doesn't need to handle those anymore. I removed those properties from AndroidManifest as we have defined them in gradle build script.

cc @aleffert @shahidtamboli @nasthagiri 