### PR TITLE
Support transifex

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,23 @@
+[main]
+type = ANDROID
+host = https://www.transifex.com
+
+[edx-mobile-apps.android-app-strings]
+file_filter = VideoLocker/res/values-<lang>/strings.xml
+source_file = VideoLocker/res/values/strings.xml
+source_lang = en
+
+[edx-mobile-apps.android-app-email]
+file_filter = VideoLocker/res/values-<lang>/email.xml
+source_file = VideoLocker/res/values/email.xml
+source_lang = en
+
+[edx-mobile-apps.android-app-errors]
+file_filter = VideoLocker/res/values-<lang>/errors.xml
+source_file = VideoLocker/res/values/errors.xml
+source_lang = en
+
+[edx-mobile-apps.android-app-labels]
+file_filter = VideoLocker/res/values-<lang>/labels.xml
+source_file = VideoLocker/res/values/labels.xml
+source_lang = en

--- a/.tx/config
+++ b/.tx/config
@@ -7,11 +7,6 @@ file_filter = VideoLocker/res/values-<lang>/strings.xml
 source_file = VideoLocker/res/values/strings.xml
 source_lang = en
 
-[edx-mobile-apps.android-app-email]
-file_filter = VideoLocker/res/values-<lang>/email.xml
-source_file = VideoLocker/res/values/email.xml
-source_lang = en
-
 [edx-mobile-apps.android-app-errors]
 file_filter = VideoLocker/res/values-<lang>/errors.xml
 source_file = VideoLocker/res/values/errors.xml

--- a/VideoLocker/res/layout/delete_video_dialog.xml
+++ b/VideoLocker/res/layout/delete_video_dialog.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/dialog_layout"
     android:layout_width="250dp"
     android:layout_height="wrap_content"
     android:background="@android:color/white"
     android:minWidth="250dp"
     android:orientation="vertical"
-    android:splitMotionEvents="false" >
+    android:splitMotionEvents="false">
 
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/tv_dialog_title"
@@ -18,6 +19,7 @@
         android:layout_marginRight="10dp"
         android:layout_marginTop="20dp"
         android:gravity="center"
+        tools:text="@string/delete_single_video_dialog"
         android:textAllCaps="true"
         android:textSize="17sp" />
 

--- a/VideoLocker/res/layout/drawer_navigation.xml
+++ b/VideoLocker/res/layout/drawer_navigation.xml
@@ -24,7 +24,7 @@
             android:maxWidth="200dp"
             android:paddingTop="10dp"
             android:textSize="20sp"
-            tools:text="@string/name_default" />
+            tools:text="Username" />
 
         <org.edx.mobile.view.custom.ETextView
             android:id="@+id/email_tv"
@@ -36,7 +36,7 @@
             android:paddingBottom="5dp"
             android:paddingTop="5dp"
             android:textSize="13sp"
-            tools:text="@string/email_default" />
+            tools:text="user@domain.com" />
     </LinearLayout>
 
     <LinearLayout

--- a/VideoLocker/res/layout/fragment_course_combined_info.xml
+++ b/VideoLocker/res/layout/fragment_course_combined_info.xml
@@ -52,7 +52,8 @@
                     style="@style/regular_text"
                     android:textColor="@color/white"
                     android:textSize="13sp"
-                    tools:text="XX | XX | XXXXXX" />
+                    android:textAllCaps="true"
+                    tools:text="XX | xx | xxxxx" />
 
             </LinearLayout>
 
@@ -126,6 +127,7 @@
                         android:textColor="@color/white"
                         android:textSize="16sp"
                         android:padding="10dp"
+                        android:textAllCaps="true"
                         android:text="@string/view_button_text" />
 
                 </LinearLayout>

--- a/VideoLocker/res/layout/fragment_find_courses_dialog.xml
+++ b/VideoLocker/res/layout/fragment_find_courses_dialog.xml
@@ -39,6 +39,7 @@
         android:layout_margin="25dp"
         android:background="@drawable/bt_blue"
         android:text="@string/open_edx_btn_text"
+        android:textAllCaps="true"
         android:textSize="16sp"
         android:gravity="center_vertical|center_horizontal"
         android:padding="10dp"/>

