### PR TITLE
Override Animation is set for Activity if called from Sign in screen

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/LaunchActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/LaunchActivity.java
@@ -20,12 +20,18 @@ import org.edx.mobile.view.custom.ETextView;
 
 public class LaunchActivity extends BaseFragmentActivity {
 
+    public static final String OVERRIDE_ANIMATION_FLAG = "override_animation_flag";
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_launch);
-        overridePendingTransition(R.anim.slide_in_from_right,
-                R.anim.slide_out_to_left);
+
+        //Activity override animation has to be handled if the Launch Activity
+        //is called after user logs out and closes the Sign-in screen.
+        if(getIntent().getBooleanExtra(OVERRIDE_ANIMATION_FLAG,false)){
+            overridePendingTransition(R.anim.no_transition,R.anim.slide_out_to_bottom);
+        }
 
         //The onTick method need not be run in the LaunchActivity
         runOnTick = false;

--- a/VideoLocker/src/main/java/org/edx/mobile/view/NavigationFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/NavigationFragment.java
@@ -17,7 +17,6 @@ import android.widget.TextView;
 
 import com.facebook.Session;
 import com.facebook.SessionState;
-import com.facebook.UiLifecycleHelper;
 
 import org.edx.mobile.R;
 import org.edx.mobile.base.BaseFragmentActivity;
@@ -214,7 +213,7 @@ public class NavigationFragment extends Fragment {
                 segIO.trackUserLogout();
                 segIO.resetIdentifyUser();
 
-                Router.getInstance().showLaunchScreen(getActivity());
+                Router.getInstance().showLaunchScreen(getActivity(),true);
                 Router.getInstance().showLogin(getActivity());
 
             }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/Router.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/Router.java
@@ -60,8 +60,9 @@ public class Router {
         sourceActivity.startActivity(settingsIntent);
     }
 
-    public void showLaunchScreen(Activity sourceActivity) {
+    public void showLaunchScreen(Activity sourceActivity, boolean overrideAnimation) {
         Intent launchIntent = new Intent(sourceActivity, LaunchActivity.class);
+        launchIntent.putExtra(LaunchActivity.OVERRIDE_ANIMATION_FLAG,overrideAnimation);
         launchIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         sourceActivity.startActivity(launchIntent);
     }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/SplashActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/SplashActivity.java
@@ -39,12 +39,11 @@ public class SplashActivity extends BaseFragmentActivity {
                         intent = new Intent(SplashActivity.this, MyCoursesListActivity.class);
                         startActivity(intent);
                     } else {
-                        Router.getInstance().showLaunchScreen(SplashActivity.this);
+                        Router.getInstance().showLaunchScreen(SplashActivity.this, false);
                     }
                     finish();
                 }
             }
         }, SPLASH_TIME_OUT);
     }
-    
 }


### PR DESCRIPTION
The Activity was animating from Left to Right if the Sign in screen was closed after logging out. The correct animation should be that the Sign-in screen animates to the bottom of the screen. This has been fixed.

Please review - @rohan-dhamal-clarice @aleffert 

JIRA: https://openedx.atlassian.net/browse/MOB-1552
