### PR TITLE
Show disabled navigation buttons for course units

### DIFF
--- a/VideoLocker/res/color/button_text.xml
+++ b/VideoLocker/res/color/button_text.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="true" android:color="@color/edx_brand_primary_accent" />
+    <item android:color="@color/button_text_disabled" />
+</selector>

--- a/VideoLocker/res/layout/activity_course_base.xml
+++ b/VideoLocker/res/layout/activity_course_base.xml
@@ -194,7 +194,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:gravity="center_vertical"
-                        android:textColor="@color/edx_brand_primary_accent"
+                        android:textColor="?attr/buttonTextColor"
                         android:background="@color/white"
                         android:text="@string/assessment_previous_unit">
                 </Button>
@@ -209,7 +209,7 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_vertical"
                         android:background="@color/white"
-                        android:textColor="@color/edx_brand_primary_accent"
+                        android:textColor="?attr/buttonTextColor"
                         android:text="@string/assessment_next_unit">
                 </Button>
             </LinearLayout>

--- a/VideoLocker/res/values/attrs.xml
+++ b/VideoLocker/res/values/attrs.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <attr name="edgePopupMenuStyle" format="reference" />
+    <declare-styleable name="Theme">
+        <attr name="buttonTextColor" format="color" />
+        <attr name="edgePopupMenuStyle" format="reference" />
+    </declare-styleable>
 
     <declare-styleable name="PopupMenu">
         <attr name="android:dropDownWidth" />

--- a/VideoLocker/res/values/colors.xml
+++ b/VideoLocker/res/values/colors.xml
@@ -95,6 +95,7 @@
     <color name="video_details_background_transparent">#CC1F2124</color>
     <color name="delete_panel_bg">#3E4247</color>
     <color name="empty_list_text">#c8c8c8</color>
+    <color name="button_text_disabled">@color/edx_grayscale_neutral_base</color>
     <color name="switch_default_button_color">#C3C3C3</color>
     <color name="switch_default_bg_color">#3C4045</color>
     <color name="switch_disabled_bg_color_off">@color/grey_4</color>

--- a/VideoLocker/res/values/styles.xml
+++ b/VideoLocker/res/values/styles.xml
@@ -36,6 +36,7 @@
         <item name="android:popupMenuStyle">@style/CustomPopupMenu</item>
         <item name="edgePopupMenuStyle">@style/CustomEdgePopupMenu</item>
         <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
+        <item name="buttonTextColor">@color/button_text</item>
     </style>
 
     <!-- we need to change the color of the drawer arrow toggle -->

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -160,14 +160,9 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements 
 
         View prevButton = findViewById(R.id.goto_prev);
         Button nextButton = (Button) findViewById(R.id.goto_next);
-        nextButton.setVisibility(View.VISIBLE);
-        prevButton.setVisibility(View.VISIBLE);
+        prevButton.setEnabled(curIndex > 0);
+        nextButton.setEnabled(curIndex < pagerAdapter.getCount() - 1);
  
-        if ( curIndex == 0 ){
-            prevButton.setVisibility(View.GONE);
-        } else if ( curIndex >= pagerAdapter.getCount() -1 ){
-            nextButton.setVisibility(View.GONE);
-        }
         findViewById(R.id.course_unit_nav_bar).requestLayout();
 
         setTitle(selectedUnit.getDisplayName());


### PR DESCRIPTION
The agreed-upon style for non-interactable buttons is to disable them instead of hiding them. This commit changes the behaviour of the course unit navigation buttons to match this guideline.

https://openedx.atlassian.net/browse/MA-994

![disabled_nav_buttons](https://cloud.githubusercontent.com/assets/4244109/8709674/8cfdc8ce-2b5d-11e5-91c6-3ec4ecf47a11.png)