### PR TITLE
Add null check before calling GroupSummaryActivity

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/GroupsListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/GroupsListFragment.java
@@ -70,9 +70,11 @@ public class GroupsListFragment extends Fragment implements SocialProvider.Callb
     private ISegment segIO;
 
     private void launchGroup(SocialGroup group){
-        Intent intent = new Intent(getActivity(), GroupSummaryActivity.class);
-        intent.putExtra(GroupSummaryActivity.EXTRA_GROUP, group);
-        startActivityForResult(intent, REQUEST_GROUP_SUMMARY);
+        if(group!=null){
+            Intent intent = new Intent(getActivity(), GroupSummaryActivity.class);
+            intent.putExtra(GroupSummaryActivity.EXTRA_GROUP, group);
+            startActivityForResult(intent, REQUEST_GROUP_SUMMARY);
+        }
     }
 
     @Override


### PR DESCRIPTION
An Illegal exception is thrown if the Group is null in GroupSummaryActivity. I have added null check for group before calling GroupSummaryActivity.

Please review - @hanningni @rohan-dhamal-clarice 

JIRA: https://openedx.atlassian.net/browse/MOB-1669

Fabric- https://fabric.io/edx-inc/android/apps/org.edx.mobile/issues/550c5fe05141dcfd8f2eef2a