### PR TITLE
Do not reload the Section/Subsection/Video list view 

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/IDatabase.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/IDatabase.java
@@ -328,5 +328,27 @@ public interface IDatabase {
      */
     DownloadedState getDownloadedStateForVideoId(String videoId,
             DataCallback<DownloadedState> dataCallback);
+
+    /**
+     * Return true if any Video is marked as Downloading for the courseId in the database for logged in user
+     * Used to handle reloading of Section listing
+     * @return boolean flag if download is in progress
+     */
+    public Boolean isAnyVideoDownloadingInCourse(DataCallback<Boolean> callback, String courseId);
+
+    /**
+     * Return true if any Video is marked as Downloading for a section in the database for logged in user
+     * Used to handle reloading of subsection listing
+     * @return boolean flag if download is in progress
+     */
+    public Boolean isAnyVideoDownloadingInSection(DataCallback<Boolean> callback, String courseId, String section);
+
+    /**
+     * Return true if any Video is marked as Downloading for a subsection in the database for logged in user
+     * Used to handle reloading of Video listing
+     * @return boolean flag if download is in progress
+     */
+    public Boolean isAnyVideoDownloadingInSubSection(DataCallback<Boolean> callback, String courseId,
+                                                     String section, String subSection);
     
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/IDatabaseImpl.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/IDatabaseImpl.java
@@ -564,4 +564,36 @@ class IDatabaseImpl extends IDatabaseBaseImpl implements IDatabase {
         });
         return enqueue(op);
     }
