### PR TITLE
Return on touch as false if Recent Videos is in Edit mode

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/MyRecentVideoAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/MyRecentVideoAdapter.java
@@ -49,6 +49,9 @@ public abstract class MyRecentVideoAdapter extends VideoBaseAdapter<SectionItemI
 
                     @Override
                     public boolean onTouch(View v, MotionEvent event) {
+                        if(AppConstants.myVideosDeleteMode){
+                            return false;
+                        }
                         holder.videolayout.setSelected(
                                 selectedPosition != holder.position
                                         && (event.getAction() == MotionEvent.ACTION_DOWN


### PR DESCRIPTION
The video should not be clickable if the Recent Videos listing is in Edit Mode. 

Please review - @rohan-dhamal-clarice @hanningni @aleffert 

JIRA: https://openedx.atlassian.net/browse/MOB-1594

