### PR TITLE
Set current playing videoId as null for the adapter on Tab switch

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyRecentVideosFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyRecentVideosFragment.java
@@ -758,6 +758,7 @@ public class MyRecentVideosFragment extends MyVideosBaseFragment {
     public void reloadList() {
         if(getView()!=null){
             addToRecentAdapter(getView());
+            notifyAdapter();
         }
     }
 
@@ -807,4 +808,14 @@ public class MyRecentVideosFragment extends MyVideosBaseFragment {
         PrefManager prefManager = new PrefManager(getActivity(), PrefManager.Pref.LOGIN);
         return prefManager.getCurrentUserProfile();
     }
+
+    /**
+     * Set the current playing videoId as null in adapter
+     */
+    public void setCurrentPlayingVideoIdAsNull(){
+        if(adapter!=null){
+            adapter.setVideoId(null);
+        }
+    }
+
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyVideosTabActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyVideosTabActivity.java
@@ -300,6 +300,10 @@ public class MyVideosTabActivity extends PlayerActivity implements VideoListCall
                     }
                     if(playerFragment!=null){
                         playerFragment.unlockOrientation();
+                    }else{
+                        //Set the current playing videoId as null to the adapter only if tab switch was done
+                        //not on orientation change during the video was being played
+                        recentVideosFragment.setCurrentPlayingVideoIdAsNull();
                     }
                     pushFragments(tabId, recentVideosFragment);
                     if(recentVideosFragment!=null){


### PR DESCRIPTION
There was an issue where the last playing video was remaining selected on tab change from Recent Videos -> All Videos -> Recent Videos. This issue has been fixed.

Please review - @rohan-dhamal-clarice @hanningni 