### PR TITLE
Add offline panel in Chapter List and Video List

### DIFF
--- a/VideoLocker/res/layout/fragment_chapter_list.xml
+++ b/VideoLocker/res/layout/fragment_chapter_list.xml
@@ -85,6 +85,14 @@
         android:text="@string/started_downloading"
         android:visibility="gone" />
 
+    <LinearLayout
+        android:id="@+id/offline_access_panel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone" >
+        <include layout="@layout/panel_offline_access" />
+    </LinearLayout>
+
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/no_chapter_tv"
         style="@style/bold_text"

--- a/VideoLocker/res/layout/fragment_video_list.xml
+++ b/VideoLocker/res/layout/fragment_video_list.xml
@@ -50,7 +50,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_above="@id/bottom_panel"
-        android:layout_alignParentTop="true"
-/>
+        android:layout_alignParentTop="true"/>
+
+    <include
+        android:id="@+id/offline_access_panel"
+        layout="@layout/panel_video_not_available_offline"
+        android:visibility="gone"/>
 
 </RelativeLayout>

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseChapterListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseChapterListFragment.java
@@ -172,8 +172,7 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
                             videoIntent.putExtra("FromMyVideos", false);
                             startActivity(videoIntent);
                         } else {
-                            UiUtil.showMessage(CourseChapterListFragment.this.getView(),
-                                    getString(R.string.section_offline_header));
+                            UiUtil.showOfflineAccessMessage(CourseChapterListFragment.this.getView());
                         }
                     } else {
                         Intent lectureIntent = new Intent(getActivity(),


### PR DESCRIPTION
The offline access panel was missing in Video List Fragment. Hence the offline access message was not displaying. This has been fixed.

@rohan-dhamal-clarice @aleffert - Please review

JIRA: https://openedx.atlassian.net/browse/MOB-408