### PR TITLE
Fix db query defaults

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationBase.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationBase.java
@@ -38,7 +38,7 @@ abstract class DbOperationBase<T> implements IDbOperation<T> {
             }
         }
         
-        return null;
+        return getDefaultValue();
     }
     
     /**
@@ -48,4 +48,10 @@ abstract class DbOperationBase<T> implements IDbOperation<T> {
      * @return
      */
     public abstract T execute(SQLiteDatabase db);
+
+    /**
+     * Returns the default value of the data type.
+     * @return The data type
+     */
+    public abstract T getDefaultValue();
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationDelete.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationDelete.java
@@ -25,4 +25,9 @@ class DbOperationDelete extends DbOperationBase<Integer> {
         return count;
     }
 
+    @Override
+    public Integer getDefaultValue() {
+        return -1;
+    }
+
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationExists.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationExists.java
@@ -18,4 +18,9 @@ class DbOperationExists extends DbOperationSelect<Boolean> {
         return (exists != null && exists);
     }
     
+    @Override
+    public Boolean getDefaultValue() {
+        return false;
+    }
+    
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationGetColumn.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationGetColumn.java
@@ -45,4 +45,9 @@ class DbOperationGetColumn<T> extends DbOperationSelect<List<T>> {
         return list;
     }
     
+    @Override
+    public List<T> getDefaultValue() {
+        return new ArrayList<T>();
+    }
+    
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationGetCount.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationGetCount.java
@@ -19,4 +19,9 @@ class DbOperationGetCount extends DbOperationSelect<Integer> {
         return count;
     }
     
+    @Override
+    public Integer getDefaultValue() {
+        return 0;
+    }
+    
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationGetVideo.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationGetVideo.java
@@ -30,4 +30,14 @@ class DbOperationGetVideo extends DbOperationSelect<VideoModel> {
         return video;
     }
     
+    @Override
+    public VideoModel getDefaultValue() {
+        // Returning null should be fine here, as video should only be queried if
+        // it exists, or at least there should be a null check on the client code
+        // otherwise. If we want to return an empty object here, then we will
+        // need an appropriate constructor or initializer in the default
+        // VideoModel implementation as well.
+        return null;
+    }
+    
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationGetVideos.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationGetVideos.java
@@ -32,4 +32,9 @@ class DbOperationGetVideos extends DbOperationSelect<List<VideoModel>> {
         return list;
     }
     
+    @Override
+    public List<VideoModel> getDefaultValue() {
+        return new ArrayList<VideoModel>();
+    }
+    
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationInsert.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationInsert.java
@@ -28,4 +28,9 @@ class DbOperationInsert extends DbOperationBase<Long> {
         return id;
     }
 
+    @Override
+    public Long getDefaultValue() {
+        return -1L;
+    }
+
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationSingleValueByRawQuery.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationSingleValueByRawQuery.java
@@ -20,16 +20,17 @@ class DbOperationSingleValueByRawQuery<T> extends DbOperationBase<T> {
     public T execute(SQLiteDatabase db) {
         Cursor c = db.rawQuery(sqlQuery, selectionArgs);
         
+        T result = null;
         if (c.moveToFirst()) {
             if (columnType == Long.class) { 
                 Long column = c.getLong(0);
-                return (T) column;
+                result = (T) column;
             } else if (columnType == String.class) {
                 String column = c.getString(0);
-                return (T) column;
+                result = (T) column;
             } else if (columnType == Integer.class) {
                 Integer column = c.getInt(0);
-                return (T) column;
+                result = (T) column;
             } else {
                 logger.warn("Class types does NOT match for: " + columnType);
             }
@@ -37,7 +38,7 @@ class DbOperationSingleValueByRawQuery<T> extends DbOperationBase<T> {
         
         c.close();
         
-        return null;
+        return result;
     }
     
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationSingleValueByRawQuery.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationSingleValueByRawQuery.java
@@ -41,4 +41,19 @@ class DbOperationSingleValueByRawQuery<T> extends DbOperationBase<T> {
         return result;
     }
     
+    @Override
+    public T getDefaultValue() {
+        if (columnType == Long.class) {
+            return (T) (Long) (-1L);
+        } else if (columnType == String.class) {
+            return (T) "";
+        } else if (columnType == Integer.class) {
+            return (T) (Integer) (-1);
+        } else {
+            logger.warn("Class types does NOT match for: " + columnType);
+        }
+
+        return null;
+    }
+
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationUpdate.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/impl/DbOperationUpdate.java
@@ -32,4 +32,9 @@ class DbOperationUpdate extends DbOperationBase<Integer> {
         return count;
     }
 
+    @Override
+    public Integer getDefaultValue() {
+        return 0;
+    }
+
 }


### PR DESCRIPTION
Synchronous database queries currently return null upon encountering an exception. Since this renders catching the exception useless, and in fact detrimental, I have fixed that to return the default non-null value for that type instead. This fixes the exception in https://openedx.atlassian.net/browse/MA-914

Also fixed an issue where the cursor was not getting closed at the correct point in some queries.

cc @hanningni @aleffert