### PR TITLE
Handle Play / Download on Mobile network

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
@@ -191,12 +191,8 @@ public class VideoListFragment extends Fragment {
                         // hide delete panel first, so that multiple-tap is blocked
                         hideDeletePanel(VideoListFragment.this.getView());
 
-                        if (NetworkUtil.isConnectedWifi(getContext())) {
-
-                        }else if (NetworkUtil.isConnectedMobile(getContext())) {
-                            ((VideoListActivity) getActivity()).showInfoMessage(getString(R.string.need_data));
-                            notifyAdapter();
-                        } else {
+                        DownloadEntry de = (DownloadEntry) model;
+                        if(!de.isDownloaded()){
                             IDialogCallback dialogCallback = new IDialogCallback() {
                                 @Override
                                 public void onPositiveClicked() {
@@ -205,10 +201,14 @@ public class VideoListFragment extends Fragment {
 
                                 @Override
                                 public void onNegativeClicked() {
-                                    //
+                                    ((VideoListActivity) getActivity()).showInfoMessage(getString(R.string.wifi_off_message));
+                                    notifyAdapter();
                                 }
                             };
-                            MediaConsentUtils.consentToMediaDownload(getActivity(), dialogCallback);
+                            MediaConsentUtils.consentToMediaPlayback(getActivity(), dialogCallback);
+                        }else{
+                            //Video is downloaded. Hence play
+                            startOnlinePlay(model, position);
                         }
                     }
                 }
@@ -216,13 +216,7 @@ public class VideoListFragment extends Fragment {
                 @Override
                 public void download(final DownloadEntry videoData, final ProgressWheel progressWheel) {
                     try {
-                        if (!NetworkUtil.isConnected(getContext())) {
-                            ((VideoListActivity) getActivity()).showInfoMessage(getString(R.string.need_data));
-                            notifyAdapter();
-                        } else {
-                            if (!(getActivity() instanceof VideoListActivity)) {
-                                return;
-                            }
+                        if (NetworkUtil.isConnected(getContext())) {
                             IDialogCallback dialogCallback = new IDialogCallback() {
                                 @Override
                                 public void onPositiveClicked() {
@@ -231,12 +225,12 @@ public class VideoListFragment extends Fragment {
 
                                 @Override
                                 public void onNegativeClicked() {
-                                    //
+                                    ((VideoListActivity) getActivity()).showInfoMessage(getString(R.string.wifi_off_message));
+                                    notifyAdapter();
                                 }
                             };
-                            MediaConsentUtils.consentToMediaDownload(getActivity(), dialogCallback);
+                            MediaConsentUtils.consentToMediaPlayback(getActivity(), dialogCallback);
                         }
-
                     } catch (Exception e) {
                         logger.error(e);
                     }
@@ -854,7 +848,7 @@ public class VideoListFragment extends Fragment {
             DownloadEntry v = videoModel;
             if (v != null) {
                 // mark this as partially watches, as playing has started
-                db.updateVideoLastPlayedOffset(v.videoId, offset, 
+                db.updateVideoLastPlayedOffset(v.videoId, offset,
                         setCurrentPositionCallback);
             }
         } catch (Exception ex) {

--- a/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
@@ -191,7 +191,9 @@ public class VideoListFragment extends Fragment {
                         // hide delete panel first, so that multiple-tap is blocked
                         hideDeletePanel(VideoListFragment.this.getView());
 
-                        if (!NetworkUtil.isConnected(getContext())) {
+                        if (NetworkUtil.isConnectedWifi(getContext())) {
+
+                        }else if (NetworkUtil.isConnectedMobile(getContext())) {
                             ((VideoListActivity) getActivity()).showInfoMessage(getString(R.string.need_data));
                             notifyAdapter();
                         } else {

--- a/VideoLocker/src/main/java/org/edx/mobile/util/BrowserUtil.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/BrowserUtil.java
@@ -1,6 +1,5 @@
 package org.edx.mobile.util;
 
-import android.app.Dialog;
 import android.content.Intent;
 import android.net.Uri;
 import android.support.v4.app.FragmentActivity;
@@ -12,7 +11,6 @@ import org.edx.mobile.http.Api;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.analytics.SegmentFactory;
-import org.edx.mobile.view.dialog.DialogFactory;
 import org.edx.mobile.view.dialog.IDialogCallback;
 
 public class BrowserUtil {
@@ -38,31 +36,29 @@ public class BrowserUtil {
 
         // verify if the app is running on zero-rated network?
         if (NetworkUtil.isConnectedMobile(activity) && NetworkUtil.isOnZeroRatedNetwork(activity)) {
-            // inform user if they get may charged for this browsing this URL
-            IDialogCallback callback = new IDialogCallback() {
-                @Override
-                public void onPositiveClicked() {
-                    openInBrowser(activity, url);
-                }
-
-                @Override
-                public void onNegativeClicked() {
-                }
-            };
-
-            MediaConsentUtils.showLeavingAppDataDialog(activity, callback);
-        }else{
             String baseUrl = new Api(activity).getBaseUrl();
 
             if(url.indexOf(baseUrl) >= 0) {
                 openInBrowser(activity, url);
-            }
-            else if(url.startsWith("/")) {
+            }else if(url.startsWith("/")) {
                 openInBrowser(activity, String.format("%s%s", baseUrl, url));
+            }else {
+                // inform user they may get charged for browsing this URL
+                IDialogCallback callback = new IDialogCallback() {
+                    @Override
+                    public void onPositiveClicked() {
+                        openInBrowser(activity, url);
+                    }
+
+                    @Override
+                    public void onNegativeClicked() {
+                    }
+                };
+
+                MediaConsentUtils.showLeavingAppDataDialog(activity, callback);
             }
-            else {
-                openInBrowser(activity, url);
-            }
+        }else{
+            openInBrowser(activity, url);
         }
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/util/BrowserUtil.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/BrowserUtil.java
@@ -37,22 +37,8 @@ public class BrowserUtil {
         }
 
         // verify if the app is running on zero-rated network?
-        if (NetworkUtil.isOnZeroRatedNetwork(activity)) {
+        if (NetworkUtil.isConnectedMobile(activity) && NetworkUtil.isOnZeroRatedNetwork(activity)) {
             // inform user if they get may charged for this browsing this URL
-            Dialog d = DialogFactory.getChargesApplyConfirmationDialog(activity, url);
-            d.show();
-            return;
-        }
-
-        String baseUrl = new Api(activity).getBaseUrl();
-
-        if(url.indexOf(baseUrl) >= 0) {
-            openInBrowser(activity, url);
-        }
-        else if(url.startsWith("/")) {
-            openInBrowser(activity, String.format("%s%s", baseUrl, url));
-        }
-        else {
             IDialogCallback callback = new IDialogCallback() {
                 @Override
                 public void onPositiveClicked() {
@@ -65,6 +51,18 @@ public class BrowserUtil {
             };
 
             MediaConsentUtils.showLeavingAppDataDialog(activity, callback);
+        }else{
+            String baseUrl = new Api(activity).getBaseUrl();
+
+            if(url.indexOf(baseUrl) >= 0) {
+                openInBrowser(activity, url);
+            }
+            else if(url.startsWith("/")) {
+                openInBrowser(activity, String.format("%s%s", baseUrl, url));
+            }
+            else {
+                openInBrowser(activity, url);
+            }
         }
     }
 
@@ -77,12 +75,6 @@ public class BrowserUtil {
             intent.setData(Uri.parse(url));
             context.startActivity(intent);
 
-/*          Intent intent = new Intent(context, WebviewActivity.class);
-            intent.addCategory(Intent.CATEGORY_BROWSABLE);
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            intent.setData(Uri.parse(url));
-            context.startActivity(intent);*/
-            
             try{
                 ISegment segIO = SegmentFactory.getInstance();
                 segIO.trackOpenInBrowser(url);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseChapterListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseChapterListFragment.java
@@ -205,10 +205,11 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
 
                             @Override
                             public void onNegativeClicked() {
-                                //
+                                ((CourseDetailTabActivity) getActivity())
+                                        .showInfoMessage(getString(R.string.wifi_off_message));
                             }
                         };
-                        MediaConsentUtils.consentToMediaDownload(getActivity(), dialogCallback);
+                        MediaConsentUtils.consentToMediaPlayback(getActivity(), dialogCallback);
 
                     } catch (Exception e) {
                         logger.error(e);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseLectureListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseLectureListActivity.java
@@ -122,10 +122,11 @@ public class CourseLectureListActivity extends BaseFragmentActivity {
 
                         @Override
                         public void onNegativeClicked() {
-                            //
+                            CourseLectureListActivity.this.showInfoMessage(getString(R.string.wifi_off_message));
+                            adapter.notifyDataSetChanged();
                         }
                     };
-                    MediaConsentUtils.consentToMediaDownload(CourseLectureListActivity.this, dialogCallback);
+                    MediaConsentUtils.consentToMediaPlayback(CourseLectureListActivity.this, dialogCallback);
                 }
             };
 


### PR DESCRIPTION
Handling network related error messages such that the following scenarios are handled.
1. On Zero rated network, no network related messages need to be displayed other than the "If you leave the app, you will no longer be viewing free edX content. Data charges may apply." message when user clicks on a URL which opens on external browser.
2. No network related messages when user is connected to Wifi.
3. No network related messages for downloaded videos.
4.  On non zero rated network, need to display specific messages based on wifi preferences. No message needs to be displayed if user is leaving the application to external browsers

Basecamp link - https://basecamp.com/1768823/projects/5356725/messages/38451181

JIRA: https://openedx.atlassian.net/browse/MOB-1572
JIRA: https://openedx.atlassian.net/browse/MOB-1570
JIRA: https://openedx.atlassian.net/browse/MOB-1578

Pending - Handling Video playing when user switches from wifi to mobile network on a non-zero rated carrier. I will work on this and update this branch.

cc - @rohan-dhamal-clarice @aleffert 