### PR TITLE
Fix testing environment

### DIFF
--- a/VideoLocker/src/test/java/org/edx/mobile/test/BaseTestCase.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/BaseTestCase.java
@@ -8,13 +8,17 @@ import com.google.gson.JsonParser;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.util.Modules;
 
+import org.edx.mobile.core.EdxDefaultModule;
+import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.util.Config;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
@@ -42,29 +46,17 @@ public class BaseTestCase {
     public void setUp() throws Exception {
         context = RuntimeEnvironment.application;
         config = createConfig();
-        // Set up a new config instance that serves the mock host url
-        JsonObject properties;
-        try {
-            InputStream in = context.getAssets().open("config/config.json");
-            JsonParser parser = new JsonParser();
-            JsonElement config = parser.parse(new InputStreamReader(in));
-            properties = config.getAsJsonObject();
-        } catch (Exception e) {
-            properties = new JsonObject();
-            logger.error(e);
-        }
-
-        config = new Config(properties);
 
         module = new CustomGuiceModule();
+        glueInjections();
         print("Started Test Case: " + getClass().getName());
     }
 
-    protected void glueInjections(){
+    private void glueInjections() {
         addBindings();
         if ( !module.isEmpty()  ) {
             Injector injector = RoboGuice.getOrCreateBaseApplicationInjector(RuntimeEnvironment.application, RoboGuice.DEFAULT_STAGE,
-                (Module) RoboGuice.newDefaultRoboModule(RuntimeEnvironment.application), module);
+                (Module) RoboGuice.newDefaultRoboModule(RuntimeEnvironment.application), Modules.override(new EdxDefaultModule(context)).with(module));
             inject(injector);
         }
     }
@@ -74,7 +66,10 @@ public class BaseTestCase {
      */
     protected void inject(Injector injector ){}
 
-    protected void addBindings(){}
+    protected void addBindings() {
+        module.addBinding(IEdxEnvironment.class, Mockito.mock(IEdxEnvironment.class));
+        module.addBinding(Config.class, config);
+    }
 
     protected Config createConfig(){
         // Set up a new config instance that serves the mock host url
@@ -95,6 +90,7 @@ public class BaseTestCase {
 
     @After
     public void tearDown() throws Exception {
+        RoboGuice.Util.reset();
         print("Finished Test Case: " + getClass().getName());
     }
 
@@ -126,7 +122,13 @@ public class BaseTestCase {
         protected void configure() {
             Set<Map.Entry<Class<?>, Object>> entries = bindings.entrySet();
             for (Map.Entry<Class<?>, Object> entry : entries) {
-                binder.bind((Class<Object>) entry.getKey()).toInstance(entry.getValue());
+                Class<Object> classToBind = (Class<Object>) entry.getKey();
+                Object value = entry.getValue();
+                if (value instanceof Class) {
+                    binder.bind(classToBind).to((Class) value);
+                } else {
+                    binder.bind(classToBind).toInstance(value);
+                }
             }
         }
     }

--- a/VideoLocker/src/test/java/org/edx/mobile/test/TestApplication.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/TestApplication.java
@@ -1,0 +1,36 @@
+package org.edx.mobile.test;
+
+import org.edx.mobile.base.MainApplication;
+import org.edx.mobile.logger.Logger;
+
+/**
+ * The {@link MainApplication} class is overridden for testing in
+ * order to only have the components enabled that are relevant to
+ * the tests, and setting a mock RoboGuice module.
+ *
+ * The following components are not enabled:
+ *
+ * - Application lifecycle callbacks.
+ *   This was used to detect to force the application to start
+ *   from the main screen when relaunched from the background,
+ *   which is not present in the current tests.
+ *
+ * - RoboGuice injector initialization.
+ *
+ * - Crashlytics/Fabric crash reporting.
+ *
+ * - Facebook SDK intialization.
+ *
+ * - Parse notifications initialization and subscription.
+ *
+ * - Checking for application upgrades, and repairing download
+ *   statuses and clearing the web view cookie cache.
+ */
+public class TestApplication extends MainApplication {
+    @Override
+    public void onCreate() {
+        // initialize logger
+        Logger.init(this.getApplicationContext());
+        application = this;
+    }
+}

--- a/VideoLocker/src/test/java/org/edx/mobile/test/http/ApiTests.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/http/ApiTests.java
@@ -242,7 +242,7 @@ public class ApiTests extends HttpBaseTestCase {
         EnrolledCoursesResponse e = api.getEnrolledCourses().get(0);
         final String courseId = e.getCourse().getId();
         HttpRequestDelegate<CourseComponent> requestDelegate = new HttpRequestDelegate<CourseComponent>(
-                api, null, new ServiceManager().getEndPointCourseStructure(courseId)) {
+                api, null, serviceManager.getEndPointCourseStructure(courseId)) {
             @Override
             public CourseComponent fromJson(String json) throws Exception{
                 CourseStructureV1Model model = new CourseStructureJsonHandler().processInput(json);

--- a/VideoLocker/src/test/java/org/edx/mobile/test/http/OkHttpBaseTestCase.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/http/OkHttpBaseTestCase.java
@@ -49,11 +49,11 @@ public class OkHttpBaseTestCase extends BaseTestCase {
 
     @Override
     public void setUp() throws Exception {
-        super.setUp();
-
         server = new MockWebServer();
         server.setDispatcher(new MockResponseDispatcher());
         server.start();
+
+        super.setUp();
     }
 
     @Override

--- a/VideoLocker/src/test/java/org/edx/mobile/test/http/RestApiManagerTests.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/http/RestApiManagerTests.java
@@ -19,6 +19,7 @@ import org.edx.mobile.services.ServiceManager;
 import org.edx.mobile.util.Config;
 import org.junit.Ignore;
 import org.mockito.Mockito;
+import org.robolectric.RuntimeEnvironment;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,22 +37,19 @@ public class RestApiManagerTests extends OkHttpBaseTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apiManager = new RestApiManager(context);
-        serviceManager = new ServiceManager();
-        glueInjections();
     }
     
     @Override
     public void addBindings() {
-        module.addBinding(IEdxEnvironment.class, Mockito.mock(IEdxEnvironment.class));
-        module.addBinding(Config.class, config);
+        super.addBindings();
         module.addBinding(IApi.class, RestApiManager.class);
     }
 
     @Override
     protected void inject(Injector injector ){
-        injector.injectMembers(apiManager);
-        injector.injectMembers(serviceManager);
+        super.inject(injector);
+        apiManager = injector.getInstance(RestApiManager.class);
+        serviceManager = injector.getInstance(ServiceManager.class);
     }
 
     public void testSyncLastSubsection() throws Exception {

--- a/VideoLocker/src/test/java/org/edx/mobile/test/http/SocialLoginTests.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/http/SocialLoginTests.java
@@ -28,7 +28,6 @@ public class SocialLoginTests extends HttpBaseTestCase  {
     public void testGetProfile() throws Exception {
         if ( shouldSkipTest ) return;
 
-        Api api = new Api(RuntimeEnvironment.application);
         ProfileModel profile = api.getProfile();
         assertNotNull(profile);
         assertNotNull("profile.email cannot be null", profile.email);

--- a/VideoLocker/src/test/java/org/edx/mobile/view/BaseFragmentActivityTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/BaseFragmentActivityTest.java
@@ -39,6 +39,7 @@ import org.edx.mobile.model.db.DownloadEntry;
 import org.edx.mobile.module.db.IDatabase;
 import org.edx.mobile.module.db.impl.DatabaseFactory;
 import org.edx.mobile.module.prefs.PrefManager;
+import org.edx.mobile.test.http.HttpBaseTestCase;
 import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.view.dialog.WebViewDialogFragment;
@@ -63,7 +64,7 @@ import static org.junit.Assume.*;
 
 // TODO: Test network connectivity change events too, after we manage to mock them
 @RunWith(RobolectricGradleTestRunner.class)
-public class BaseFragmentActivityTest {
+public class BaseFragmentActivityTest extends HttpBaseTestCase {
     /**
      * Method for defining the subclass of {@link BaseFragmentActivity} that
      * is being tested. Should be overridden by subclasses.

--- a/VideoLocker/src/test/java/org/edx/mobile/view/CourseUnitVideoFragmentTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/CourseUnitVideoFragmentTest.java
@@ -14,6 +14,7 @@ import android.view.WindowManager;
 import android.widget.LinearLayout;
 
 import org.edx.mobile.R;
+import org.edx.mobile.test.http.HttpBaseTestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -34,7 +35,7 @@ import static org.junit.Assume.assumeNotNull;
 // issue: https://github.com/robolectric/robolectric/issues/1810
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(sdk = 19)
-public class CourseUnitVideoFragmentTest {
+public class CourseUnitVideoFragmentTest extends HttpBaseTestCase {
     /**
      * Testing initialization
      */

--- a/VideoLocker/src/test/java/org/edx/mobile/view/CourseUnitWebviewFragmentTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/CourseUnitWebviewFragmentTest.java
@@ -4,6 +4,7 @@ import android.view.View;
 import android.webkit.WebView;
 
 import org.edx.mobile.R;
+import org.edx.mobile.test.http.HttpBaseTestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
@@ -16,7 +17,7 @@ import static org.junit.Assert.*;
 // https://github.com/robolectric/robolectric/issues/793
 // We should add mock web server and test the handling later
 @RunWith(RobolectricGradleTestRunner.class)
-public class CourseUnitWebviewFragmentTest {
+public class CourseUnitWebviewFragmentTest extends HttpBaseTestCase {
     /**
      * Testing initialization
      */


### PR DESCRIPTION
RoboJuice integration in commit 5158557b9df55463301a58c3b186716b14cf330a broke the testing environment, as it removed the mock `Application` and `Config` implementations. It introduced a weak structure for setting up the injections in tests, which is patched to work properly in this commit. All the view related tests now extend HttpBaseTestCase so that they can utilize the mock web server and have the other injections set up as well.

https://openedx.atlassian.net/browse/MA-894