### PR TITLE
add empty message for course list on video-only mode

### DIFF
--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -262,7 +262,9 @@
     <!-- Label for mode switch menu item-->
     <string name="assessment_full_course">Full Course</string>
 
-    <!-- Label showing assessment only available on website-->
+    <!-- Label for empty video in video only mode-->
+    <string name="assessment_empty_video_info">There are no videos in this section. To view other section content, select the Video icon above and switch to full course mode.</string>
+   <!-- Label showing assessment only available on website-->
     <string name="assessment_not_available">This interactive component isn\'t yet available on mobile.</string>
     <!-- Label showing assessment only available on website-->
     <string name="assessment_explore_on_web">Explore other parts of this course or view this on web.</string>

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineActivity.java
@@ -89,8 +89,9 @@ public class CourseOutlineActivity extends CourseVideoListActivity {
 
     @Override
     public void updateListUI() {
-           if( fragment != null )
-               fragment.reloadList();
+        if( fragment != null )
+            fragment.reloadList();
+        fragment.updateMessageView(null);
     }
 
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -23,6 +23,7 @@ import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.view.adapters.CourseOutlineAdapter;
 import org.edx.mobile.view.common.TaskProcessCallback;
+import org.edx.mobile.view.custom.ETextView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -102,8 +103,23 @@ public class CourseOutlineFragment extends MyVideosBaseFragment {
             return;
         CourseComponent courseComponent = getCourseComponent();
         adapter.setData(courseComponent);
+        updateMessageView(view);
+    }
+    public void updateMessageView(View view){
+        if (view == null )
+            view = getView();
+        if ( view == null )
+            return;
+        ETextView messageView = (ETextView) view.findViewById(R.id.no_chapter_tv);
         if(adapter.getCount()==0){
-            view.findViewById(R.id.no_chapter_tv).setVisibility(View.VISIBLE);
+            messageView.setVisibility(View.VISIBLE);
+            if ( adapter.hasFilteredUnits() ){
+                messageView.setText(R.string.assessment_empty_video_info);
+            } else {
+                messageView.setText(R.string.no_chapter_text);
+            }
+        }else{
+            messageView.setVisibility(View.GONE);
         }
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java
@@ -23,6 +23,8 @@ import org.edx.mobile.module.storage.IStorage;
 import org.edx.mobile.third_party.iconify.Iconify;
 import org.edx.mobile.util.AppConstants;
 
+import java.util.List;
+
 import de.greenrobot.event.EventBus;
 
 /**
@@ -31,6 +33,7 @@ import de.greenrobot.event.EventBus;
 public abstract  class CourseOutlineAdapter extends CourseBaseAdapter  {
 
     private boolean currentVideoMode;
+    private int numOfTotalUnits;
 
     public CourseOutlineAdapter(Context context, IDatabase dbStore, IStorage storage) {
         super(context, dbStore, storage);
@@ -44,12 +47,14 @@ public abstract  class CourseOutlineAdapter extends CourseBaseAdapter  {
         if (component != null &&  !component.isContainer())
             return;//
         this.rootComponent = component;
+        this.numOfTotalUnits = 0;
         mData.clear();
         if ( rootComponent != null ) {
             PrefManager.UserPrefManager userPrefManager = new PrefManager.UserPrefManager(MainApplication.instance());
             currentVideoMode = userPrefManager.isUserPrefVideoModel();
-
-            for(IBlock block : rootComponent.getChildren()){
+            List<IBlock> children = rootComponent.getChildren();
+            this.numOfTotalUnits = children.size();
+            for(IBlock block : children){
                 CourseComponent comp = (CourseComponent)block;
                 if ( currentVideoMode && comp.getBlockCount().videoCount == 0 )
                     continue;
@@ -382,5 +387,12 @@ public abstract  class CourseOutlineAdapter extends CourseBaseAdapter  {
         }  else {
             return false;
         }
+    }
+
+    /**
+     * if the app is in the video-only mode, some unit will not show up
+     */
+    public boolean hasFilteredUnits(){
+        return this.numOfTotalUnits > mData.size();
     }
 }


### PR DESCRIPTION
@aleffert  please review

https://openedx.atlassian.net/browse/MA-962
Switching to video mode in a subsection with no videos just shows an empty screen. It should probably show an empty message suggesting switching to full mode.