### PR TITLE
extract course announcement page into a separate page

### DIFF
--- a/VideoLocker/AndroidManifest.xml
+++ b/VideoLocker/AndroidManifest.xml
@@ -193,6 +193,11 @@
             android:screenOrientation="portrait" />
 
         <activity
+            android:name="org.edx.mobile.view.CourseDetailInfoActivity"
+            android:label="@string/app_name"
+            android:screenOrientation="portrait" />
+
+        <activity
             android:name="org.edx.mobile.view.CreateGroupActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait" />

--- a/VideoLocker/res/drawable/left_arrow.xml
+++ b/VideoLocker/res/drawable/left_arrow.xml
@@ -1,0 +1,27 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android" >
+
+
+    <item android:top="20dp">
+        <rotate
+            android:fromDegrees="45"
+            android:toDegrees="45">
+            <shape android:shape="rectangle">
+                <size android:width="25dp" android:height="2dp"/>
+                <solid android:color="@android:color/white"/>
+            </shape>
+        </rotate>
+    </item>
+
+    <item android:bottom="20dp">
+        <rotate
+            android:fromDegrees="-45"
+            android:toDegrees="45">
+            <shape android:shape="rectangle">
+                <size android:width="25dp" android:height="2dp"/>
+                <solid android:color="@android:color/white"/>
+            </shape>
+        </rotate>
+    </item>
+
+
+</layer-list>

--- a/VideoLocker/res/layout/fragment_course_dashboard.xml
+++ b/VideoLocker/res/layout/fragment_course_dashboard.xml
@@ -40,7 +40,6 @@
             android:layout_height="wrap_content"
             style="@style/regular_text"
             android:textSize="13sp"
-            android:textAllCaps="true"
             tools:text="XX | xx | xxxxx" />
 
     </LinearLayout>

--- a/VideoLocker/res/values/styles.xml
+++ b/VideoLocker/res/values/styles.xml
@@ -30,6 +30,7 @@
         <item name="android:actionBarStyle">@style/MyActionBar</item>
         <!-- use window background for preview to avoid showing black screen -->
         <item name="android:windowBackground">@color/white</item>
+        <item name="android:homeAsUpIndicator">@drawable/left_arrow</item>
         <item name="android:actionButtonStyle">@style/ActionButtonStyle</item>
         <item name="android:titleTextStyle">@style/MyActionBarTitleText</item>
         <item name="android:popupMenuStyle">@style/CustomPopupMenu</item>
@@ -38,7 +39,7 @@
 
     <!-- we need to change the color of the drawer arrow toggle -->
     <style name="DrawerArrowStyle" parent="Widget.AppCompat.DrawerArrowToggle">
-         <item name="color">@color/edx_white</item>
+         <item name="color">@color/white</item>
     </style>
 
     <!-- Custom Preview Screen Theme -->

