### PR TITLE
Login screen placeholder text color changed

### DIFF
--- a/VideoLocker/res/values/text_styles.xml
+++ b/VideoLocker/res/values/text_styles.xml
@@ -58,6 +58,7 @@
         <item name="android:paddingLeft">10dp</item>
         <item name="android:paddingRight">10dp</item>
         <item name="font">OpenSans-Regular.ttf</item>
+        <item name="android:textColorHint">@color/hint_grey_text</item>
     </style>
 
     <style name="downloading_message">


### PR DESCRIPTION
Galaxy S4 issue for placeholder text color is fixed.

JIRA: https://openedx.atlassian.net/browse/MOB-1515

cc @rohan-dhamal-clarice  @shahidtamboli 