### PR TITLE
Increased tap area of Close button on Sign in and Sing up

### DIFF
--- a/VideoLocker/res/layout/panel_custom_action_bar.xml
+++ b/VideoLocker/res/layout/panel_custom_action_bar.xml
@@ -9,16 +9,16 @@
         style="@style/custom_activity_title"/>
 
     <RelativeLayout android:id="@+id/actionbar_close_btn_layout"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
         android:layout_alignParentLeft="true"
         android:layout_centerVertical="true"
         android:layout_marginLeft="11dp"
         android:orientation="vertical">
         <ImageView
             android:id="@+id/actionbar_close_btn"
-            android:layout_width="21dp"
-            android:layout_height="21dp"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
             android:src="@drawable/ic_close"
             android:contentDescription="@string/app_name"
             android:layout_centerInParent="true"/>


### PR DESCRIPTION
The Close button was not clickable on Sign-in and Sign up screen.
This has been fixed. 

@rohan-dhamal-clarice @aleffert - Please review