### PR TITLE
Stop webview reloading in Find Courses

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/FindCoursesActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/FindCoursesActivity.java
@@ -23,14 +23,9 @@ public class FindCoursesActivity extends FindCoursesBaseActivity {
         }catch(Exception e){
             logger.error(e);
         }
-    }
-
-    @Override
-    protected void onStart() {
-        super.onStart();
-
         String url = Config.getInstance().getEnrollmentConfig().getCourseSearchUrl();
         WebView webview = (WebView) findViewById(R.id.webview);
         webview.loadUrl(url);
     }
+
 }


### PR DESCRIPTION
The WebView was reloading and scrolling to top if a user would select a Course from Find Courses and then go back from Course Info. This has been handled by loading the url in <code>onCreate()</code> instead of <code>onStart()</code>.

Please review - @rohan-dhamal-clarice @aleffert 

JIRA: https://openedx.atlassian.net/browse/MOB-1509