### PR TITLE
Fix start date error

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/model/api/AccessError.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/model/api/AccessError.java
@@ -1,0 +1,18 @@
+package org.edx.mobile.model.api;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.HashMap;
+
+/**
+ * Created by lindaliu on 7/13/15.
+ */
+
+public enum AccessError {
+    @SerializedName("course_not_started")
+    START_DATE_ERROR,
+    @SerializedName("not_visible_to_user")
+    VISIBILITY_ERROR,
+    @SerializedName("unfulfilled_milestones")
+    MILESTONE_ERROR
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/model/api/CourseEntry.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/model/api/CourseEntry.java
@@ -21,6 +21,8 @@ public class CourseEntry implements Serializable {
     private String start; // start date
     private String course_image;
     private String end; // completion date
+    private String start_display;
+    private StartType start_type;
     private String name;
     private String org;
     private String video_outline;
@@ -32,6 +34,7 @@ public class CourseEntry implements Serializable {
     private String id;
     private String number;
     private SocialURLModel social_urls;
+    private CoursewareAccess courseware_access;
 
     @Inject
     Config config;
@@ -66,6 +69,23 @@ public class CourseEntry implements Serializable {
 
     public void setEnd(String end) {
         this.end = end;
+    }
+
+    public String getStartDisplay() {
+        return start_display;
+    }
+
+    public void setStartDisplay(String start_display) {
+        this.start_display = start_display;
+    }
+
+    public StartType getStartType() {
+        if(start_type == null) start_type = StartType.NONE_START;
+        return start_type;
+    }
+
+    public void setStartType(StartType start_type) {
+        this.start_type = start_type;
     }
 
     public String getName() {
@@ -107,6 +127,11 @@ public class CourseEntry implements Serializable {
     public void setNumber(String number) {
         this.number = number;
     }
+
+
+    public void setCoursewareAccess(CoursewareAccess access) { this.courseware_access = access; }
+
+    public CoursewareAccess getCoursewareAccess() { return courseware_access; }
 
     public boolean isStarted() {
         // check if "start" date has passed

--- a/VideoLocker/src/main/java/org/edx/mobile/model/api/CoursewareAccess.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/model/api/CoursewareAccess.java
@@ -1,0 +1,30 @@
+package org.edx.mobile.model.api;
+
+import java.io.Serializable;
+
+/**
+ * Created by lindaliu on 7/13/15.
+ */
+
+
+public class CoursewareAccess implements Serializable {
+    boolean has_access;
+    AccessError error_code;
+    String developer_message;
+    String user_message;
+
+    public CoursewareAccess(boolean has_access, AccessError error_code, String developer_message, String user_message) {
+        this.has_access = has_access;
+        this.error_code = error_code;
+        this.developer_message = developer_message;
+        this.user_message = user_message;
+    }
+
+    public AccessError getError_code() {
+        return error_code;
+    }
+
+    public String getUser_message() {
+        return user_message;
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/model/api/StartType.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/model/api/StartType.java
@@ -1,0 +1,15 @@
+package org.edx.mobile.model.api;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Created by lindaliu on 7/14/15.
+ */
+public enum StartType {
+    @SerializedName("string")
+    STRING_START,
+    @SerializedName("timestamp")
+    TIMESTAMP_START,
+    @SerializedName("empty")
+    NONE_START
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseChapterListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseChapterListFragment.java
@@ -22,9 +22,12 @@ import com.google.inject.Inject;
 import org.edx.mobile.R;
 import org.edx.mobile.base.CourseDetailBaseFragment;
 import org.edx.mobile.interfaces.NetworkObserver;
+import org.edx.mobile.model.api.AccessError;
+import org.edx.mobile.model.api.CoursewareAccess;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.model.api.LectureModel;
 import org.edx.mobile.model.api.SectionEntry;
+import org.edx.mobile.model.api.StartType;
 import org.edx.mobile.model.api.VideoResponseModel;
 import org.edx.mobile.services.VideoDownloadHelper;
 import org.edx.mobile.services.LastAccessManager;
@@ -102,9 +105,10 @@ public class CourseChapterListFragment extends CourseDetailBaseFragment
 
         //Initialize the Course not started text view.
         if (!enrollment.getCourse().isStarted()) {
-            startDate = DateUtil.formatCourseNotStartedDate(enrollment.getCourse().getStart());
-            if (startDate != null) {
-                startDate = "<font color='" + getString(R.color.grey_text_course_not_started) + "'>" + startDate + "</font>";
+            CoursewareAccess error = enrollment.getCourse().getCoursewareAccess();
+            StartType type = enrollment.getCourse().getStartType();
+            if (error.getError_code() == AccessError.START_DATE_ERROR && !(type == StartType.NONE_START)) {
+                startDate = "<font color='" + getString(R.color.grey_text_course_not_started) + "'>" + enrollment.getCourse().getStartDisplay() + "</font>";
                 String courseScheduledText  =  ResourceUtil.getFormattedString(R.string.course_content_available_text,
                         "start_time", startDate).toString();
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/MyCourseAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/MyCourseAdapter.java
@@ -15,8 +15,10 @@ import com.android.volley.toolbox.NetworkImageView;
 
 import org.edx.mobile.R;
 import org.edx.mobile.core.IEdxEnvironment;
+import org.edx.mobile.model.api.AccessError;
 import org.edx.mobile.model.api.CourseEntry;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
+import org.edx.mobile.model.api.StartType;
 import org.edx.mobile.social.SocialMember;
 import org.edx.mobile.util.DateUtil;
 import org.edx.mobile.util.images.ImageCacheManager;
@@ -104,10 +106,11 @@ BaseListAdapter<EnrolledCoursesResponse> {
                 Date startDate = DateUtil.convertToDate(courseData.getStart());
                 String startDt; 
                 Date endDate = DateUtil.convertToDate(courseData.getEnd());
-                String endDt; 
-
-                if (!courseData.isStarted()) {
-                    if(startDate!=null){
+                String endDt;
+                AccessError error = enrollment.getCourse().getCoursewareAccess().getError_code();
+                if (error == AccessError.START_DATE_ERROR) {
+                    StartType type = enrollment.getCourse().getStartType();
+                    if(type.equals(StartType.TIMESTAMP_START)){
                         startDt = getContext().getString(R.string.label_starting_from)
                                 + " - " + dateformat.format(startDate);                 
                         holder.starting_from.setText(startDt);


### PR DESCRIPTION
This is the PR for MA-836. The "Jan 1, 2030" start date error is fixed using the new fields in the course enrollments mobile API endpoint.

Reviewers: @BenjiLee, @aleffert 