### PR TITLE
Hide Confirm Delete Dialog when Device screen locked

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
@@ -63,7 +63,7 @@ public class VideoListFragment extends Fragment {
     protected IDatabase db;
     protected IStorage storage;
     private static final int MSG_UPDATE_PROGRESS = 1022;
-    private DeleteVideoDialogFragment newFragment;
+    private DeleteVideoDialogFragment confirmDeleteFragment, downloadSizeExceedDialog;
     private String openInBrowserUrl;
     private String chapterName;
     private LectureModel lecture;
@@ -605,17 +605,12 @@ public class VideoListFragment extends Fragment {
             if (offlineBar != null) {
                 offlineBar.setVisibility(View.GONE);
             }
-            if (myVideosFlag) {
-                //addDataToMyVideoAdapter();
-                // hideOpenInBrowserPanel();
-            } else {
+            if (!myVideosFlag) {
                 AppConstants.videoListDeleteMode = false;
                 addDataToOnlineAdapter();
                 showOpenInBrowserPanel();
                 hideDeletePanel(getView());
-                if(newFragment!=null){
-                    newFragment.dismiss();
-                }
+                hideConfirmDeleteDialog();
             }
 
         }
@@ -764,6 +759,7 @@ public class VideoListFragment extends Fragment {
         super.onStop();
         isActivityStarted = false;
         AppConstants.videoListDeleteMode = false;
+        hideConfirmDeleteDialog();
         if(myVideosFlag){
             adapter.unselectAll();
         }
@@ -1005,7 +1001,7 @@ public class VideoListFragment extends Fragment {
         dialogMap.put("message_1", getString(R.string.download_exceed_message));
         dialogMap.put("yes_button", getString(R.string.label_yes));
         dialogMap.put("no_button",  getString(R.string.label_no));
-        newFragment = DeleteVideoDialogFragment.newInstance(dialogMap,
+        downloadSizeExceedDialog = DeleteVideoDialogFragment.newInstance(dialogMap,
                 new IDialogCallback() {
             @Override
             public void onPositiveClicked() {
@@ -1015,12 +1011,12 @@ public class VideoListFragment extends Fragment {
             @Override
             public void onNegativeClicked() {
                 notifyAdapter();
-                newFragment.dismiss();
+                downloadSizeExceedDialog.dismiss();
             }
         });
-        newFragment.setStyle(DialogFragment.STYLE_NO_TITLE, 0);
-        newFragment.show(getFragmentManager(), "dialog");
-        newFragment.setCancelable(false);
+        downloadSizeExceedDialog.setStyle(DialogFragment.STYLE_NO_TITLE, 0);
+        downloadSizeExceedDialog.show(getFragmentManager(), "dialog");
+        downloadSizeExceedDialog.setCancelable(false);
     }
 
     protected void showConfirmDeleteDialog(int itemCount) {
@@ -1035,7 +1031,7 @@ public class VideoListFragment extends Fragment {
             dialogMap.put("message_1",
                     getString(R.string.delete_multiple_video_dialog));
         }
-        newFragment = DeleteVideoDialogFragment.newInstance(dialogMap,
+        confirmDeleteFragment = DeleteVideoDialogFragment.newInstance(dialogMap,
                 new IDialogCallback() {
 
             @Override
@@ -1045,12 +1041,22 @@ public class VideoListFragment extends Fragment {
 
             @Override
             public void onNegativeClicked() {
-                newFragment.dismiss();
+                confirmDeleteFragment.dismiss();
             }
         });
-        newFragment.setStyle(DialogFragment.STYLE_NO_TITLE, 0);
-        newFragment.show(getFragmentManager(), "dialog");
-        newFragment.setCancelable(false);
+        confirmDeleteFragment.setStyle(DialogFragment.STYLE_NO_TITLE, 0);
+        confirmDeleteFragment.show(getFragmentManager(), "dialog");
+        confirmDeleteFragment.setCancelable(false);
+    }
+
+    protected void hideConfirmDeleteDialog() {
+        try{
+            if(confirmDeleteFragment!=null){
+                confirmDeleteFragment.dismiss();
+            }
+        }catch(Exception e){
+            logger.error(e);
+        }
     }
 
 


### PR DESCRIPTION
The confirm Delete popup was remaining open when the device is locked.
This has been resolved.

Please review - @aleffert @rohan-dhamal-clarice 

JIRA: https://openedx.atlassian.net/browse/MOB-1444