### PR TITLE
Hide left navigation panel from showing up on Handouts activity

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/base/BaseSingleFragmentActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/BaseSingleFragmentActivity.java
@@ -3,6 +3,7 @@ package org.edx.mobile.base;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v4.widget.DrawerLayout;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -90,6 +91,18 @@ public abstract class BaseSingleFragmentActivity extends BaseFragmentActivity {
     private void hideOfflineBar(){
         if(offlineBar!=null){
             offlineBar.setVisibility(View.GONE);
+        }
+    }
+
+    /**
+     * Call this function if you do not want to allow
+     * opening/showing the drawer(Navigation Fragment) on swiping left to right
+     */
+    protected void blockDrawerFromOpening(){
+        DrawerLayout mDrawerLayout = (DrawerLayout)
+                findViewById(R.id.drawer_layout);
+        if (mDrawerLayout != null) {
+            mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
         }
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/base/BaseSingleFragmentActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/BaseSingleFragmentActivity.java
@@ -99,10 +99,10 @@ public abstract class BaseSingleFragmentActivity extends BaseFragmentActivity {
      * opening/showing the drawer(Navigation Fragment) on swiping left to right
      */
     protected void blockDrawerFromOpening(){
-        DrawerLayout mDrawerLayout = (DrawerLayout)
+        DrawerLayout drawerLayout = (DrawerLayout)
                 findViewById(R.id.drawer_layout);
-        if (mDrawerLayout != null) {
-            mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
+        if (drawerLayout != null) {
+            drawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
         }
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseHandoutActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseHandoutActivity.java
@@ -11,6 +11,13 @@ public class CourseHandoutActivity extends BaseSingleFragmentActivity {
     private Fragment fragment;
 
     @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        //Handouts activity should not contain the drawer(Navigation Fragment).
+        blockDrawerFromOpening();
+    }
+
+    @Override
     protected void onStart() {
         super.onStart();
         setTitle(getString(R.string.tab_label_handouts));


### PR DESCRIPTION
The left navigation bar was accessible on Handouts screen. This has been blocked.

Please review : @rohan-dhamal-clarice @hanningni @aleffert 

JIRA: https://openedx.atlassian.net/browse/MOB-1626