+
+    @Override
+    public Boolean isAnyVideoDownloadingInCourse(final DataCallback<Boolean> callback, String courseId) {
+        DbOperationExists op = new DbOperationExists(false,DbStructure.Table.DOWNLOADS, null,
+                DbStructure.Column.EID + "=? AND "+ DbStructure.Column.USERNAME + "=? AND "
+                        + DbStructure.Column.DOWNLOADED + "=?",
+                new String[] {courseId, username, String.valueOf(DownloadedState.DOWNLOADING.ordinal()) }, null);
+        op.setCallback(callback);
+        return enqueue(op);
+    }
+
+    @Override
+    public Boolean isAnyVideoDownloadingInSection(final DataCallback<Boolean> callback, String courseId, String section) {
+        DbOperationExists op = new DbOperationExists(false,DbStructure.Table.DOWNLOADS, null,
+                DbStructure.Column.EID + "=? AND "+ DbStructure.Column.CHAPTER + "=? AND "+
+                DbStructure.Column.USERNAME + "=? AND "+ DbStructure.Column.DOWNLOADED + "=?",
+                new String[] {courseId, section, username, String.valueOf(DownloadedState.DOWNLOADING.ordinal()) }, null);
+        op.setCallback(callback);
+        return enqueue(op);
+    }
+
+    @Override
+    public Boolean isAnyVideoDownloadingInSubSection(final DataCallback<Boolean> callback, String courseId,
+                                                     String section, String subSection) {
+        DbOperationExists op = new DbOperationExists(false,DbStructure.Table.DOWNLOADS, null,
+                DbStructure.Column.EID + "=? AND "+ DbStructure.Column.CHAPTER + "=? AND "+
+                        DbStructure.Column.SECTION + "=? AND "+ DbStructure.Column.USERNAME + "=? AND "+
+                        DbStructure.Column.DOWNLOADED + "=?",
+                new String[] {courseId, section, subSection, username, String.valueOf(DownloadedState.DOWNLOADING.ordinal()) }, null);
+        op.setCallback(callback);
+        return enqueue(op);
+    }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
@@ -800,10 +800,12 @@ public class VideoListFragment extends Fragment {
             if (msg.what == MSG_UPDATE_PROGRESS) {
                 if (isActivityStarted()) {
                     if (!AppConstants.offline_flag) {
-                        if (adapter != null) {
-                            adapter.setSelectedPosition(playingVideoIndex);
-                            adapter.notifyDataSetChanged();
-                            logger.debug("Download list reloaded");
+                        if (adapter != null && enrollment!=null && chapterName!=null && lecture!=null) {
+                            if(db.isAnyVideoDownloadingInSubSection(null, enrollment.getCourse().getId(), chapterName, lecture.name)){
+                                adapter.setSelectedPosition(playingVideoIndex);
+                                adapter.notifyDataSetChanged();
+                                logger.debug("Download list reloaded");
+                            }
                         }
                         sendEmptyMessageDelayed(MSG_UPDATE_PROGRESS, 3000);
                     }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseChapterListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseChapterListFragment.java
@@ -121,7 +121,6 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
             } catch (Exception ex) {
                 logger.error(ex);
             }
-
         }
 
         chapterListView = (ListView) view
@@ -481,13 +480,14 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment implemen
     private final Handler handler = new Handler() {
         public void handleMessage(android.os.Message msg) {
             if (msg.what == MSG_UPDATE_PROGRESS) {
-                if (isActivityStarted()) {
-                    if (!AppConstants.offline_flag) {
-                        if (adapter != null) {
-                            adapter.notifyDataSetChanged();
+                if (isActivityStarted()){
+                    if(!AppConstants.offline_flag) {
+                        if (adapter != null && enrollment != null) {
+                            if (db.isAnyVideoDownloadingInCourse(null, enrollment.getCourse().getId()))
+                                adapter.notifyDataSetChanged();
                         }
-                        sendEmptyMessageDelayed(MSG_UPDATE_PROGRESS, 3000);
                     }
+                    sendEmptyMessageDelayed(MSG_UPDATE_PROGRESS, 3000);
                 }
             }
         }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseLectureListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseLectureListActivity.java
@@ -46,6 +46,7 @@ public class CourseLectureListActivity extends BaseFragmentActivity {
     private boolean isActivityVisible;
     private static final int MSG_UPDATE_PROGRESS = 1026;
     private EnrolledCoursesResponse enrollment;
+    private SectionEntry chapter;
     private String activityTitle;
 
     @Override
@@ -165,7 +166,7 @@ public class CourseLectureListActivity extends BaseFragmentActivity {
 
 
     private void loadData() {
-        SectionEntry chapter = (SectionEntry) getIntent().getSerializableExtra("lecture");
+        chapter = (SectionEntry) getIntent().getSerializableExtra("lecture");
         setTitle(chapter.chapter);
         activityTitle = chapter.chapter;
 
@@ -354,13 +355,15 @@ public class CourseLectureListActivity extends BaseFragmentActivity {
     private final Handler handler = new Handler() {
         public void handleMessage(android.os.Message msg) {
             if (msg.what == MSG_UPDATE_PROGRESS) {
-                if (isActivityStarted()) {
-                    if (!AppConstants.offline_flag) {
-                        if (adapter != null) {
-                            adapter.notifyDataSetChanged();
+                if (isActivityStarted()){
+                    if(!AppConstants.offline_flag) {
+                        if (adapter != null && chapter != null && enrollment != null) {
+                            if (db.isAnyVideoDownloadingInSection(null, enrollment.getCourse().getId(), chapter.chapter)){
+                                adapter.notifyDataSetChanged();
+                            }
                         }
-                        sendEmptyMessageDelayed(MSG_UPDATE_PROGRESS, 3000);
                     }
+                    sendEmptyMessageDelayed(MSG_UPDATE_PROGRESS, 3000);
                 }
             }
         }


### PR DESCRIPTION
The section/subsection/video listing was always being notified and reloaded even when there is no download in progress in the whole course/section/subsection respectively. This has been handled to reload only if downloading is in progress. 

Please review - @rohan-dhamal-clarice @hanningni @aleffert 

JIRA: https://openedx.atlassian.net/browse/MOB-1571