### PR TITLE
Force video player to LTR layout direction

### DIFF
--- a/VideoLocker/res/layout-land/player_controller.xml
+++ b/VideoLocker/res/layout-land/player_controller.xml
@@ -74,6 +74,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
+        android:layoutDirection="ltr"
         android:background="#CC000000"
         android:orientation="vertical"
         android:padding="7dp" >
@@ -201,6 +202,7 @@
         android:layout_height="match_parent"
         android:layout_above="@id/panel_bottom"
         android:layout_below="@id/video_top_bar"
+        android:layoutDirection="ltr"
         android:paddingLeft="10dp"
         android:paddingRight="10dp" >
 

--- a/VideoLocker/res/layout/player_controller.xml
+++ b/VideoLocker/res/layout/player_controller.xml
@@ -72,6 +72,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
+        android:layoutDirection="ltr"
         android:background="#CC000000"
         android:orientation="vertical"
         android:padding="7dp" >
@@ -206,6 +207,7 @@
         android:layout_height="match_parent"
         android:layout_above="@id/panel_bottom"
         android:layout_below="@id/video_top_bar"
+        android:layoutDirection="ltr"
         android:paddingLeft="10dp"
         android:paddingRight="10dp" >
 


### PR DESCRIPTION
It seems that video players are not customarily mirrored in RTL mode, and it's not implemented in the website as well, so we force it to LTR mode.

https://openedx.atlassian.net/browse/MA-837

@aleffert please review