### PR TITLE
MA-319_update_skip_slide_events

### DIFF
--- a/VideoLocker/src/androidTest/java/org/edx/mobile/test/SegmentTests.java
+++ b/VideoLocker/src/androidTest/java/org/edx/mobile/test/SegmentTests.java
@@ -182,8 +182,9 @@ public class SegmentTests extends BaseTestCase {
         String unitUrl = "uniturl";
         double oldTime = 10.2;
         double newTime = 10.22;
+        Boolean skipSeek = true
         Properties props = segment.trackVideoSeek(videoId, oldTime,
-                newTime, courseId, unitUrl);
+                newTime, courseId, unitUrl, skipSeek);
         // verify that the track method was called
         Mockito.verify(tracker).track(Mockito.eq(ISegment.Keys.SEEK_VIDEO),
                 (Properties) Mockito.any());
@@ -193,12 +194,11 @@ public class SegmentTests extends BaseTestCase {
         Properties dataProps = (Properties)props.get(ISegment.Keys.DATA);
         testCommonProperties(dataProps);
         assertTrue(props.containsKey(ISegment.Keys.NAME));
-
         assertTrue(dataProps.containsKey(ISegment.Keys.SEEK_TYPE));
+        assertTrue(dataProps.containsValue(ISegment.Values.SKIP));
         assertTrue(dataProps.containsKey(ISegment.Keys.NEW_TIME));
         assertTrue(dataProps.containsKey(ISegment.Keys.OLD_TIME));
         assertTrue(dataProps.containsKey(ISegment.Keys.REQUESTED_SKIP_INTERVAL));
-
         testAnalyticsContext((Properties)props.get(ISegment.Keys.CONTEXT));
 
         print(props.toString());

--- a/VideoLocker/src/main/java/org/edx/mobile/module/analytics/ISegment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/analytics/ISegment.java
@@ -39,7 +39,7 @@ public interface ISegment {
     Properties trackVideoLoading(String videoId, String courseId, String unitUrl);
 
     Properties trackVideoSeek(String videoId, Double oldTime,
-            Double newTime, String courseId, String unitUrl);
+            Double newTime, String courseId, String unitUrl, Boolean skipSeek);
 
     void resetIdentifyUser();
 
@@ -179,6 +179,7 @@ public interface ISegment {
     
     public static interface Values{
         public static final String SKIP = "skip";
+        public static final String SLIDE = "slide";
         public static final String MOBILE = "mobile";
         public static final String VIDEOPLAYER = "videoplayer";
         public static final String PASSWORD = "Password";

--- a/VideoLocker/src/main/java/org/edx/mobile/module/analytics/ISegmentEmptyImpl.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/analytics/ISegmentEmptyImpl.java
@@ -49,7 +49,7 @@ public class ISegmentEmptyImpl implements ISegment {
     }
 
     @Override
-    public Properties trackVideoSeek(String videoId, Double oldTime, Double newTime, String courseId, String unitUrl) {
+    public Properties trackVideoSeek(String videoId, Double oldTime, Double newTime, String courseId, String unitUrl, Boolean skipSeek) {
         return null;
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/module/analytics/ISegmentImpl.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/analytics/ISegmentImpl.java
@@ -174,11 +174,12 @@ class ISegmentImpl implements ISegment {
      * @param newTime
      * @param courseId
      * @param unitUrl
+     * @param skipSeek
      * @return 
      */
     @Override
     public Properties trackVideoSeek(String videoId,
-            Double oldTime, Double newTime, String courseId, String unitUrl){
+            Double oldTime, Double newTime, String courseId, String unitUrl, Boolean skipSeek){
         try{
             SegmentAnalyticsEvent aEvent = getCommonProperties(videoId, Values.VIDEO_SEEKED);
             aEvent.setCourseContext(courseId, unitUrl, Values.VIDEOPLAYER);
@@ -189,7 +190,8 @@ class ISegmentImpl implements ISegment {
             skipInterval = formatDoubleValue(skipInterval, 3);
             aEvent.data.putValue(Keys.OLD_TIME, oldTime);
             aEvent.data.putValue(Keys.NEW_TIME, newTime);
-            aEvent.data.putValue(Keys.SEEK_TYPE, Values.SKIP);
+            if (skipSeek){ aEvent.data.putValue(Keys.SEEK_TYPE, Values.SKIP);}
+            else {aEvent.data.putValue(Keys.SEEK_TYPE, Values.SLIDE);}
             aEvent.data.putValue(Keys.REQUESTED_SKIP_INTERVAL, skipInterval);
 
             tracker.track(Keys.SEEK_VIDEO, aEvent.properties);
@@ -438,7 +440,7 @@ class ISegmentImpl implements ISegment {
      * @param videoId  -  Video id for which download has started
      * @param courseId
      * @param unitUrl
-     * @return 
+     * @return
      */
     @Override
     public Properties trackSingleVideoDownload(String videoId, String courseId,

--- a/VideoLocker/src/main/java/org/edx/mobile/player/PlayerController.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/PlayerController.java
@@ -738,6 +738,9 @@ public class PlayerController extends FrameLayout {
         info.setClassName(PlayerController.class.getName());
     }
 
+    /**
+     * Listener for the rewind 30 seconds button in the media player
+     */
     private View.OnClickListener mRewListener = new View.OnClickListener() {
         public void onClick(View v) {
             if (mPlayer == null) {
@@ -764,26 +767,6 @@ public class PlayerController extends FrameLayout {
         }
     };
 
-    private View.OnClickListener mFfwdListener = new View.OnClickListener() {
-        public void onClick(View v) {
-            if (mPlayer == null) {
-                return;
-            }
-
-            int pos = mPlayer.getCurrentPosition();
-            // apply 30 seconds forward
-            pos += 30 * 1000; // milliseconds
-            mPlayer.seekTo(pos);
-            setProgress();
-
-            show(sDefaultTimeout);
-
-            // callback this event
-//          if (mEventListener != null) {
-//              mEventListener.onSeek(pos);
-//          }
-        }
-    };
 
     private void installPrevNextListeners() {
         if(mNextListener!=null){

--- a/VideoLocker/src/main/java/org/edx/mobile/player/PlayerFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/PlayerFragment.java
@@ -1631,7 +1631,8 @@ public class PlayerFragment extends Fragment implements IPlayerListener, Seriali
             segIO.trackVideoSeek(videoEntry.videoId,
                     lastPostion/AppConstants.MILLISECONDS_PER_SECOND,
                     newPosition/AppConstants.MILLISECONDS_PER_SECOND,
-                    videoEntry.eid, videoEntry.lmsUrl);
+                    videoEntry.eid, videoEntry.lmsUrl,
+                    isRewindClicked);
         }catch(Exception e){
             logger.error(e);
         }


### PR DESCRIPTION
@aleffert @rohan-dhamal-clarice @hanningni 

Need to distinguish between skip (back 30 seconds) and slide events. Are there any problems with the way I have implemented this? For example: in ios, slide and skip are in two different functions but in android, its one function with an if statement.

Tested against mobile3 sandbox.