### PR TITLE
Revert ignoring of ApiTests and SocialLoginTests

### DIFF
--- a/VideoLocker/src/test/java/org/edx/mobile/test/http/ApiTests.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/http/ApiTests.java
@@ -12,7 +12,7 @@ import org.edx.mobile.model.api.VideoResponseModel;
 import org.edx.mobile.module.registration.model.RegistrationDescription;
 import org.edx.mobile.test.BaseTestCase;
 import org.edx.mobile.util.Config;
-import org.junit.Ignore;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +30,6 @@ import static org.junit.Assert.*;
  * real webservice right now
  * 
  */
-@Ignore
 public class ApiTests extends HttpBaseTestCase {
 
 
@@ -39,6 +38,7 @@ public class ApiTests extends HttpBaseTestCase {
         super.setUp();
     }
     
+    @Test
     public void testSyncLastSubsection() throws Exception {
         if( shouldSkipTest ) return;
 
@@ -65,6 +65,7 @@ public class ApiTests extends HttpBaseTestCase {
         print("sync returned: " + model.last_visited_module_id);
     }
 
+    @Test
     public void testGetLastAccessedModule() throws Exception {
         if( shouldSkipTest ) return;
 
@@ -82,6 +83,7 @@ public class ApiTests extends HttpBaseTestCase {
     //  print(model.json);
     }
 
+    @Test
     public void testResetPassword() throws Exception {
         if( shouldSkipTest ) return;
 
@@ -92,6 +94,7 @@ public class ApiTests extends HttpBaseTestCase {
         print("test: finished: reset password");
     }
 
+    @Test
     public void testHandouts() throws Exception {
         if( shouldSkipTest ) return;
 
@@ -108,6 +111,7 @@ public class ApiTests extends HttpBaseTestCase {
         print(model.handouts_html);
     }
 
+    @Test
     public void testChannelId() throws Exception {
         if( shouldSkipTest ) return;
 
@@ -122,6 +126,7 @@ public class ApiTests extends HttpBaseTestCase {
         assertTrue(subscription_id != null);
     }
 
+    @Test
     public void testCourseStructure() throws Exception {
         if( shouldSkipTest ) return;
         login();
@@ -144,6 +149,7 @@ public class ApiTests extends HttpBaseTestCase {
         }
     }
 
+    @Test
     public void login() throws Exception {
         if( shouldSkipTest ) return;
         Config.TestAccountConfig config  = Config.getInstance().getTestAccountConfig();
@@ -158,6 +164,7 @@ public class ApiTests extends HttpBaseTestCase {
         assertNotNull(profile);
     }
 
+    @Test
     public void testGetAnnouncement() throws Exception {
         if( shouldSkipTest ) return;
 
@@ -176,6 +183,7 @@ public class ApiTests extends HttpBaseTestCase {
         }
     }
 
+    @Test
     public void testReadRegistrationDescription() throws Exception {
         if( shouldSkipTest ) return;
 
@@ -191,6 +199,7 @@ public class ApiTests extends HttpBaseTestCase {
         assertNotNull(form.getFields().get(0).getFieldType());
     }
 
+    @Test
     public void testEnrollInACourse() throws Exception {
         if( shouldSkipTest ) return;
 

--- a/VideoLocker/src/test/java/org/edx/mobile/test/http/SocialLoginTests.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/http/SocialLoginTests.java
@@ -6,7 +6,7 @@ import org.edx.mobile.http.Api;
 import org.edx.mobile.model.api.ProfileModel;
 import org.edx.mobile.test.BaseTestCase;
 import org.edx.mobile.util.Environment;
-import org.junit.Ignore;
+import org.junit.Test;
 import org.robolectric.RuntimeEnvironment;
 
 import static org.junit.Assert.*;
@@ -20,7 +20,6 @@ import static org.junit.Assert.*;
  * real webservice right now
  *
  */
-@Ignore
 public class SocialLoginTests extends HttpBaseTestCase  {
 
 
@@ -29,6 +28,7 @@ public class SocialLoginTests extends HttpBaseTestCase  {
         super.setUp();
     }
     
+    @Test
     public void testGetProfile() throws Exception {
         if ( shouldSkipTest ) return;
 


### PR DESCRIPTION
In #256 I added the `@Test` and `@Ignore` annotation as appropriate in the ported test suites. The `ApiTests` and `SocialLoginTests` classes were accidentally marked as ignored instead of testable. This commit reverts that mistake.