--- a/VideoLocker/res/layout/fragment_settings.xml
+++ b/VideoLocker/res/layout/fragment_settings.xml
@@ -50,6 +50,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:checked="true"
+                android:textAllCaps="true"
                 android:switchMinWidth="80dp"
                 android:switchTextAppearance="@style/default_switch"
                 android:textOff="@string/toggle_turn_off"

--- a/VideoLocker/res/layout/panel_download_msg.xml
+++ b/VideoLocker/res/layout/panel_download_msg.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/include_layout"
     android:layout_width="match_parent"
     android:layout_height="70dp"
-    android:background="@color/include_msg_color" >
+    android:background="@color/include_msg_color">
 
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/text_download_msg_cnt"
@@ -13,7 +14,7 @@
         android:layout_centerVertical="true"
         android:layout_marginLeft="14dp"
         android:layout_marginRight="5dp"
-        android:text="@string/text_download_msg_cnt"
+        tools:text="20"
         android:textSize="18sp" />
 
     <org.edx.mobile.view.custom.ETextView
@@ -23,7 +24,7 @@
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
         android:layout_toRightOf="@+id/text_download_msg_cnt"
-        android:text="@string/text_download_msg_plural"
+        tools:text="Video Downloaded"
         android:textSize="16sp" />
 
     <org.edx.mobile.view.custom.EButton

--- a/VideoLocker/res/layout/panel_download_msg.xml
+++ b/VideoLocker/res/layout/panel_download_msg.xml
@@ -37,6 +37,7 @@
         android:layout_marginRight="15dp"
         android:background="@drawable/logout_bg_selector"
         android:padding="5dp"
+        android:textAllCaps="true"
         android:text="@string/view_button_text"
         android:textSize="15sp" />
 

--- a/VideoLocker/res/layout/panel_find_course.xml
+++ b/VideoLocker/res/layout/panel_find_course.xml
@@ -35,6 +35,7 @@
 			android:padding="10dp"
             android:background="@drawable/bt_blue"
             android:text="@string/find_course_btn_text"
+            android:textAllCaps="true"
             android:textColor="@color/white"
             android:textSize="15sp" />
         

--- a/VideoLocker/res/layout/row_chapter_list.xml
+++ b/VideoLocker/res/layout/row_chapter_list.xml
@@ -62,7 +62,7 @@
         android:layout_marginLeft="10dp"
         android:layout_marginRight="0dp"
         android:layout_toLeftOf="@id/bulk_download_layout"
-        tools:text="@string/no_of_videos"
+        tools:text="0"
         android:textColor="@color/grey_text_mycourse"
         android:textSize="15sp" />
 

--- a/VideoLocker/res/layout/row_download_list.xml
+++ b/VideoLocker/res/layout/row_download_list.xml
@@ -1,9 +1,10 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/downloads_row_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@android:color/white"
-    android:padding="10dp" >
+    android:padding="10dp">
 
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/downloads_name"
@@ -50,7 +51,7 @@
         android:layout_marginLeft="18dp"
         android:lines="1"
         android:singleLine="true"
-        android:text="@string/download_time"
+        tools:text="53:59:21"
         android:textColor="@color/grey_video_size_text"
         android:textSize="12sp" />
 
@@ -64,7 +65,7 @@
         android:layout_toRightOf="@+id/download_time"
         android:lines="1"
         android:singleLine="true"
-        android:text="@string/download_percentage"
+        tools:text="45.20/200MB"
         android:textColor="@color/grey_video_size_text"
         android:textSize="12sp" />
 

--- a/VideoLocker/res/layout/row_myvideo_course_list.xml
+++ b/VideoLocker/res/layout/row_myvideo_course_list.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content" >
+    android:layout_height="wrap_content">
 
     <LinearLayout
         android:id="@+id/course_row_layout"
@@ -71,7 +72,7 @@
                     android:ellipsize="end"
                     android:maxWidth="150dp"
                     android:singleLine="true"
-                    android:text="@string/videos_no"
+                    tools:text="@string/videos_no"
                     android:textColor="@color/org_code_txt"
                     android:textSize="12sp" />
 
