### PR TITLE
disable resync with parse for app upgrade

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/module/notification/UserNotificationManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/notification/UserNotificationManager.java
@@ -67,10 +67,14 @@ public class UserNotificationManager {
             return;
         PrefManager.AppInfoPrefManager pmanager =
                 new PrefManager.AppInfoPrefManager(MainApplication.instance());
-        if ( pmanager.isAppUpgradeNeedSyncWithParse() ){
-            pmanager.setAppUpgradeNeedSyncWithParse(false);
-            resubscribeAll();
-        }
+        //TODO - not sure if we need to resync with parse server.
+        //there is a bug that parse server can send duplicated message
+        //if user uninstall and reinstall the app. but we handle it
+        //already by checking the notification-id. 
+//        if ( pmanager.isAppUpgradeNeedSyncWithParse() ){
+//            pmanager.setAppUpgradeNeedSyncWithParse(false);
+//            resubscribeAll();
+//        }
         if ( pmanager.isAppSettingNeedSyncWithParse() ){
             pmanager.setAppSettingNeedSyncWithParse(false);
             ParseHandleHelper.tryToSaveLanguageSetting();


### PR DESCRIPTION
 disable resync with parse server for app appgrade.  app will subscribe to parse when my course view is refreshed