--- a/VideoLocker/src/main/java/org/edx/mobile/base/MyVideosBaseFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/MyVideosBaseFragment.java
@@ -71,7 +71,7 @@ public abstract class MyVideosBaseFragment extends Fragment {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         if ( courseData != null)
-            outState.putSerializable(Router.EXTRA_COURSE_DATA, courseData);
+            outState.putSerializable(Router.EXTRA_ENROLLMENT, courseData);
         if ( courseComponentId != null )
             outState.putString(Router.EXTRA_COURSE_COMPONENT_ID, courseComponentId);
         super.onSaveInstanceState(outState);
@@ -79,7 +79,7 @@ public abstract class MyVideosBaseFragment extends Fragment {
 
     protected void restore(Bundle savedInstanceState) {
         if (savedInstanceState != null) {
-            courseData = (EnrolledCoursesResponse) savedInstanceState.getSerializable(Router.EXTRA_COURSE_DATA);
+            courseData = (EnrolledCoursesResponse) savedInstanceState.getSerializable(Router.EXTRA_ENROLLMENT);
             courseComponentId = (String) savedInstanceState.getString(Router.EXTRA_COURSE_COMPONENT_ID);
         }
     }

--- a/VideoLocker/src/main/java/org/edx/mobile/model/api/CourseEntry.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/model/api/CourseEntry.java
@@ -2,14 +2,12 @@ package org.edx.mobile.model.api;
 
 import android.content.Context;
 
-import org.edx.mobile.R;
 import org.edx.mobile.http.Api;
 import org.edx.mobile.social.SocialMember;
 import org.edx.mobile.util.DateUtil;
 import org.edx.mobile.util.SocialUtils;
 
 import java.io.Serializable;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 
@@ -233,16 +231,9 @@ public class CourseEntry implements Serializable {
             detailBuilder.append( getNumber());
 
         }
-        if ( isStarted() && ! isEnded() &&  getEnd() != null){
-            if (detailBuilder.length() > 0){
-                detailBuilder.append(" | ");
-            }
-            SimpleDateFormat dateFormat = new SimpleDateFormat("MMMM dd");
-            Date endDate = DateUtil.convertToDate( getEnd());
-            detailBuilder.append(context.getString(R.string.label_ending_on));
-            detailBuilder.append(" - ");
-            detailBuilder.append(dateFormat.format(endDate));
-        }
+        //https://openedx.atlassian.net/browse/MA-858
+        //we remove the ending data for now
+
         return detailBuilder.toString();
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
@@ -112,7 +112,7 @@ public abstract  class CourseBaseActivity  extends BaseFragmentActivity implemen
     @Override
     public void onSaveInstanceState(Bundle outState) {
         if ( courseData != null)
-            outState.putSerializable(Router.EXTRA_COURSE_DATA, courseData);
+            outState.putSerializable(Router.EXTRA_ENROLLMENT, courseData);
         if ( courseComponentId != null )
             outState.putString(Router.EXTRA_COURSE_COMPONENT_ID, courseComponentId);
         super.onSaveInstanceState(outState);
@@ -120,7 +120,7 @@ public abstract  class CourseBaseActivity  extends BaseFragmentActivity implemen
 
     protected void restore(Bundle savedInstanceState) {
         if (savedInstanceState != null) {
-            courseData = (EnrolledCoursesResponse) savedInstanceState.getSerializable(Router.EXTRA_COURSE_DATA);
+            courseData = (EnrolledCoursesResponse) savedInstanceState.getSerializable(Router.EXTRA_ENROLLMENT);
             courseComponentId =   (String)savedInstanceState.getString(Router.EXTRA_COURSE_COMPONENT_ID);
 
         }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseCombinedInfoFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseCombinedInfoFragment.java
@@ -22,6 +22,7 @@ import com.facebook.widget.LikeView;
 import org.apache.http.protocol.HTTP;
 import org.edx.mobile.R;
 import org.edx.mobile.base.CourseDetailBaseFragment;
+import org.edx.mobile.base.MainApplication;
 import org.edx.mobile.loader.AsyncTaskResult;
 import org.edx.mobile.loader.FriendsInCourseLoader;
 import org.edx.mobile.model.api.AnnouncementsModel;
@@ -52,7 +53,7 @@ import java.util.List;
 public class CourseCombinedInfoFragment extends CourseDetailBaseFragment implements View.OnClickListener, LoaderManager.LoaderCallbacks<AsyncTaskResult<List<SocialMember>>> {
 
     static final String TAG = CourseCombinedInfoFragment.class.getCanonicalName();
-    static final String ANNOUNCEMENTS = TAG + ".announcements";
+
     private final int LOADER_ID = 0x416BED;
 
     private CourseImageHeader headerImageView;
@@ -106,7 +107,13 @@ public class CourseCombinedInfoFragment extends CourseDetailBaseFragment impleme
         shareButton.setOnClickListener(this);
 
         TextView handoutText = (TextView) view.findViewById(R.id.combined_course_handout_text);
-        handoutText.setOnClickListener(this);
+        View handoutArrow =  view.findViewById(R.id.next_arrow);
+        if (MainApplication.Q4_ASSESSMENT_FLAG ) {
+            handoutText.setVisibility(View.GONE);
+            handoutArrow.setVisibility(View.GONE);
+        } else {
+            handoutText.setOnClickListener(this);
+        }
 
         TextView certificateButton = (TextView) view.findViewById(R.id.view_cert_button);
         certificateButton.setOnClickListener(this);
@@ -143,7 +150,7 @@ public class CourseCombinedInfoFragment extends CourseDetailBaseFragment impleme
         if (savedInstanceState != null) {
 
             try {
-                savedAnnouncements = savedInstanceState.getParcelableArrayList(ANNOUNCEMENTS);
+                savedAnnouncements = savedInstanceState.getParcelableArrayList(Router.EXTRA_ANNOUNCEMENTS);
             } catch (Exception ex) {
                 logger.error(ex);
             }
@@ -247,7 +254,7 @@ public class CourseCombinedInfoFragment extends CourseDetailBaseFragment impleme
         super.onSaveInstanceState(outState);
 
         if (savedAnnouncements != null) {
-            outState.putParcelableArrayList(ANNOUNCEMENTS, new ArrayList<Parcelable>(savedAnnouncements));
+            outState.putParcelableArrayList(Router.EXTRA_ANNOUNCEMENTS, new ArrayList<Parcelable>(savedAnnouncements));
         }
         uiHelper.onSaveInstanceState(outState);
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDashboardActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDashboardActivity.java
@@ -43,7 +43,9 @@ public class CourseDashboardActivity extends CourseBaseActivity implements Cours
     @Override
     protected void onStart() {
         super.onStart();
-        setTitle(getString(R.string.course_home));
+        if ( courseData != null && courseData.getCourse() != null ){
+            setTitle(courseData.getCourse().getName());
+        }
     }
 
     @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDetailInfoActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDetailInfoActivity.java
@@ -1,0 +1,194 @@
+package org.edx.mobile.view;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentTransaction;
+import android.text.TextUtils;
+import android.view.Menu;
+import android.view.View;
+
+import org.edx.mobile.R;
+import org.edx.mobile.http.Api;
+import org.edx.mobile.interfaces.NetworkObserver;
+import org.edx.mobile.model.api.EnrolledCoursesResponse;
+import org.edx.mobile.util.AppConstants;
+import org.edx.mobile.util.NetworkUtil;
+
+
+public class CourseDetailInfoActivity extends CourseBaseActivity {
+
+    private CourseCombinedInfoFragment fragment;
+
+
+    public static String TAG = CourseDetailInfoActivity.class.getCanonicalName();
+
+    private View offlineBar;
+
+
+    Bundle bundle;
+    String activityTitle;
+
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setApplyPrevTransitionOnRestart(true);
+
+        bundle = getIntent().getBundleExtra(Router.EXTRA_BUNDLE);
+        offlineBar = findViewById(R.id.offline_bar);
+        if (!(NetworkUtil.isConnected(this))) {
+            AppConstants.offline_flag = true;
+            invalidateOptionsMenu();
+            if(offlineBar!=null){
+                offlineBar.setVisibility(View.VISIBLE);
+            }
+        }
+
+        try{
+            EnrolledCoursesResponse courseData = (EnrolledCoursesResponse) bundle
+                    .getSerializable(Router.EXTRA_ENROLLMENT);
+
+            //check courseData again, it may be fetched from local cache
+            if ( courseData != null ) {
+                activityTitle = courseData.getCourse().getName();
+
+                try{
+                    segIO.screenViewsTracking(courseData.getCourse().getName());
+                }catch(Exception e){
+                    logger.error(e);
+                }
+            } else {
+
+                boolean handleFromNotification = handleIntentFromNotification();
+                //this is not from notification
+                if (!handleFromNotification) {
+                    //it is a good idea to go to the my course page. as loading of my courses
+                    //take a while to load. that the only way to get anouncement link
+                    Router.getInstance().showMyCourses(this);
+                    finish();
+                }
+            }
+
+        }catch(Exception ex){
+            Router.getInstance().showMyCourses(this);
+            finish();
+            logger.error(ex);
+        }
+
+    }
+
+    /**
+     * @return <code>true</code> if handle intent from notification successfully
+     */
+    private boolean handleIntentFromNotification(){
+        if ( bundle != null ){
+            String courseId = bundle.getString(Router.EXTRA_COURSE_ID);
+            //this is from notification
+            if (!TextUtils.isEmpty(courseId)){
+                try{
+                    bundle.remove(Router.EXTRA_COURSE_ID);
+                    Api api = new Api(this);
+                    EnrolledCoursesResponse courseData = api.getCourseById(courseId);
+                    if (courseData != null && courseData.getCourse() != null ) {
+                        bundle.putSerializable(Router.EXTRA_ENROLLMENT, courseData);
+                        activityTitle = courseData.getCourse().getName();
+                        return true;
+                    }
+                }catch (Exception ex){
+                    logger.error(ex);
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        handleIntentFromNotification();
+        invalidateOptionsMenu();
+    }
+
+    @Override
+    protected void onOffline() {
+        AppConstants.offline_flag = true;
+        if(offlineBar!=null){
+            offlineBar.setVisibility(View.VISIBLE);
+        }
+
+        for (Fragment fragment : getSupportFragmentManager().getFragments()){
+            if (fragment instanceof NetworkObserver){
+                ((NetworkObserver) fragment).onOffline();
+            }
+        }
+        invalidateOptionsMenu();
+    }
+
+    @Override
+    protected void onOnline() {
+        AppConstants.offline_flag = false;
+        if(offlineBar!=null){
+            offlineBar.setVisibility(View.GONE);
+        }
+
+        for (Fragment fragment : getSupportFragmentManager().getFragments()){
+            if (fragment instanceof NetworkObserver){
+                ((NetworkObserver) fragment).onOnline();
+            }
+        }
+        invalidateOptionsMenu();
+    }
+
+
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        finish();
+    }
+
+
+    @Override
+    protected void onPostCreate(Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
+        if (savedInstanceState == null){
+            try {
+
+                fragment = new CourseCombinedInfoFragment();
+
+                if (courseData != null) {
+                    Bundle bundle = new Bundle();
+                    bundle.putSerializable(Router.EXTRA_ENROLLMENT, courseData);
+                    fragment.setArguments(bundle);
+
+                }
+                //this activity will only ever hold this lone fragment, so we
+                // can afford to retain the instance during activity recreation
+                fragment.setRetainInstance(true);
+
+                FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
+                fragmentTransaction.add(R.id.fragment_container, fragment);
+                fragmentTransaction.disallowAddToBackStack();
+                fragmentTransaction.commit();
+
+            } catch (Exception e) {
+                logger.error(e);
+            }
+        }
+    }
+
+    protected boolean createOptionMenu(Menu menu) {
+        return false;
+    }
+
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        return false;
+    }
+
+    @Override
+    protected String getUrlForWebView() {
+        if ( courseData != null && courseData.getCourse() != null ){
+            return courseData.getCourse().getCourse_url();
+        }
+        return "";
+    }
+
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineActivity.java
@@ -46,7 +46,7 @@ public class CourseOutlineActivity extends CourseVideoListActivity {
 
                 if (courseData != null) {
                     Bundle bundle = new Bundle();
-                    bundle.putSerializable(Router.EXTRA_COURSE_DATA, courseData);
+                    bundle.putSerializable(Router.EXTRA_ENROLLMENT, courseData);
                     bundle.putString(Router.EXTRA_COURSE_COMPONENT_ID, courseComponentId);
                     fragment.setArguments(bundle);
                 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -59,7 +59,7 @@ public class CourseOutlineFragment extends MyVideosBaseFragment {
         try {
             if( courseData == null ) {
                 final Bundle bundle = getArguments();
-                courseData = (EnrolledCoursesResponse) bundle.getSerializable(Router.EXTRA_COURSE_DATA);
+                courseData = (EnrolledCoursesResponse) bundle.getSerializable(Router.EXTRA_ENROLLMENT);
                 courseComponentId = (String) bundle.getString(Router.EXTRA_COURSE_COMPONENT_ID);
             }
         } catch (Exception ex) {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/Router.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/Router.java
@@ -29,7 +29,7 @@ public class Router {
     public static final String EXTRA_SEQUENTIAL = "sequential";
     public static final String EXTRA_COURSE_UNIT = "course_unit";
     public static final String EXTRA_COURSE_COMPONENT_ID = "course_component_id";
-    public static final String EXTRA_COURSE_DATA = "course_data";
+
     static private Router sInstance;
 
     // Note that this is not thread safe. The expectation is that this only happens
@@ -145,7 +145,12 @@ public class Router {
         courseBundle.putSerializable(EXTRA_ENROLLMENT, model);
         courseBundle.putBoolean(EXTRA_ANNOUNCEMENTS, true);
 
-        Intent courseDetail = new Intent(activity, CourseDetailTabActivity.class);
+
+        Intent courseDetail;
+        if (MainApplication.Q4_ASSESSMENT_FLAG)
+            courseDetail = new Intent(activity, CourseDetailInfoActivity.class);
+        else
+            courseDetail = new Intent(activity, CourseDetailTabActivity.class);
         courseDetail.putExtra( EXTRA_BUNDLE, courseBundle);
         courseDetail.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
         activity.startActivity(courseDetail);
@@ -154,7 +159,7 @@ public class Router {
     public void showCourseContainerOutline(Activity activity, EnrolledCoursesResponse model, String courseComponentId) {
 
         Bundle courseBundle = new Bundle();
-        courseBundle.putSerializable(EXTRA_COURSE_DATA, model);
+        courseBundle.putSerializable(EXTRA_ENROLLMENT, model);
         courseBundle.putString(EXTRA_COURSE_COMPONENT_ID, courseComponentId);
 
         Intent courseDetail = new Intent(activity, CourseOutlineActivity.class);
@@ -170,7 +175,7 @@ public class Router {
                                      String courseId,  CourseComponent unit ) {
 
         Bundle courseBundle = new Bundle();
-        courseBundle.putSerializable(EXTRA_COURSE_DATA, model);
+        courseBundle.putSerializable(EXTRA_ENROLLMENT, model);
         courseBundle.putSerializable(EXTRA_COURSE_COMPONENT_ID, courseId);
         courseBundle.putSerializable(EXTRA_COURSE_UNIT, unit);
 
@@ -184,7 +189,7 @@ public class Router {
     public void showCourseDashboard(Activity activity, EnrolledCoursesResponse model,
                                      boolean announcements) {
         Bundle courseBundle = new Bundle();
-        courseBundle.putSerializable(EXTRA_COURSE_DATA, model);
+        courseBundle.putSerializable(EXTRA_ENROLLMENT, model);
         courseBundle.putBoolean(EXTRA_ANNOUNCEMENTS, announcements);
 
         Intent courseDetail = new Intent(activity, CourseDashboardActivity.class);

--- a/VideoLocker/src/test/java/org/edx/mobile/test/http/ApiTests.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/http/ApiTests.java
@@ -23,18 +23,21 @@ import org.edx.mobile.model.course.IBlock;
 import org.edx.mobile.module.registration.model.RegistrationDescription;
 import org.edx.mobile.services.CourseManager;
 import org.edx.mobile.services.ServiceManager;
-import org.edx.mobile.test.BaseTestCase;
 import org.edx.mobile.util.Config;
 import org.junit.Test;
 
-import java.lang.Exception;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/VideoLocker/src/test/java/org/edx/mobile/view/CourseOutlineActivityTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/CourseOutlineActivityTest.java
@@ -49,7 +49,7 @@ public class CourseOutlineActivityTest extends CourseBaseActivityTest {
         EnrolledCoursesResponse courseData = new EnrolledCoursesResponse();
         String courseComponentId = "id";
         Bundle data  = new Bundle();
-        data.putSerializable(Router.EXTRA_COURSE_DATA, courseData);
+        data.putSerializable(Router.EXTRA_ENROLLMENT, courseData);
         data.putString(Router.EXTRA_COURSE_COMPONENT_ID, courseComponentId);
 
         controller.create(data).postCreate(null);
@@ -60,8 +60,8 @@ public class CourseOutlineActivityTest extends CourseBaseActivityTest {
         assertTrue(fragment.getRetainInstance());
         Bundle args = fragment.getArguments();
         assertNotNull(args);
-        assertEquals(data.getSerializable(Router.EXTRA_COURSE_DATA),
-                args.getSerializable(Router.EXTRA_COURSE_DATA));
+        assertEquals(data.getSerializable(Router.EXTRA_ENROLLMENT),
+                args.getSerializable(Router.EXTRA_ENROLLMENT));
         assertEquals(data.getSerializable(Router.EXTRA_COURSE_COMPONENT_ID),
                 args.getSerializable(Router.EXTRA_COURSE_COMPONENT_ID));
     }


### PR DESCRIPTION
@aleffert  please review
the fixes are related to 
1. In android in announcement section two tabs appears courseware and course info and view course handouts but we have handouts tab in previous screen too. However, in iOS these tabs are not appearing.
2. In android top left arrow which takes user to the previous screen is in black however in iOS its white
3. On tapping any course the text after the main logo edx| Demox is all in capital however in iOS it's not.  
 
https://openedx.atlassian.net/browse/MA-858

cc @1zaman 