@@ -84,7 +85,7 @@
                     android:maxWidth="150dp"
                     android:paddingLeft="7dp"
                     android:singleLine="true"
-                    android:text="@string/size_of_videos"
+                    tools:text="890 MB"
                     android:textColor="@color/org_code_txt"
                     android:textSize="12sp" />
             </LinearLayout>

--- a/VideoLocker/res/layout/row_video_list.xml
+++ b/VideoLocker/res/layout/row_video_list.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@drawable/list_selector"
-    android:orientation="vertical" >
+    android:orientation="vertical">
 
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/txt_course_title"
@@ -45,7 +46,6 @@
             android:layout_centerVertical="true"
             android:layout_marginLeft="10dp"
             android:layout_marginRight="20dp"
-            android:contentDescription="@string/video_size"
             android:src="@drawable/cyan_circle" />
 
         <org.edx.mobile.view.custom.ETextView
@@ -74,7 +74,7 @@
             android:ellipsize="end"
             android:maxWidth="100dp"
             android:singleLine="true"
-            android:text="@string/video_playing_time"
+            tools:text="3:45"
             android:textColor="@color/grey_video_size_text"
             android:textSize="13sp" />
 
@@ -89,7 +89,7 @@
             android:ellipsize="end"
             android:maxWidth="100dp"
             android:singleLine="true"
-            android:text="@string/video_size"
+            tools:text="200 MB"
             android:textColor="@color/grey_video_size_text"
             android:textSize="13sp"
  />

--- a/VideoLocker/res/values/email.xml
+++ b/VideoLocker/res/values/email.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<resources>
-    
-    <!--  Send Feedback Messages -->
-	<string name="Email_subject">Customer Feedback</string>
-    
-</resources>

--- a/VideoLocker/res/values/labels.xml
+++ b/VideoLocker/res/values/labels.xml
@@ -14,7 +14,6 @@
     
     
     <!-- Dialog Fragment Labels -->
-    <string name="label_resetpassword">reset password</string>
     <string name="label_cancel">Cancel</string>
     <string name="label_no">No</string>
     <string name="label_download">Download</string>

--- a/VideoLocker/res/values/locales.xml
+++ b/VideoLocker/res/values/locales.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="cc_english_code">en</string>
+    <string name="lbl_cc_english">English</string>
+    <string name="cc_chinese_code">zh</string>
+    <string name="lbl_cc_chinese">Chinese</string>
+    <string name="cc_portugal_code">pt</string>
+    <string name="lbl_cc_portugal">Portugal</string>
+    <string name="cc_german_code">de</string>
+    <string name="lbl_cc_german">German</string>
+    <string name="cc_french_code">fr</string>
+    <string name="lbl_cc_french">French</string>
+    <string name="cc_spanish_code">es</string>
+    <string name="lbl_cc_spanish">Spanish</string>
+</resources>

--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="course_details_your_certificate">Your Certificate</string>
     <string name="course_details_friends_in_course">Friends in this course</string>
     <string name="course_details_share">Share</string>
-    <string name="course_details_ending">ENDING</string>
+    <string name="course_details_ending">Ending</string>
     <string name="course_details_congratulations">Congratulations!</string>
     <string name="course_details_earned_cert">You\'ve earned a certificate</string>
     <string name="friends_in_course">Friends in %1$s</string>
@@ -48,7 +48,7 @@
     <string name="download_data_dialog_title">Data Charges May Apply</string>
     <string name="download_data_dialog_message">You’re not on a preferred network or wi-fi. Significant data charges may apply.</string>
     <string name="need_data">This feature requires an active internet connection.</string>
-    <string name="play_data_dialog_OK">OK</string>
+    <string name="play_data_dialog_OK">Ok</string>
     <string name="play_data_dialog_Cancel">Cancel</string>
 
     <!-- Login Activity Place Holders -->
@@ -76,7 +76,6 @@
     <string name="label_find_courses">Find Courses</string>
     <string name="label_my_groups">My Study Groups</string>
     <string name="label_submit_feedback">Submit Feedback</string>
-    <string name="email_subject">Submit Feedback</string>
     <string name="toggle_turn_on">ON</string>
     <string name="toggle_turn_off">OFF</string>
     <string name="logout">Logout</string>
