### PR TITLE
Use custom TextView instead of default TextView for Empty Announcements

### DIFF
--- a/VideoLocker/res/layout/fragment_course_combined_info.xml
+++ b/VideoLocker/res/layout/fragment_course_combined_info.xml
@@ -329,7 +329,7 @@
                 style="@style/api_progress_style"
                 android:visibility="gone" />
 
-            <TextView
+            <org.edx.mobile.view.custom.ETextView
                 android:id="@+id/no_announcement_tv"
                 style="@style/bold_text"
                 android:layout_marginTop="80dp"


### PR DESCRIPTION
The font type for Empty Announcements was not correct. This has been fixed.

Please review - @rohan-dhamal-clarice @hanningni 

JIRA: https://openedx.atlassian.net/browse/MOB-1698