### PR TITLE
Add null checks before using context in prefmanager

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
@@ -89,8 +89,11 @@ public class PrefManager {
      * @return boolean
      */
     public boolean getBoolean(String key, boolean defaultValue) {
-        return context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
-                .getBoolean(key, defaultValue);
+        if(context!=null) {
+            return context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
+                    .getBoolean(key, defaultValue);
+        }
+        return defaultValue;
     }
     
     /**
@@ -99,8 +102,11 @@ public class PrefManager {
      * @return long
      */
     public long getLong(String key) {
-        return context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
-                .getLong(key, -1);
+        if(context!=null){
+            return context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
+                    .getLong(key, -1);
+        }
+        return -1;
     }
     
     /**
@@ -120,8 +126,11 @@ public class PrefManager {
      * @return float
      */
     public float getFloat(String key, float defaultValue) {
-        return context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
-                .getFloat(key, defaultValue);
+        if(context!=null){
+            return context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
+                    .getFloat(key, defaultValue);
+        }
+        return defaultValue;
     }
 
     /**


### PR DESCRIPTION
A crash was reported in Fabric of null pointer exception for context in PrefManager while calling <code>getBoolean()</code>. 
I have added null checks.

Please review - @hanningni @rohan-dhamal-clarice 

JIRA: https://openedx.atlassian.net/browse/MOB-1663
Fabric - https://fabric.io/edx-inc/android/apps/org.edx.mobile/issues/550b0c895141dcfd8f2c21eb