@@ -87,19 +86,21 @@
     <string name="label_settings">My Settings</string>
 
     <!-- Help Dialog Place Holder messages -->
-    <string name="confirm_dialog_title_help">RESET PASSWORD</string>
-    <string name="success_dialog_title_help">PASSWORD RESET E-MAIL SENT</string>
-    <string name="title_reset_password_failed">RESET PASSWORD ERROR</string>
-    <string name="wifi_dialog_title_help">ALLOW CELLULAR DOWNLOAD</string>
+    <string name="confirm_dialog_title_help">Reset Password</string>
+    <string name="success_dialog_title_help">Password reset e-mail sent</string>
+    <string name="title_reset_password_failed">Reset Password Error</string>
+    <string name="wifi_dialog_title_help">Allow cellular download</string>
     <string name="success_dialog_message_help">We\'ve sent a message with password reset instructions to your e-mail address. 
         If you don\'t see it in the next few minutes, make sure to check your spam folder.</string>
     <string name="confirm_dialog_message_help">Enter the e-mail address for your account, and we\'ll send you instructions to
          reset your password.</string>
     <string name="wifi_dialog_message_help">Allow your device to download videos over your cellular connection when 
-        \nWi-Fi is not available. Data charges may apply.</string>
+        Wi-Fi is not available. Data charges may apply.</string>
     <string name="delete_dialog_title_help">Confirm Delete</string>
-    <string name="delete_single_video_dialog">Are you sure you want to\n delete this video?</string>
-    <string name="delete_multiple_video_dialog">Are you sure you want to\n delete these videos?</string>
+    <plurals name="delete_video_dialog_msg">
+        <item quantity="one">Are you sure you want to delete this video?</item>
+        <item quantity="other">Are you sure you want to delete these videos?</item>
+    </plurals>
     <string name="delete_successful_dialog_title_help">Delete</string>
     <string name="leaving_app_data_title">Leaving the edX App</string>
     <string name="leaving_app_data_message">If you leave the app, you will no longer be viewing free edX content. Data charges may apply.</string>
@@ -118,7 +119,7 @@
     <string name="label_ended">Ended</string>
     <string name="label_ending_on">Ending</string>
     <string name="label_my_friends_courses">My Friends\' Courses</string>
-    <string name="course_banner_certified">Certificate\n Earned</string>
+    <string name="course_banner_certified">Certificate Earned</string>
     <string name="course_friends_also_enrolled">Friends also enrolled in this course</string>
 
     <!-- Course Details -->
@@ -145,7 +146,7 @@
     <string name="my_all_videos">All Videos</string>
     <string name="my_recent_videos">Recent Videos</string>
     <string name="offline_text">Offline Mode</string>
-    <string name="no_videos_to_display">You haven\'t downloaded\n any videos.</string>
+    <string name="no_videos_to_display">You haven\'t downloaded any videos.</string>
 
     <!-- My Downloads -->
     <string name="download_name">Engaging in Interaction</string>
@@ -153,7 +154,7 @@
         <item quantity="one">Video Downloaded</item>
         <item quantity="other">Videos Downloaded</item>
     </plurals>
-    <string name="view_button_text">VIEW</string>
+    <string name="view_button_text">View</string>
     <string name="download_failed_text">Download Failed</string>
     <string name="announcement_date">Announcement date</string>
     <plurals name="downloading_count_videos">
@@ -177,8 +178,8 @@
     <string name="or_symbol"> | </string>
 
     <!-- Wifi New Message -->
-    <string name="allow">ALLOW</string>
-    <string name="do_not_allow">DON\'T ALLOW</string>
+    <string name="allow">Allow</string>
+    <string name="do_not_allow">Don\'T allow</string>
 
     <!-- Player Settings -->
     <string name="lbl_closed_caption">Closed Captions</string>
@@ -226,17 +227,15 @@
     <string name="dialog_fbinstall_positive">Show in Google Play</string>
 
     <!-- My Groups -->
-    <string name="tab_DISCUSSION">DISCUSSION</string>
-    <string name="tab_DETAILS">DETAILS</string>
 
     <string name="find_course_text">Looking for a new challenge?</string>
