### PR TITLE
Change method getVideoByUrl to return video entries which are not online

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/IDatabase.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/IDatabase.java
@@ -171,7 +171,7 @@ public interface IDatabase {
     public IVideoModel getVideoEntryByVideoId(String videoId, DataCallback<IVideoModel> callback);
     
     /**
-     * Returns {@link IVideoModel} for given videoUrl.
+     * Returns {@link IVideoModel} which is downloaded or download is in progress for given videoUrl.
      * @param videoUrl
      * @param callback
      * @return

--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/IDatabaseImpl.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/IDatabaseImpl.java
@@ -277,8 +277,9 @@ class IDatabaseImpl extends IDatabaseBaseImpl implements IDatabase {
     public IVideoModel getVideoByVideoUrl(String videoUrl,
             DataCallback<IVideoModel> callback) {
         DbOperationGetVideo op = new DbOperationGetVideo(false,DbStructure.Table.DOWNLOADS, null, 
-                DbStructure.Column.URL + "=? AND "+ DbStructure.Column.USERNAME + "=?" , 
-                new String[] { videoUrl, username}, null);
+                DbStructure.Column.URL + "=? AND "+DbStructure.Column.DOWNLOADED + "!=? AND "
+                + DbStructure.Column.USERNAME + "=?" ,
+                new String[] { videoUrl, String.valueOf(DownloadedState.ONLINE.ordinal()), username}, null);
         op.setCallback(callback);
         return enqueue(op);
     }


### PR DESCRIPTION
This fixes the issue of showing downloading progress even if another video with the same URL is already downloaded.

Please review - @rohan-dhamal-clarice @hanningni @aleffert 

JIRA: https://openedx.atlassian.net/browse/MOB-1593