### PR TITLE
Fix video delete functionality

### DIFF
--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -523,7 +523,7 @@
         <!-- Message indicating one video deleted. {video_count} is 1-->
         <item quantity="one">{video_count} video deleted </item>
         <!-- Message indicating more than one video deleted. {video_count} is number of videos deleted-->
-        <item quantity="other">{{video_count}} videos deleted</item>
+        <item quantity="other">{video_count} videos deleted</item>
     </plurals>
 
     <!-- Notification related -->

--- a/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
@@ -926,11 +926,15 @@ public class VideoListFragment extends MyVideosBaseFragment {
         }
 
         if(deletedVideoCount>0){
-            String format =  ResourceUtil.getFormattedStringForQuantity(R.plurals.deleted_video,
-                "video_num", deletedVideoCount).toString();
+            try {
+                String format = ResourceUtil.getFormattedStringForQuantity(R.plurals.deleted_video,
+                        "video_count", deletedVideoCount).toString();
 
-            ((VideoListActivity) getActivity())
-                    .showInfoMessage(String.format(format, deletedVideoCount));
+                ((VideoListActivity) getActivity())
+                        .showInfoMessage(String.format(format, deletedVideoCount));
+            } catch (Exception ex) {
+                logger.error(ex);
+            }
         }
         getView().findViewById(R.id.delete_btn).setVisibility(View.GONE);
         getView().findViewById(R.id.edit_btn).setVisibility(View.VISIBLE);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyRecentVideosFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyRecentVideosFragment.java
@@ -453,34 +453,34 @@ public class MyRecentVideosFragment extends MyVideosBaseFragment {
 
     //Deleting Downloaded videos on getting confirmation
     private void onConfirmDelete() {
-        try{
-            int deletedVideoCount = 0;
-            ArrayList<SectionItemInterface> list = adapter.getSelectedItems();
-            if (list != null) {
-                for (SectionItemInterface section : list) {
-                    if (section.isDownload()) {
-                        DownloadEntry de = (DownloadEntry) section;
-                        storage.removeDownload(de);
-                        deletedVideoCount++;
-                    }
+        int deletedVideoCount = 0;
+        ArrayList<SectionItemInterface> list = adapter.getSelectedItems();
+        if (list != null) {
+            for (SectionItemInterface section : list) {
+                if (section.isDownload()) {
+                    DownloadEntry de = (DownloadEntry) section;
+                    storage.removeDownload(de);
+                    deletedVideoCount++;
                 }
             }
-            addToRecentAdapter(getView());
-            notifyAdapter();
-            videoListView.setOnItemClickListener(adapter);
-            AppConstants.myVideosDeleteMode = false;
-            ((MyVideosTabActivity) getActivity()).hideCheckBox();
-            if(deletedVideoCount>0){
+        }
+        addToRecentAdapter(getView());
+        notifyAdapter();
+        videoListView.setOnItemClickListener(adapter);
+        AppConstants.myVideosDeleteMode = false;
+        ((MyVideosTabActivity) getActivity()).hideCheckBox();
+        if(deletedVideoCount>0){
+            try{
                 String format =  ResourceUtil.getFormattedStringForQuantity(R.plurals.deleted_video, "video_count", deletedVideoCount).toString();
                 UiUtil.showMessage(MyRecentVideosFragment.this.getView(),
                         String.format(format, deletedVideoCount));
+            }catch(Exception ex){
+                logger.error(ex);
             }
-            getView().findViewById(R.id.delete_btn).setVisibility(View.GONE);
-            getView().findViewById(R.id.edit_btn).setVisibility(View.VISIBLE);
-            getView().findViewById(R.id.cancel_btn).setVisibility(View.GONE);
-        }catch(Exception ex){
-            logger.error(ex);
         }
+        getView().findViewById(R.id.delete_btn).setVisibility(View.GONE);
+        getView().findViewById(R.id.edit_btn).setVisibility(View.VISIBLE);
+        getView().findViewById(R.id.cancel_btn).setVisibility(View.GONE);
     }
 
     //Handle check box selection in Delete mode


### PR DESCRIPTION
Due to incorrect string formatting and a generic try catch block over the whole method, the UI state was being left in an inconsistent state upon deleting videos. This PR is designed to address both issues.

More detailed discussion is available on the JIRA issue: https://openedx.atlassian.net/browse/MA-857