-    <string name="find_course_btn_text">FIND A MOBILE-FRIENDLY COURSE</string>
+    <string name="find_course_btn_text">Find a mobile-friendly course</string>
     <string name="signin_with_text">Or Sign in with</string>
     <string name="facebook_text">Facebook</string>
     <string name="google_text">Google</string>
     <string name="course_not_listed_text">Don\'t see one of your courses?</string>
     <string name="course_content_available_text">This course hasn\'t started yet. Come back on START_DATE to see your videos.</string>
-    <string name="open_edx_btn_text">OPEN EDX.ORG IN MY BROWSER</string>
+    <string name="open_edx_btn_text">Open edx.org in my browser</string>
     <string name="find_courses_dialog_text_1">Our team is currently working hard to let you enroll in courses within the app.</string>
     <string name="find_courses_dialog_text_2">In the meantime, &lt;b&gt;you can enroll in courses through our website&lt;/b&gt; - you\'ll need to log in, enroll, and then return to the app when you\'re done.</string>
     <string name="find_courses_title">Find Courses</string>
@@ -246,7 +245,6 @@
 
     <!-- Landing Activity text -->
     <string name="already_have_an_account">Already have an account? Sign in</string>
-    <string name="improve_your_career">Improve your career,\nyour mind, your life</string>
     <string name="sign_up_and_learn">Sign up and start learning</string>
 
     <!-- Registration Screen -->

--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -65,14 +65,11 @@
         and password are correct and try again.</string>
     <string name="login_failed_no_grant">This account has not been activated. Check your e-mail for activation instructions.</string>
     <string name="new_user">Need an account?</string>
-    <string name="sign_up">https://courses.edx.org/register</string>
     <string name="by_signing_up">By signing in to this app, you agree to the </string>
     <string name="licensing_agreement">edX Terms of Service and Honor Code</string>
     <string name="login_title">Sign in to edX</string>
 
     <!-- Navigation Drawer Labels -->
-    <string name="name_default">Username</string>
-    <string name="email_default">user@domain.com</string>
     <string name="action_settings">Settings</string>
     <string name="label_my_courses">My Courses</string>
     <string name="label_my_videos">My Videos</string>
@@ -125,7 +122,6 @@
     <string name="course_friends_also_enrolled">Friends also enrolled in this course</string>
 
     <!-- Course Details -->
-    <string name="no_of_videos">0</string>
     <string name="course_content">Course Content</string>
     <string name="chapter_name">Course Name</string>
     <string name="tab_label_courseware">Courseware</string>
@@ -272,4 +268,7 @@
     <string name="open_external_url_desc">This link will open in your mobile browser, and you may incur additional data charges.</string>
 
     <string name="offline_handouts_text">You are in offline mode. To view handouts, connect to the internet.</string>
+
+    <!--  Send Feedback Messages -->
+    <string name="email_subject">Customer Feedback</string>
 </resources>

--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -142,8 +142,6 @@
 
     <!-- Video List -->
     <string name="video_title">Video Title</string>
-    <string name="video_playing_time">3:45</string>
-    <string name="video_size">200MB</string>
     <string name="started_downloading">Downloading</string>
     <string name="title_download">Downloads</string>
 
@@ -155,24 +153,18 @@
 
     <!-- My Downloads -->
     <string name="download_name">Engaging in Interaction</string>
-    <string name="download_time">53:59:21</string>
-    <string name="download_percentage">45.20/200MB</string>
-    <string name="text_download_msg_cnt">20</string>
-    <string name="text_download_msg_singular">Video Downloaded</string>
-    <string name="text_download_msg_plural">Videos Downloaded</string>
+    <plurals name="text_download_msg">
+        <item quantity="one">Video Downloaded</item>
+        <item quantity="other">Videos Downloaded</item>
+    </plurals>
     <string name="view_button_text">VIEW</string>
     <string name="download_failed_text">Download Failed</string>
-    <string name="video_title_label">Title</string>
-    <string name="video_section_label">Section</string>
-    <string name="video_subsection_label">Subsection</string>
-    <string name="videos_no">4 Videos</string>
-    <string name="size_of_videos">890 MB</string>
     <string name="announcement_date">Announcement date</string>
