### PR TITLE
Switch FB/Google login to use OAuth token exchange instead of login_oaut...

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -1,31 +1,50 @@
 package org.edx.mobile.base;
 
 
+import android.app.Activity;
 import android.app.Application;
+import android.content.Intent;
 import android.content.IntentFilter;
 import android.graphics.Bitmap.CompressFormat;
+import android.os.Bundle;
 
 import com.crashlytics.android.Crashlytics;
 import com.newrelic.agent.android.NewRelic;
 
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.module.analytics.SegmentFactory;
+import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.module.storage.Storage;
 import org.edx.mobile.receivers.NetworkConnectivityReceiver;
+import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.Config;
 import org.edx.mobile.util.Environment;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.util.images.ImageCacheManager;
 import org.edx.mobile.util.images.RequestManager;
+import org.edx.mobile.view.Router;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import io.fabric.sdk.android.Fabric;
 
 /**
  * This class initializes the modules of the app based on the configuration.
  */
-public class MainApplication extends Application {
+public class MainApplication extends Application{
+
+    protected final Logger logger = new Logger(getClass().getName());
 
     NetworkConnectivityReceiver connectivityReceiver;
+
+    private static MainApplication application;
+
+    public static final MainApplication instance(){
+        return application;
+    }
+
+
 
     @Override
     public void onCreate() {
@@ -40,6 +59,9 @@ public class MainApplication extends Application {
     private void init() {
         // initialize logger
         Logger.init(this.getApplicationContext());
+
+        application = this;
+        registerActivityLifecycleCallbacks(new MyActivityLifecycleCallbacks());
 
         // setup environment
         Environment env = new Environment();
@@ -79,7 +101,9 @@ public class MainApplication extends Application {
         // register connectivity receiver
         connectivityReceiver = new NetworkConnectivityReceiver();
         registerReceiver(connectivityReceiver, new IntentFilter("android.net.conn.CONNECTIVITY_CHANGE"));
+
     }
+
     
     /**
      * Create the image cache. Uses Memory Cache by default. 
@@ -98,5 +122,53 @@ public class MainApplication extends Application {
                 , DISK_IMAGECACHE_COMPRESS_FORMAT
                 , DISK_IMAGECACHE_QUALITY
                 , ImageCacheManager.CacheType.MEMORY);
+    }
+
+
+    /**
+     * callback when application is launched from background or from a cold launch,
+     */
+    public void onApplicationLaunchedFromBackground(){
+        logger.debug("onApplicationLaunchedFromBackground");
+        PrefManager pref = new PrefManager(this, PrefManager.Pref.LOGIN);
+        if ( pref.hasAuthTokenSocialCookie() ){
+             Router.getInstance().forceLogout(this);
+        }
+    }
+
+
+    private final class MyActivityLifecycleCallbacks
+            implements Application.ActivityLifecycleCallbacks{
+
+        Activity  prevPausedOne;
+
+        public void onActivityCreated(Activity activity, Bundle bundle) {
+
+        }
+
+        public void onActivityDestroyed(Activity activity) {
+
+        }
+
+        public void onActivityPaused(Activity activity) {
+            prevPausedOne = activity;
+        }
+
+        public void onActivityResumed(Activity activity) {
+             if( null ==  prevPausedOne || prevPausedOne == activity ){
+                 //application launched from background,
+                 onApplicationLaunchedFromBackground();
+             }
+        }
+
+        public void onActivitySaveInstanceState(Activity activity,
+                                                Bundle outState) {
+        }
+
+        public void onActivityStarted(Activity activity) {
+        }
+
+        public void onActivityStopped(Activity activity) {
+        }
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
@@ -165,6 +165,14 @@ public class PrefManager {
         put(PrefManager.Key.AUTH_JSON, null);
         put(PrefManager.Key.AUTH_TOKEN_SOCIAL, null);
         put(PrefManager.Key.AUTH_TOKEN_BACKEND, null);
+        put(PrefManager.Key.AUTH_TOKEN_SOCIAL_COOKIE, null);
+    }
+
+    /**
+     *  check if app is currently logged in through Google/Facebook
+     */
+    public boolean hasAuthTokenSocialCookie(){
+        return  null !=  getString(Key.AUTH_TOKEN_SOCIAL_COOKIE);
     }
     
     /**
@@ -190,7 +198,8 @@ public class PrefManager {
         return context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
                 .getBoolean(PrefManager.Key.LASTACCESSED_SYNCED_FLAG, true);
     }
-    
+
+
     /**
      * Returns last accessed subsection id for the given course. 
      * @return

--- a/VideoLocker/src/main/java/org/edx/mobile/util/AppConstants.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/AppConstants.java
@@ -7,6 +7,7 @@ public class AppConstants {
     public static boolean myVideosDeleteMode  = false;
     public static boolean videoListDeleteMode  = false;
 
+    public static final String APP_LAUNCH_FROM_BACKGROUND = "app_launch_from_background";
     public static final String LOGOUT_CLICKED = "user_logout_clicked";
     public static final String VIDEOLIST_BACK_PRESSED = "offline_video_back_pressed";
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/NavigationFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/NavigationFragment.java
@@ -207,23 +207,11 @@ public class NavigationFragment extends Fragment {
 
             @Override
             public void onClick(View v) {
-                pref.clearAuth();
-                pref.put(PrefManager.Key.TRANSCRIPT_LANGUAGE, 
-                        getString(R.string.lbl_cc_cancel));
-
-                Intent intent = new Intent();
-                intent.setAction(AppConstants.LOGOUT_CLICKED);
-                getActivity().sendBroadcast(intent); 
-                
-                ISegment segIO = SegmentFactory.getInstance();
-                segIO.trackUserLogout();
-                segIO.resetIdentifyUser();
-
-                Router.getInstance().showLaunchScreen(getActivity(),true);
-                Router.getInstance().showLogin(getActivity());
-
+                Router.getInstance().forceLogout(getActivity());
             }
         });
+
+
         
 
         TextView version_tv = (TextView) layout.findViewById(R.id.tv_version_no);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/Router.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/Router.java
@@ -1,10 +1,15 @@
 package org.edx.mobile.view;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 
+import org.edx.mobile.R;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
+import org.edx.mobile.module.analytics.ISegment;
+import org.edx.mobile.module.analytics.SegmentFactory;
+import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.util.AppConstants;
 
 /**
@@ -60,16 +65,16 @@ public class Router {
         sourceActivity.startActivity(settingsIntent);
     }
 
-    public void showLaunchScreen(Activity sourceActivity, boolean overrideAnimation) {
-        Intent launchIntent = new Intent(sourceActivity, LaunchActivity.class);
+    public void showLaunchScreen(Context context, boolean overrideAnimation) {
+        Intent launchIntent = new Intent(context, LaunchActivity.class);
         launchIntent.putExtra(LaunchActivity.OVERRIDE_ANIMATION_FLAG,overrideAnimation);
         launchIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        sourceActivity.startActivity(launchIntent);
+        context.startActivity(launchIntent);
     }
 
-    public void showLogin(Activity sourceActivity) {
-        Intent launchIntent = new Intent(sourceActivity, LoginActivity.class);
-        sourceActivity.startActivity(launchIntent);
+    public void showLogin(Context context) {
+        Intent launchIntent = new Intent(context, LoginActivity.class);
+        context.startActivity(launchIntent);
     }
 
     public void showRegistration(Activity sourceActivity) {
@@ -103,5 +108,25 @@ public class Router {
         courseDetail.putExtra(CourseDetailTabActivity.EXTRA_BUNDLE, courseBundle);
         courseDetail.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
         activity.startActivity(courseDetail);
+    }
+
+    /**
+     *  this method can be called either through UI [ user clicks LOGOUT button],
+     *  or programmatically
+     */
+    public void forceLogout(Context context){
+        PrefManager pref = new PrefManager(context, PrefManager.Pref.LOGIN);
+        pref.clearAuth();
+        pref.put(PrefManager.Key.TRANSCRIPT_LANGUAGE, "none");
+        Intent intent = new Intent();
+        intent.setAction(AppConstants.LOGOUT_CLICKED);
+        context.sendBroadcast(intent);
+
+        ISegment segIO = SegmentFactory.getInstance();
+        segIO.trackUserLogout();
+        segIO.resetIdentifyUser();
+
+        Router.getInstance().showLaunchScreen(context,true);
+        Router.getInstance().showLogin(context);
     }
 }


### PR DESCRIPTION
Acceptance criteria:
1. Users who have already logged in via sessions should be logged out (as if they clicked the log out button)

if app is launched from background, we check if app is already logged in via old social path.
if so,  app will log out.
 
2. Future FB/Google users should authenticate via OAuth instead of session cookies

this part  depends on the change of server side response.  not done yet.