### PR TITLE
Move speed-test behind a flag in the config

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/receivers/NetworkConnectivityReceiver.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/receivers/NetworkConnectivityReceiver.java
@@ -13,6 +13,7 @@ import org.edx.mobile.model.DownloadDescriptor;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.analytics.SegmentFactory;
 import org.edx.mobile.services.DownloadSpeedService;
+import org.edx.mobile.util.Config;
 import org.edx.mobile.util.NetworkUtil;
 
 /**
@@ -20,29 +21,29 @@ import org.edx.mobile.util.NetworkUtil;
  */
 public class NetworkConnectivityReceiver extends BroadcastReceiver {
 
-    private static final String TAG = NetworkConnectivityReceiver.class.getSimpleName();
-
     private static final Logger logger = new Logger(NetworkConnectivityReceiver.class);
     private static boolean isFirstStart = false;
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        ConnectivityManager cm =
-                (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        // speed-test is moved behind a flag in the configuration
+        if(Config.getInstance().isSpeedTestEnabled()) {
+            ConnectivityManager cm =
+                    (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
 
-        NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
-        boolean isConnected = activeNetwork != null && activeNetwork.isAvailable();
+            NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
+            boolean isConnected = activeNetwork != null && activeNetwork.isAvailable();
 
-        // do NOT test download speed on Zero-Rated network
-        if(isConnected && !NetworkUtil.isOnZeroRatedNetwork(context)) {
-            logger.debug("Have reconnected, testing download speed.");
-            //start an instance of the download speed service so it can run in the background
-            Intent speedTestIntent = new Intent(context, DownloadSpeedService.class);
-            String downloadEndpoint = context.getString(R.string.speed_test_url);
-            speedTestIntent.putExtra(DownloadSpeedService.EXTRA_FILE_DESC,
-                    new DownloadDescriptor(downloadEndpoint, !isFirstStart));
-            context.startService(speedTestIntent);
-            isFirstStart = true;
+            if (isConnected) {
+                logger.debug("Have reconnected, testing download speed.");
+                //start an instance of the download speed service so it can run in the background
+                Intent speedTestIntent = new Intent(context, DownloadSpeedService.class);
+                String downloadEndpoint = context.getString(R.string.speed_test_url);
+                speedTestIntent.putExtra(DownloadSpeedService.EXTRA_FILE_DESC,
+                        new DownloadDescriptor(downloadEndpoint, !isFirstStart));
+                context.startService(speedTestIntent);
+                isFirstStart = true;
+            }
         }
 
         //Track the connection change. Record if the user is on a cell network.
@@ -54,7 +55,6 @@ public class NetworkConnectivityReceiver extends BroadcastReceiver {
             String carrierName = manager.getNetworkOperatorName();
 
             segIO.trackUserCellConnection(carrierName, NetworkUtil.isOnZeroRatedNetwork(context));
-
         }
 
     }

--- a/VideoLocker/src/main/java/org/edx/mobile/receivers/NetworkConnectivityReceiver.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/receivers/NetworkConnectivityReceiver.java
@@ -33,7 +33,8 @@ public class NetworkConnectivityReceiver extends BroadcastReceiver {
         NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
         boolean isConnected = activeNetwork != null && activeNetwork.isAvailable();
 
-        if(isConnected) {
+        // do NOT test download speed on Zero-Rated network
+        if(isConnected && !NetworkUtil.isOnZeroRatedNetwork(context)) {
             logger.debug("Have reconnected, testing download speed.");
             //start an instance of the download speed service so it can run in the background
             Intent speedTestIntent = new Intent(context, DownloadSpeedService.class);

--- a/VideoLocker/src/main/java/org/edx/mobile/util/Config.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/Config.java
@@ -42,6 +42,7 @@ public class Config {
     private static final String OAUTH_CLIENT_ID = "OAUTH_CLIENT_ID";
     private static final String OAUTH_CLIENT_SECRET = "OAUTH_CLIENT_SECRET";
     private static final String USE_DEPRECATED_REGISTRATION_API = "USE_DEPRECATED_REGISTRATION_API";
+    private static final String SPEED_TEST_ENABLED = "SPEED_TEST_ENABLED";
 
     /* Composite configuration keys */
     private static final String COURSE_ENROLLMENT = "COURSE_ENROLLMENT";
@@ -274,6 +275,15 @@ public class Config {
 
     public boolean isUseDeprecatedRegistrationAPI() {
         return getBoolean(USE_DEPRECATED_REGISTRATION_API, false);
+    }
+
+    /**
+     * Empty or no config returns false.
+     * Otherwise, returns the value from the config.
+     * @return
+     */
+    public boolean isSpeedTestEnabled() {
+        return getBoolean(SPEED_TEST_ENABLED, false);
     }
 
     /**


### PR DESCRIPTION
I might add more checks as needed. I am working on monitoring the network traffic to identify if there are any other third party links being hit.

I have disabled speed-test on zero rated network because that uses a amazon S3 URL (non-zero rated).

cc @shahidtamboli @hanningni  @nasthagiri 