-    <string name="label_videos">videos</string>
-    <string name="label_video">video</string>
+    <plurals name="downloading_count_videos">
+        <item quantity="one">Downloading %1$d video</item>
+        <item quantity="other">Downloading %1$d videos</item>
+    </plurals>
     <string name="download_exceed_title">Large Download</string>
-    <string name="downloading_multiple">Downloading %1$s videos</string>
-    <string name="downloading_single">Downloading %1$s video</string>
 
     <!-- lecture complete dialog texts -->
     <string name="title_lecture_complete">You\'ve reached the end of this video.</string>
@@ -195,18 +187,6 @@
     <!-- Player Settings -->
     <string name="lbl_closed_caption">Closed Captions</string>
     <string name="lbl_video_speed">Video Speed</string>
-    <string name="cc_english_code">en</string>
-    <string name="lbl_cc_english">English</string>
-    <string name="cc_chinese_code">zh</string>
-    <string name="lbl_cc_chinese">Chinese</string>
-    <string name="cc_portugal_code">pt</string>
-    <string name="lbl_cc_portugal">Portugal</string>
-    <string name="cc_german_code">de</string>
-    <string name="lbl_cc_german">German</string>
-    <string name="cc_french_code">fr</string>
-    <string name="lbl_cc_french">French</string>
-    <string name="cc_spanish_code">es</string>
-    <string name="lbl_cc_spanish">Spanish</string>
     <string name="lbl_cc_cancel">None</string>
 
     <!-- My Group Strings -->
@@ -217,12 +197,6 @@
     <string name="create_group_disclaimer">Creating an edX group will also create a Facebook group. The group discussion can only be seen by group members.</string>
     <string name="create_group_next">Next</string>
 
-    <string name="label_group_privacy">Group Privacy</string>
-    <string name="label_group_privacy_open">Open</string>
-    <string name="label_group_privacy_close">Close</string>
-    <string name="button_add">Add</string>
-    <string name="button_cancel">Cancel</string>
-    <string name="add_friends">Add Friends</string>
     <string name="connected_as">Connected as %1$s</string>
     <string name="open_study_group">Open study group in facebook</string>
 
@@ -249,7 +223,6 @@
     <string name="friends_search">Search</string>
     <string name="done_text">Done</string>
     <string name="unread_text">%s Unread</string>
-    <string name="back_text">Back</string>
     <string name="group_summary_count">Group Members (%1$s)</string>
     <string name="group_summary_no_friends">You do not have any friends in this group</string>
     <string name="dialog_fbinstall_title">Facebook Required</string>

