### PR TITLE
Change sign in with text as per original spec

### DIFF
--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -357,7 +357,7 @@
     <string name="find_course_text">Looking for a new challenge?</string>
     <!-- Button label to bring up course finder -->
     <string name="find_course_btn_text">Find a mobile-friendly course</string>
-    <!-- Button label to bring up course finder -->
+    <!-- Message between sign in button and social login buttons -->
     <string name="signin_with_text">Or Sign in with</string>
     <!-- Facebook login method -->
     <string name="facebook_text">Facebook</string>

--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -358,7 +358,7 @@
     <!-- Button label to bring up course finder -->
     <string name="find_course_btn_text">Find a mobile-friendly course</string>
     <!-- Button label to bring up course finder -->
-    <string name="signin_with_text">signing in to this app in with</string>
+    <string name="signin_with_text">Or Sign in with</string>
     <!-- Facebook login method -->
     <string name="facebook_text">Facebook</string>
     <!-- Google login method -->


### PR DESCRIPTION
The text on the login screen for "Or sign in with" was changed in https://github.com/edx/edx-app-android/pull/161. Please see attached screenshot with the wrong message. 
![screenshot_2015-03-12-14-58-18](https://cloud.githubusercontent.com/assets/7403872/6615282/82042000-c8c8-11e4-9620-962fbb01ca25.png)

This has been reverted back to the original message. 

Please review - @rohan-dhamal-clarice @aleffert @hanningni 