### PR TITLE
Notification: refresh & payload

### DIFF
--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -454,7 +454,7 @@
 
     <!-- Notification related -->
     <!-- Template for notification title -->
-    <string name="COURSE_ANNOUNCEMENT_NOTIFICATION_TITLE">Course Announcement</string>
+    <string name="COURSE_ANNOUNCEMENT_NOTIFICATION_TITLE">New Announcement</string>
     <!-- toggle between subscribe and unsubscribe to course announcement -->
     <string name="notification_toggle">Notifications</string>
 </resources>

--- a/VideoLocker/src/main/java/org/edx/mobile/module/notification/BaseNotificationPayload.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/notification/BaseNotificationPayload.java
@@ -1,18 +1,43 @@
 package org.edx.mobile.module.notification;
 
+import android.text.TextUtils;
+
 import com.google.gson.annotations.SerializedName;
 
 /**
  * Created by hanning on 4/17/15.
  */
 public abstract class BaseNotificationPayload {
-    private @SerializedName("payload_version") String payloadVersion;
+    private @SerializedName("action") String action;
+    private @SerializedName("push_hash") String pushHash;
+    private @SerializedName("notification-id") String notificationId;
 
-    public String getPayloadVersion() {
-        return payloadVersion;
+    public String getAction() {
+        return action;
     }
 
-    public void setPayloadVersion(String payloadVersion) {
-        this.payloadVersion = payloadVersion;
+    public void setAction(String action) {
+        this.action = action;
     }
+
+    public String getPushHash() {
+        return pushHash;
+    }
+
+    public void setPushHash(String pushHash) {
+        this.pushHash = pushHash;
+    }
+
+    public String getNotificationId() {
+        return notificationId;
+    }
+
+    public void setNotificationId(String notificationId) {
+        this.notificationId = notificationId;
+    }
+
+    public String getIdentifier(){
+        return TextUtils.isEmpty(notificationId) ? pushHash : notificationId;
+    }
+
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/notification/CourseUpdateNotificationPayload.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/notification/CourseUpdateNotificationPayload.java
@@ -10,75 +10,30 @@ import java.util.List;
 
 /**
 {
-        "title": "Course Announcement",
-        "loc-args": [
-        "VAL video"
-        ],
-        "action-loc-key": "VIEW_BUTTON",
-        "loc-key": "COURSE_ANNOUNCEMENT_NOTIFICATION_BODY",
-        "action": "course.announcement",
-        "title-loc-key": "COURSE_ANNOUNCEMENT_NOTIFICATION_TITLE",
-        "title-loc-args": []
-        }
+     "action": "course.announcement",
+     "course-name": "edX Demonstration Course",
+     "course-id": "edX/DemoX/Demo_Course",
+     "push_hash": "d41d8cd98f00b204e9800998ecf8427e",
+     "aps": {
+     "content-available": 1,
+     "alert": ""
+     },
+     "notification-id": "742e9881-e224-4ba9-b4d0-8a1f8b62b276"
+}
  **/
 public class CourseUpdateNotificationPayload extends BaseNotificationPayload{
 
-    private @SerializedName("push_hash") String pushHash;
-    private @SerializedName("loc-args") List<String> locArgs;
-    private @SerializedName("action-loc-key") String actionLocKey;
-    private @SerializedName("loc-key") String localKey;
-    private @SerializedName("action") String action;
-    private @SerializedName("title-loc-key") String titleLocKey;
-    private @SerializedName("title-loc-args") List<String> titleLocArgs;
+
+    private @SerializedName("course-name") String courseName;
     private @SerializedName("course-id") String courseId;
-    private @SerializedName("alert") String alert;
 
-    public List<String> getLocArgs() {
-        return locArgs;
+
+    public String getCourseName() {
+        return courseName;
     }
 
-    public void setLocArgs(List<String> locArgs) {
-        this.locArgs = locArgs;
-    }
-
-    public String getActionLocKey() {
-        return actionLocKey;
-    }
-
-    public void setActionLocKey(String actionLocKey) {
-        this.actionLocKey = actionLocKey;
-    }
-
-    public String getLocalKey() {
-        return localKey;
-    }
-
-    public void setLocalKey(String localKey) {
-        this.localKey = localKey;
-    }
-
-    public String getAction() {
-        return action;
-    }
-
-    public void setAction(String action) {
-        this.action = action;
-    }
-
-    public String getTitleLocKey() {
-        return titleLocKey;
-    }
-
-    public void setTitleLocKey(String titleLocKey) {
-        this.titleLocKey = titleLocKey;
-    }
-
-    public List<String> getTitleLocArgs() {
-        return titleLocArgs;
-    }
-
-    public void setTitleLocArgs(List<String> titleLocArgs) {
-        this.titleLocArgs = titleLocArgs;
+    public void setCourseName(String courseName) {
+        this.courseName = courseName;
     }
 
     public String getCourseId() {
@@ -89,21 +44,6 @@ public class CourseUpdateNotificationPayload extends BaseNotificationPayload{
         this.courseId = courseId;
     }
 
-    public String getAlert() {
-        return alert;
-    }
-
-    public void setAlert(String alert) {
-        this.alert = alert;
-    }
-
-    public String getPushHash() {
-        return pushHash;
-    }
-
-    public void setPushHash(String pushHash) {
-        this.pushHash = pushHash;
-    }
 
     public boolean isValid(){
         return !TextUtils.isEmpty(courseId);

--- a/VideoLocker/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
@@ -238,7 +238,43 @@ public class PrefManager {
         }
         return raw;
     }
-    
+
+    public static class AppInfoPrefManager extends PrefManager{
+        public AppInfoPrefManager(Context context){
+            super(context, PrefManager.Pref.APP_INFO);
+        }
+        public long getAppVersionCode(){
+            return getLong(Key.APP_VERSION_CODE);
+        }
+        public void setAppVersionCode(long code){
+            super.put(Key.APP_VERSION_CODE, code);
+        }
+        public String getAppVersionName(){
+            return getString(Key.APP_VERSION_NAME);
+        }
+        public void setAppVersionName(String code){
+            super.put(Key.APP_VERSION_NAME, code);
+        }
+        public boolean isNotificationEnabled(){
+            return getBoolean(Key.NOTIFICATION, false);
+        }
+        public void setNotificationEnabled(boolean enabled){
+            super.put(Key.NOTIFICATION, enabled);
+        }
+        public boolean isAppUpgradeNeedSyncWithParse(){
+            return getBoolean(Key.AppUpgradeNeedSyncWithParse, false);
+        }
+        public void setAppUpgradeNeedSyncWithParse(boolean enabled){
+            super.put(Key.AppUpgradeNeedSyncWithParse, enabled);
+        }
+        public String getPrevNotificationHashKey(){
+            return getString(Key.AppNotificationPushHash);
+        }
+        public void setPrevNotificationHashKey(String code){
+            super.put(Key.AppNotificationPushHash, code);
+        }
+    }
+
     /**
      * Contains preference name constants.
      *
@@ -273,9 +309,12 @@ public class PrefManager {
         public static final String SEGMENT_KEY_BACKEND = "segment_backend";
         public static final String SHARE_COURSES = "share_courses";
         public static final String SPEED_TEST_KBPS = "speed_test_kbps";
-        public static final String APP_VERSION = "app_version_name";
+        public static final String APP_VERSION_NAME = "app_version_name";
+        public static final String APP_VERSION_CODE = "app_version_code";
         public static final String NOTIFICATION_PROFILE_JSON = "notification_profile_json";
-
+        private static final String NOTIFICATION = "notification";
+        public static final String AppNotificationPushHash = "AppNotificationPushHash";
+        public static final String AppUpgradeNeedSyncWithParse = "AppUpgradeNeedSyncWithParse";
     }
     
     public static final class Value {

--- a/VideoLocker/src/main/java/org/edx/mobile/module/storage/Storage.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/storage/Storage.java
@@ -457,11 +457,12 @@ public class Storage implements IStorage {
      * If progress of any of the downloads is 100%, then marks the video as DOWNLOADED.
      */
     public void repairDownloadCompletionData() {
-        PrefManager pref = new PrefManager(context, PrefManager.Pref.APP_INFO);
-        String lastSavedVersionName = pref.getString(PrefManager.Key.APP_VERSION);
-        if (lastSavedVersionName == null || !lastSavedVersionName.equals(PropertyUtil.getManifestVersionName(context))) {
+        PrefManager.AppInfoPrefManager pref = new PrefManager.AppInfoPrefManager(context);
+        String lastSavedVersionName = pref.getAppVersionName();
+        String curVersionName = PropertyUtil.getManifestVersionName(context);
+        if (lastSavedVersionName == null || !lastSavedVersionName.equals(curVersionName)) {
             // current version not matching with the last saved version
-            pref.put(PrefManager.Key.APP_VERSION, PropertyUtil.getManifestVersionName(context));
+            pref.setAppVersionName(curVersionName);
 
             // attempt to repair the data
             Thread maintenanceThread = new Thread(new Runnable() {

--- a/VideoLocker/src/main/java/org/edx/mobile/util/PropertyUtil.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/PropertyUtil.java
@@ -22,4 +22,19 @@ public class PropertyUtil {
         }
         return null;
     }
+
+    /**
+     * check version number is a better approach comparing with Version Name.
+     * @return Application's version code from the {@code PackageManager}.
+     */
+    public static int getManifestVersionCode(Context context) {
+        try {
+            PackageInfo packageInfo = context.getPackageManager()
+                    .getPackageInfo(context.getPackageName(), 0);
+            return packageInfo.versionCode;
+        } catch (PackageManager.NameNotFoundException e) {
+            // should never happen
+            return -1;
+        }
+    }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDetailTabActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDetailTabActivity.java
@@ -91,6 +91,8 @@ public class CourseDetailTabActivity extends BaseTabActivity {
             }
 
         }catch(Exception ex){
+            Router.getInstance().showMyCourses(this);
+            finish();
             logger.error(ex);
         }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyCoursesListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyCoursesListActivity.java
@@ -13,6 +13,7 @@ import org.edx.mobile.interfaces.NetworkObserver;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.module.db.DataCallback;
 import org.edx.mobile.module.facebook.IUiLifecycleHelper;
+import org.edx.mobile.module.notification.UserNotificationManager;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.social.facebook.FacebookProvider;
 import org.edx.mobile.util.AppConstants;
@@ -120,7 +121,7 @@ public class MyCoursesListActivity extends BaseTabActivity implements NetworkObs
         invalidateOptionsMenu();
         uiLifecycleHelper.onResume();
         changeSocialMode(new FacebookProvider().isLoggedIn());
-
+        UserNotificationManager.getInstance().checkAppUpgrade();
     }
 
     @Override


### PR DESCRIPTION
@aleffert  please review.


1.  to handle notification payload change.
2.  to avoid duplicated notification events.