--- a/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
@@ -1020,13 +1020,8 @@ public class VideoListFragment extends Fragment {
         dialogMap.put("title", getString(R.string.delete_dialog_title_help));
         dialogMap.put("yes_button", getString(R.string.label_delete));
         dialogMap.put("no_button",  getString(R.string.label_cancel));
-        if (itemCount == 1) {
-            dialogMap.put("message_1",
-                    getString(R.string.delete_single_video_dialog));
-        } else {
-            dialogMap.put("message_1",
-                    getString(R.string.delete_multiple_video_dialog));
-        }
+        dialogMap.put("message_1", getResources().getQuantityString(R.plurals.delete_video_dialog_msg, itemCount));
+
         confirmDeleteFragment = DeleteVideoDialogFragment.newInstance(dialogMap,
                 new IDialogCallback() {
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseChapterListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseChapterListFragment.java
@@ -430,12 +430,9 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
                     if(isActivityStarted) {
                         adapter.notifyDataSetChanged();
                         (getActivity()).invalidateOptionsMenu();
-                        if (result > 1) {
-                            String msg = String.format(getString(R.string.downloading_multiple), result);
-                            UiUtil.showMessage(CourseChapterListFragment.this.getView(), msg);
-                        } else if (result == 1) {
-                            String msg = String.format(getString(R.string.downloading_single), result);
-                            UiUtil.showMessage(CourseChapterListFragment.this.getView(), msg);
+                        if (result > 0) {
+                            String format = getResources().getQuantityString(R.plurals.downloading_count_videos, result.intValue());
+                            UiUtil.showMessage(CourseChapterListFragment.this.getView(), String.format(format, result));
                         } else {
                             UiUtil.showMessage(CourseChapterListFragment.this.getView(),
                                     getString(R.string.msg_video_not_downloaded));

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseLectureListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseLectureListActivity.java
@@ -321,12 +321,9 @@ public class CourseLectureListActivity extends BaseFragmentActivity {
                     if(isActivityStarted()){
                         adapter.notifyDataSetChanged();
                         invalidateOptionsMenu();
-                        if(result>1){
-                            showInfoMessage(getString(R.string.started_downloading)+" "+result+
-                                    " "+getString(R.string.label_videos));
-                        }else if (result==1){
-                            showInfoMessage(getString(R.string.started_downloading)+" "+result+
-                                    " "+getString(R.string.label_video));
+                        if(result>0){
+                            String format = getResources().getQuantityString(R.plurals.downloading_count_videos, result.intValue());
+                            showInfoMessage(String.format(format, result));
                         } else {
                             showInfoMessage(getString(R.string.msg_video_not_downloaded));
                         }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DownloadListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DownloadListActivity.java
@@ -16,6 +16,7 @@ import org.edx.mobile.view.adapters.DownloadEntryAdapter;
 
 import android.app.ActionBar;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.Menu;
@@ -146,11 +147,8 @@ public class DownloadListActivity extends BaseFragmentActivity {
                 tvCount.setText(String.valueOf(count));
 
                 TextView tvCountMsg = (TextView) findViewById(R.id.text_download_msg);
-                if (count ==1) {
-                    tvCountMsg.setText(getString(R.string.text_download_msg_singular));
-                } else {
-                    tvCountMsg.setText(getString(R.string.text_download_msg_plural));
-                }
+                String countMessage = getResources().getQuantityString(R.plurals.text_download_msg, (int)count);
+                tvCountMsg.setText(countMessage);
 
                 Button view_btnView = (Button) findViewById(R.id.button_view);
                 view_btnView.setOnClickListener(new OnClickListener() {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyRecentVideosFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyRecentVideosFragment.java
@@ -411,11 +411,7 @@ public class MyRecentVideosFragment extends Fragment {
     protected void showConfirmDeleteDialog(int itemCount) {
         Map<String, String> dialogMap = new HashMap<String, String>();
         dialogMap.put("title", getString(R.string.delete_dialog_title_help));
-        if (itemCount == 1) {
-            dialogMap.put("message_1",  getString(R.string.delete_single_video_dialog));
-        } else {
-            dialogMap.put("message_1",  getString(R.string.delete_multiple_video_dialog));
-        }
+        dialogMap.put("message_1", getResources().getQuantityString(R.plurals.delete_video_dialog_msg, itemCount));
         dialogMap.put("yes_button", getString(R.string.label_delete));
         dialogMap.put("no_button",  getString(R.string.label_cancel));
         deleteDialogFragment = DeleteVideoDialogFragment.newInstance(dialogMap,

--- a/VideoLocker/src/main/java/org/edx/mobile/view/NavigationFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/NavigationFragment.java
@@ -185,7 +185,7 @@ public class NavigationFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 String to = Config.getInstance().getFeedbackEmailAddress();
-                String subject = getString(R.string.Email_subject);
+                String subject = getString(R.string.email_subject);
                 String email = "";
                 EmailUtil.sendEmail(getActivity(), to, subject, email);
             }


### PR DESCRIPTION
This also:
- Fixes some cases involving plurals
- Removes a number of unused strings
- Moves placeholder UI strings out of the localization files and makes
  them use the 'tools' namespace

Note that there is still some work we need to do before we can actually
enable translations:

- Replace UPPERCASE strings with Normal Capitalization and then do the
  uppercasing within the code.
- Remove new lines (\n) from UI strings where they don't make sense and
  make sure the views still fit properly.
  For example, wifi_dialog_message_help breaks in the middle of a
  sentence. It's okay to have newlines if they're breaks that should be
  there in any language and don't depend on knowing the width of the
  dialog.

JIRA: MA-312