### PR TITLE
Update script to fix travis build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,7 @@ before_script:
   - adb wait-for-device
   - adb shell input keyevent 82 &
   - chmod +x gradlew
-  - chmod +x travis-build.sh
-  - chmod +x travis-acceptance-tests.sh
+#  - chmod +x travis-acceptance-tests.sh
 
 script: 
   - ./gradlew uninstallAll createProdDebugCoverageReport copyUnitTestBuildArtifacts


### PR DESCRIPTION
<code>travis-build.sh</code> is already removed. So, the <code>chmod</code> command was causing problem. Removed that command from script.

cc @aleffert @shahidtamboli 