### PR TITLE
Remove parser receiver from manifest to avoid crash when parse is dis…

### DIFF
--- a/VideoLocker/AndroidManifest.xml
+++ b/VideoLocker/AndroidManifest.xml
@@ -270,7 +270,8 @@
         <!--   Parse Setup -->
         <!--  https://www.parse.com/apps/quickstart#parse_push/android/existing  -->
         <service android:name="com.parse.PushService" />
-        <receiver android:name="com.parse.ParseBroadcastReceiver">
+        <!-- we have to add a level of indirection to avoid crash as parse maybe disabled by setting -->
+        <receiver android:name="org.edx.mobile.module.notification.EdxParseBroadcastReceiver">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.USER_PRESENT" />

--- a/VideoLocker/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -36,7 +36,7 @@ import io.fabric.sdk.android.Fabric;
  */
 public class MainApplication extends Application{
     //FIXME - temporary solution
-    public static final boolean Q4_ASSESSMENT_FLAG = true;
+    public static final boolean Q4_ASSESSMENT_FLAG = false;
     //FIXME - temporary solution
     public static final boolean ForumEnabled = false;
 

--- a/VideoLocker/src/main/java/org/edx/mobile/module/notification/EdxParseBroadcastReceiver.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/notification/EdxParseBroadcastReceiver.java
@@ -1,0 +1,24 @@
+package org.edx.mobile.module.notification;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import org.edx.mobile.util.Config;
+
+/**
+ * we can not put ParseBroadcastReceiver directly into manifest file as
+ * it will cause random crash when the parse notification is disabled.
+ */
+public class EdxParseBroadcastReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if ( Config.getInstance().isNotificationEnabled() ) {
+            Config.ParseNotificationConfig parseNotificationConfig =
+                Config.getInstance().getParseNotificationConfig();
+            if (parseNotificationConfig.isEnabled()) {
+                new com.parse.ParseBroadcastReceiver().onReceive(context, intent);
+            }
+        }
+    }
+}


### PR DESCRIPTION
@aleffert  please review.

 if the notification flag is turned off and app will crash occasionally.   as ParseBroadcastReceiver is registered on device reboot and it is specified in the manifest file. 