### PR TITLE
Creating a special application class for testing disabling unnecessary components

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -43,7 +43,7 @@ public class MainApplication extends MultiDexApplication {
 
     protected final Logger logger = new Logger(getClass().getName());
 
-    private static MainApplication application;
+    protected static MainApplication application;
 
     public static final MainApplication instance(){
         return application;
@@ -145,7 +145,7 @@ public class MainApplication extends MultiDexApplication {
      * Create the image cache. Uses Memory Cache by default.
      * Change to Disk for a Disk based LRU implementation.
      */
-    private void createImageCache(){
+    protected void createImageCache(){
         int DISK_IMAGECACHE_SIZE = 1024*1024*10;
         CompressFormat DISK_IMAGECACHE_COMPRESS_FORMAT = CompressFormat.PNG;
         //PNG is lossless so quality is ignored but must be provided

--- a/VideoLocker/src/test/java/org/edx/mobile/test/BaseTestCase.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/BaseTestCase.java
@@ -16,7 +16,7 @@ import org.robolectric.annotation.Config;
  */
 @Ignore
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, application = TestApplication.class)
 public class BaseTestCase {
 
     protected final Logger logger = new Logger(getClass().getName());

--- a/VideoLocker/src/test/java/org/edx/mobile/test/TestApplication.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/TestApplication.java
@@ -1,0 +1,50 @@
+package org.edx.mobile.test;
+
+import org.edx.mobile.base.MainApplication;
+import org.edx.mobile.logger.Logger;
+import org.edx.mobile.module.analytics.SegmentFactory;
+import org.edx.mobile.util.Config;
+import org.edx.mobile.util.Environment;
+
+/**
+ * The {@link MainApplication} class is overridden for testing in
+ * order to only have the components enabled that are relevant to
+ * the tests.
+ *
+ * The following components are not enabled:
+ *
+ * - Application lifecycle callbacks.
+ *   This was used to detect to force the application to start
+ *   from the main screen when relaunched from the background,
+ *   which is not present in the current tests.
+ *
+ * - Crashlytics/Fabric crash reporting.
+ *
+ * - Facebook SDK intialization.
+ *
+ * - Parse notifications initialization and subscription.
+ *
+ * - Checking for application upgrades, and repairing download
+ *   statuses and clearing the web view cookie cache.
+ */
+public class TestApplication extends MainApplication {
+    @Override
+    public void onCreate() {
+        // initialize logger
+        Logger.init(this.getApplicationContext());
+
+        application = this;
+
+        // setup environment
+        Environment env = new Environment();
+        env.setupEnvironment(this.getApplicationContext());
+
+        // setup image cache
+        createImageCache();
+
+        // initialize SegmentIO
+        if (Config.getInstance().getSegmentConfig().isEnabled()) {
+            SegmentFactory.makeInstance(this);
+        }
+    }
+}

--- a/VideoLocker/src/test/java/org/edx/mobile/view/BaseFragmentActivityTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/BaseFragmentActivityTest.java
@@ -40,6 +40,7 @@ import org.edx.mobile.model.db.DownloadEntry;
 import org.edx.mobile.module.db.IDatabase;
 import org.edx.mobile.module.db.impl.DatabaseFactory;
 import org.edx.mobile.module.prefs.PrefManager;
+import org.edx.mobile.test.TestApplication;
 import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.view.dialog.WebViewDialogFragment;
@@ -63,7 +64,7 @@ import static org.junit.Assume.*;
 
 // TODO: Test network connectivity change events too, after we manage to mock them
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, application = TestApplication.class)
 public class BaseFragmentActivityTest {
     /**
      * Method for defining the subclass of {@link BaseFragmentActivity} that

--- a/VideoLocker/src/test/java/org/edx/mobile/view/CourseBaseActivityTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/CourseBaseActivityTest.java
@@ -13,6 +13,7 @@ import android.widget.TextView;
 import org.edx.mobile.BuildConfig;
 import org.edx.mobile.R;
 import org.edx.mobile.event.DownloadEvent;
+import org.edx.mobile.test.TestApplication;
 import org.edx.mobile.third_party.iconify.IconDrawable;
 import org.edx.mobile.third_party.iconify.Iconify;
 import org.junit.Ignore;
@@ -32,7 +33,7 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, application = TestApplication.class)
 public abstract class CourseBaseActivityTest extends BaseFragmentActivityTest {
     /**
      * Method for defining the subclass of {@link CourseBaseActivity} that

--- a/VideoLocker/src/test/java/org/edx/mobile/view/CourseOutlineActivityTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/CourseOutlineActivityTest.java
@@ -5,6 +5,7 @@ import android.support.v4.app.Fragment;
 
 import org.edx.mobile.BuildConfig;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
+import org.edx.mobile.test.TestApplication;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -16,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, application = TestApplication.class)
 public class CourseOutlineActivityTest extends CourseBaseActivityTest {
     /**
      * Method for defining the subclass of {@link CourseOutlineActivity} that

--- a/VideoLocker/src/test/java/org/edx/mobile/view/CourseUnitNavigationActivityTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/CourseUnitNavigationActivityTest.java
@@ -6,6 +6,7 @@ import android.view.View;
 
 import org.edx.mobile.BuildConfig;
 import org.edx.mobile.R;
+import org.edx.mobile.test.TestApplication;
 import org.edx.mobile.view.custom.DisableableViewPager;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -22,7 +23,7 @@ import static org.junit.Assert.*;
 // the demo sandbox to see this Activity, so I'm not writing tests for the
 // adapter interactions yet
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, application = TestApplication.class)
 public class CourseUnitNavigationActivityTest extends CourseBaseActivityTest {
     /**
      * Method for defining the subclass of {@link CourseUnitNavigationActivity}

--- a/VideoLocker/src/test/java/org/edx/mobile/view/CourseUnitVideoFragmentTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/CourseUnitVideoFragmentTest.java
@@ -16,6 +16,7 @@ import android.widget.TextView;
 
 import org.edx.mobile.BuildConfig;
 import org.edx.mobile.R;
+import org.edx.mobile.test.TestApplication;
 import org.edx.mobile.third_party.iconify.Iconify;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +37,7 @@ import static org.junit.Assume.assumeNotNull;
 // The SDK version needs to be lesser than Lollipop because of this
 // issue: https://github.com/robolectric/robolectric/issues/1810
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 19)
+@Config(constants = BuildConfig.class, application = TestApplication.class, sdk = 19)
 public class CourseUnitVideoFragmentTest {
     /**
      * Testing initialization

--- a/VideoLocker/src/test/java/org/edx/mobile/view/CourseUnitWebviewFragmentTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/CourseUnitWebviewFragmentTest.java
@@ -5,6 +5,7 @@ import android.webkit.WebView;
 
 import org.edx.mobile.BuildConfig;
 import org.edx.mobile.R;
+import org.edx.mobile.test.TestApplication;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
@@ -18,7 +19,7 @@ import static org.junit.Assert.*;
 // https://github.com/robolectric/robolectric/issues/793
 // We should add mock web server and test the handling later
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, application = TestApplication.class)
 public class CourseUnitWebviewFragmentTest {
     /**
      * Testing initialization


### PR DESCRIPTION
The following components have been removed from testing:

 - Application lifecycle callbacks. This was used to detect when the application was launched from the background while it was running, which will not happen in the current tests.
 - Crashlytics/Fabric crash reporting.
 - Facebook SDK intialization.
 - Parse notifications initialization and subscription.
 - Checking for application upgrades, and repairing download statuses and clearing the web view cookie cache.

See https://openedx.atlassian.net/browse/MA-821