### PR TITLE
Use custom preview screen to avoid showing black screen

### DIFF
--- a/VideoLocker/AndroidManifest.xml
+++ b/VideoLocker/AndroidManifest.xml
@@ -67,7 +67,7 @@
             android:name="org.edx.mobile.view.SplashActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
-            android:theme="@android:style/Theme.NoTitleBar" >
+            android:theme="@style/Theme.CustomPreview">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/VideoLocker/res/values/styles.xml
+++ b/VideoLocker/res/values/styles.xml
@@ -27,6 +27,14 @@
     <!-- the theme applied to the application or activity -->
     <style name="CustomActionBarTheme" parent="@android:style/Theme.Holo.Light">
         <item name="android:actionBarStyle">@style/MyActionBar</item>
+        <!-- use window background for preview to avoid showing black screen -->
+        <item name="android:windowBackground">@android:color/white</item>
+    </style>
+
+    <!-- Custom Preview Screen Theme -->
+    <style name="Theme.CustomPreview" parent="@android:style/Theme.NoTitleBar">
+        <!-- use window background for preview to avoid showing black screen -->
+        <item name="android:windowBackground">@android:color/white</item>
     </style>
 
     <!-- <item name="android:homeAsUpIndicator">@drawable/ic_back</item> -->


### PR DESCRIPTION
JIRA:  https://openedx.atlassian.net/browse/MOB-1391

This prevents showing of black screen by showing white background which matches with the background of splash screen. This is a standard way of having custom preview screen where preview screen is supposed to match the theme of the splash screen so that user doesn't feel a disconnect between preview and splash.

cc @nasthagiri @aleffert @shahidtamboli 