### PR TITLE
Apply checks for path id not being null

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
@@ -178,8 +178,11 @@ public class FindCoursesBaseActivity extends BaseFragmentActivity
 
     @Override
     public void onClickCourseInfo(String pathId) {
-        logger.debug("PathId" +pathId);
-        Router.getInstance().showCourseInfo(this, pathId);
+        //If Path id is not null or empty then call CourseInfoActivity
+        if(pathId!=null && !pathId.isEmpty()){
+            logger.debug("PathId" +pathId);
+            Router.getInstance().showCourseInfo(this, pathId);
+        }
     }
 
     @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
@@ -19,6 +19,7 @@ import org.edx.mobile.task.EnrollForCourseTask;
 import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.BrowserUtil;
 import org.edx.mobile.util.NetworkUtil;
+import org.edx.mobile.util.StringUtil;
 import org.edx.mobile.view.Router;
 import org.edx.mobile.view.custom.ETextView;
 import org.edx.mobile.view.custom.URLInterceptorWebViewClient;
@@ -179,7 +180,7 @@ public class FindCoursesBaseActivity extends BaseFragmentActivity
     @Override
     public void onClickCourseInfo(String pathId) {
         //If Path id is not null or empty then call CourseInfoActivity
-        if(pathId!=null && !pathId.isEmpty()){
+        if(!StringUtil.isStringEmpty(pathId)){
             logger.debug("PathId" +pathId);
             Router.getInstance().showCourseInfo(this, pathId);
         }

--- a/VideoLocker/src/main/java/org/edx/mobile/util/StringUtil.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/StringUtil.java
@@ -1,0 +1,16 @@
+package org.edx.mobile.util;
+
+public class StringUtil {
+
+    /**
+     * Returns false if passed string is null or empty
+     * @param text
+     * @return
+     */
+    public static boolean isStringEmpty(String text) {
+        if (text == null || text.isEmpty()){
+            return false;
+        }
+        return true;
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
@@ -185,7 +185,7 @@ public abstract class URLInterceptorWebViewClient extends WebViewClient {
                 }
 
                 //String pathId = strUrl.replace(URL_TYPE_COURSE_INFO, "").trim();
-                if (pathId.isEmpty()) {
+                if (pathId==null || pathId.isEmpty()) {
                     return false;
                 }
 


### PR DESCRIPTION
There was a crash in Fabric which was due to null value being passed to the strings replace function. I have applied logical checks as I was unable to reproduce the issue.

Please review- @rohan-dhamal-clarice @hanningni @aleffert 

JIRA: https://openedx.atlassian.net/browse/MOB-1660
Fabric - https://fabric.io/edx-inc/android/apps/org.edx.mobile/issues/550a15315141dcfd8f2a1589