### PR TITLE
Check if device is on zero rated carrier before showing submit feedback

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/util/EmailUtil.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/EmailUtil.java
@@ -1,17 +1,40 @@
 package org.edx.mobile.util;
 
-import android.content.Context;
 import android.content.Intent;
+import android.support.v4.app.FragmentActivity;
 import android.widget.Toast;
 import org.edx.mobile.R;
 import org.edx.mobile.logger.Logger;
+import org.edx.mobile.view.dialog.IDialogCallback;
 
 public class EmailUtil {
 
     private static final Logger logger = new Logger(EmailUtil.class.getName());
 
-    public static void sendEmail(Context context, String to, String subject,
-            String email) {
+    public static void sendEmail(final FragmentActivity activityContext, final String to,
+                                 final String subject, final String email) {
+        // verify if the app is running on zero-rated mobile data?
+        if (NetworkUtil.isConnectedMobile(activityContext) && NetworkUtil.isOnZeroRatedNetwork(activityContext)) {
+            // inform user they may get charged for sending email
+            IDialogCallback callback = new IDialogCallback() {
+                @Override
+                public void onPositiveClicked() {
+                    openEmailClient(activityContext, to, subject, email);
+                }
+
+                @Override
+                public void onNegativeClicked() {
+                }
+            };
+
+            MediaConsentUtils.showLeavingAppDataDialog(activityContext, callback);
+        } else {
+            openEmailClient(activityContext, to, subject, email);
+        }
+    }
+
+    private static void openEmailClient(FragmentActivity activityContext, String to, String subject,
+                                        String email){
         Intent email_intent = new Intent(Intent.ACTION_SEND);
         email_intent.putExtra(Intent.EXTRA_EMAIL, new String[] { to });
         email_intent.putExtra(Intent.EXTRA_SUBJECT, subject);
@@ -21,15 +44,17 @@ public class EmailUtil {
         try {
             email_intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
-            // add flag to make sure this call works from non-activity context
-            Intent targetIntent = Intent.createChooser(email_intent,
-                    context.getString(R.string.email_chooser_header));
-            targetIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            if(activityContext!=null){
+                // add flag to make sure this call works from non-activity context
+                Intent targetIntent = Intent.createChooser(email_intent,
+                        activityContext.getString(R.string.email_chooser_header));
+                targetIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                activityContext.startActivity(targetIntent);
+            }
 
-            context.startActivity(targetIntent);
         } catch (android.content.ActivityNotFoundException ex) {
             //There is no activity which can perform the intended share Intent
-            Toast.makeText(context, context.getString(R.string.email_client_not_present),
+            Toast.makeText(activityContext, activityContext.getString(R.string.email_client_not_present),
                     Toast.LENGTH_SHORT)
                     .show();
             logger.error(ex);


### PR DESCRIPTION
As the submit feedback opens outside the edx application, we needed to add  a check before showing email options. This has been handled.

Please review - @hanningni @rohan-dhamal-clarice 

JIRA: https://openedx.atlassian.net/browse/MOB-1620