### PR TITLE
Fix issue with wrong LayoutParams in popup menu helper

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/custom/popup/menu/MenuPopupHelper.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/custom/popup/menu/MenuPopupHelper.java
@@ -5,7 +5,7 @@ package org.edx.mobile.view.custom.popup.menu;
  * the AOSP. It uses the appcompat implementation because it exposes it's
  * internal classes, so we only need to duplicate minimal code. We use
  * a custom attribute set to define a fixed width and other things, and
- * a custom adapter with it's own layout that automatically expends the
+ * a custom adapter with it's own layout that automatically expands the
  * first level of submenus in order to support headers.
  *
  * Copyright (C) 2010 The Android Open Source Project
@@ -450,9 +450,7 @@ class MenuPopupHelper implements AdapterView.OnItemClickListener, View.OnKeyList
                         view = convertView;
                     } else {
                         view = new View(mContext);
-                     //   view.setLayoutParams(new ViewGroup.LayoutParams(
-                       //         ViewGroup.LayoutParams.MATCH_PARENT,
-                         //       mPopupPadding - mPopupItemVerticalPadding));
+                        view.setMinimumHeight(mPopupPadding - mPopupItemVerticalPadding);
                     }
                     return view;
                 } default: {


### PR DESCRIPTION
`ListView` had a bug where it could not handle the base `ViewGroup` `LayoutParams` in it's items without throwing a `ClassCastException`, that was fixed in Lollipop. The `generateLayoutParams()` method definition in `ViewGroup` that takes an existing base `LayoutParams` instance is restricted to protected access level, while only the method that takes an `AttributeSet` as parameter is publicly exposed. Therefore, in order to generate the correct `LayoutParams`, we could either create an XML layout
consisting only of a bare `View` just to acquire the correct `LayoutParams` in a generic manner, or hardcode it to use `ListView.LayoutParams` explicitly. I opted to just replace the `LayoutParams` usage with setting the minimum height instead, which works just as well, although it may not be the semantically correct attribute to use.

A minor spelling error in the class header comment is also fixed.