### PR TITLE
Fix alignment of the subtitle icon to RTL in course outline module

### DIFF
--- a/VideoLocker/res/layout/row_course_outline_list.xml
+++ b/VideoLocker/res/layout/row_course_outline_list.xml
@@ -72,6 +72,7 @@
                 android:id="@+id/row_subtitle_icon"
                 android:layout_width="35dp"
                 android:layout_height="35dp"
+                android:textDirection="locale"
                 android:gravity="center_vertical"
                 android:visibility="gone" />
         </LinearLayout>


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-832