### PR TITLE
Restart Video List Update when switched back to online

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
@@ -580,9 +580,7 @@ public class VideoListFragment extends Fragment {
             }
 
             hideOpenInBrowserPanel();
-            if (myVideosFlag) {
-                //addDataToMyVideoAdapter();
-            } else {
+            if (!myVideosFlag) {
                 handleDeleteView();
                 addDataToOfflineAdapter();
             }
@@ -600,8 +598,8 @@ public class VideoListFragment extends Fragment {
     }
 
     public void onOnline() {
+        AppConstants.offline_flag = false;
         if (!isLandscape) {
-            AppConstants.offline_flag = false;
             if (offlineBar != null) {
                 offlineBar.setVisibility(View.GONE);
             }
@@ -611,6 +609,7 @@ public class VideoListFragment extends Fragment {
                 showOpenInBrowserPanel();
                 hideDeletePanel(getView());
                 hideConfirmDeleteDialog();
+                handler.sendEmptyMessage(MSG_UPDATE_PROGRESS);
             }
 
         }


### PR DESCRIPTION
The Video download progress of a downloading video was not getting displayed when user switched from Online -> Offline -> Online mode on Video Listing. This has been fixed.

Please review - @aleffert @rohan-dhamal-clarice 

JIRA: https://openedx.atlassian.net/browse/MOB-1564