### PR TITLE
Fix navigation from course unit to outline

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
@@ -111,12 +111,6 @@ public class BaseFragmentActivity extends RoboFragmentActivity implements Networ
             setTheme(android.R.style.Theme_NoTitleBar_Fullscreen);
         }
 
-        try{
-            applyTransitionNext();
-        }catch(Exception ex){
-            logger.error(ex);
-        }
-
 
         updateActionBarShadow();
 
@@ -124,9 +118,9 @@ public class BaseFragmentActivity extends RoboFragmentActivity implements Networ
     }
 
     @Override
-    public void startActivity(Intent intent) {
+    public void startActivityForResult(Intent intent, int requestCode) {
         try{
-            super.startActivity(intent);
+            super.startActivityForResult(intent, requestCode);
             applyTransitionNext();
         }catch(Exception e){
             logger.error(e);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -28,6 +28,8 @@ import org.edx.mobile.view.custom.ETextView;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.edx.mobile.view.CourseOutlineActivity.REQUEST_SHOW_COURSE_UNIT_DETAIL;
+
 public class CourseOutlineFragment extends MyVideosBaseFragment {
 
     protected final Logger logger = new Logger(getClass().getName());
@@ -135,9 +137,11 @@ public class CourseOutlineFragment extends MyVideosBaseFragment {
                         super.rowClicked(row);
                         CourseComponent comp = row.component;
                         if ( comp.isContainer() ){
-                            environment.getRouter().showCourseContainerOutline(getActivity(), courseData, comp.getId());
+                            environment.getRouter().showCourseContainerOutline(getActivity(),
+                                    REQUEST_SHOW_COURSE_UNIT_DETAIL, courseData, comp.getId());
                         } else {
-                            environment.getRouter().showCourseUnitDetail(getActivity(), courseData, courseComponentId, comp);
+                            environment.getRouter().showCourseUnitDetail(getActivity(),
+                                    REQUEST_SHOW_COURSE_UNIT_DETAIL, courseData, courseComponentId, comp);
                         }
 
                     } catch (Exception ex) {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -1,6 +1,7 @@
 package org.edx.mobile.view;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -148,6 +149,9 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements 
             .username, selectedUnit.getCourseId());
         final PrefManager prefManager = new PrefManager(MainApplication.instance(), prefName);
         prefManager.putLastAccessedSubsection(parent.getId(), false);
+        Intent resultData = new Intent();
+        resultData.putExtra(Router.EXTRA_COURSE_UNIT, selectedUnit);
+        setResult(RESULT_OK, resultData);
     }
 
     private void tryToUpdateForEndOfSequential(){

--- a/VideoLocker/src/main/java/org/edx/mobile/view/Router.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/Router.java
@@ -151,6 +151,12 @@ public class Router {
 
     public void showCourseContainerOutline(Activity activity, EnrolledCoursesResponse model, String courseComponentId) {
 
+        showCourseContainerOutline(activity, -1, model, courseComponentId);
+    }
+
+    public void showCourseContainerOutline(Activity activity, int requestCode,
+                                           EnrolledCoursesResponse model, String courseComponentId) {
+
         Bundle courseBundle = new Bundle();
         courseBundle.putSerializable(EXTRA_ENROLLMENT, model);
         courseBundle.putString(EXTRA_COURSE_COMPONENT_ID, courseComponentId);
@@ -159,12 +165,18 @@ public class Router {
         courseDetail.putExtra( EXTRA_BUNDLE, courseBundle);
         //TODO - what's the most suitable FLAG?
        // courseDetail.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-        activity.startActivity(courseDetail);
+        activity.startActivityForResult(courseDetail, requestCode);
     }
 
 
 
     public void showCourseUnitDetail(Activity activity, EnrolledCoursesResponse model,
+                                     String courseId,  CourseComponent unit ) {
+
+        showCourseUnitDetail(activity, -1, model, courseId, unit);
+    }
+
+    public void showCourseUnitDetail(Activity activity, int requestCode, EnrolledCoursesResponse model,
                                      String courseId,  CourseComponent unit ) {
 
         Bundle courseBundle = new Bundle();
@@ -175,7 +187,7 @@ public class Router {
         Intent courseDetail = new Intent(activity, CourseUnitNavigationActivity.class);
         courseDetail.putExtra( EXTRA_BUNDLE, courseBundle);
         courseDetail.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-        activity.startActivity(courseDetail);
+        activity.startActivityForResult(courseDetail, requestCode);
     }
 
 


### PR DESCRIPTION
Implements synchronization of the course unit navigation state to the outline back stack upon returning to it. The current implementation changes the structure from using multiple instances of
`CourseOutlineActivity` to having only one master instance of it that manages a back stack of `CourseOutlineFragment` instances. This results in the slide animation being changed from the whole screen to only the fragment area (excluding the action bar, last accessed view, and video download indicator view). I'll also try implementing this logic at the `Activity` level and see if that can be achieved as well, though that will be a bit more complex.

https://openedx.atlassian.net/browse/MA-934