### PR TITLE
Changes EULA dialog header in Registration screen

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -119,7 +119,7 @@ public class RegisterActivity extends BaseFragmentActivity {
             // show EULA license that is shipped with app
             showWebDialog(getString(R.string.eula_file_link),
                     true,
-                    agreement.getText());
+                    getString(R.string.end_user_title));
         }
         else {
             // for any other link, open agreement link in a webview container


### PR DESCRIPTION
The EULA dialog header was wrong when opened from Registration screen. This has been fixed.

Please review - @rohan-dhamal-clarice @aleffert 

JIRA: https://openedx.atlassian.net/browse/MOB-1560