### PR TITLE
Check if the SectionItemInterface is of type DownloadEntry before casting

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
@@ -410,11 +410,12 @@ public class VideoListFragment extends MyVideosBaseFragment {
                 public void onItemClicked(SectionItemInterface model,
                         int position) {
                     if (!AppConstants.myVideosDeleteMode) {
-                        DownloadEntry downloadEntry = (DownloadEntry) model;
-                        if ( downloadEntry.isVideoForWebOnly ){
-                            Toast.makeText(getActivity(), R.string.video_only_on_web_short, Toast.LENGTH_SHORT).show();
-                        }
+                        //Check if the model is a DownloadEntry
                         if (model.isDownload()) {
+                            DownloadEntry downloadEntry = (DownloadEntry) model;
+                            if ( downloadEntry.isVideoForWebOnly ){
+                                Toast.makeText(getActivity(), R.string.video_only_on_web_short, Toast.LENGTH_SHORT).show();
+                            }
                             if (downloadEntry.isDownloaded()) {
                                 adapter.setVideoId(downloadEntry.videoId);
                                 // hide delete panel first, so that multiple-tap is blocked


### PR DESCRIPTION
A crash was occurring if user clicked on on the Section name in the Video Listing in My Videos - > All Videos -> Select a Course. 
This issue has been fixed

Please review  - @rohan-dhamal-clarice @hanningni @aleffert 

Fabric: https://fabric.io/edx-inc/android/apps/org.edx.mobile/issues/55150c385141dcfd8f408439