### PR TITLE
Remove usage of newer API

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/social/ISocialImpl.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/social/ISocialImpl.java
@@ -1,16 +1,15 @@
 package org.edx.mobile.social;
 
 import android.app.Activity;
-
-import java.lang.ref.WeakReference;
+import android.os.Bundle;
 
 public abstract class ISocialImpl implements ISocial {
     
     protected ISocial.Callback callback;
-    private WeakReference<Activity> activity;
+    protected Activity activity;
     
     public ISocialImpl(Activity activity) {
-        this.activity = new WeakReference<Activity>(activity);
+        this.activity = activity;
     }
     
     @Override
@@ -18,11 +17,17 @@ public abstract class ISocialImpl implements ISocial {
         this.callback = callback;
     }
 
-    public Activity getActivity(){
-        Activity wrapped = activity.get();
-        if ( wrapped != null ){
-            return wrapped.isFinishing() || wrapped.isDestroyed() ? null : wrapped;
-        }
-        return wrapped;
+    @Override
+    public void onActivityDestroyed(Activity activity) {
+        this.activity = null;
     }
+
+    // Providing empty implementations of the callbacks so that
+    // subclasses are not forced to implement all of them.
+    @Override public void onActivityCreated(Activity activity, Bundle savedInstanceState) {}
+    @Override public void onActivityPaused(Activity activity) {}
+    @Override public void onActivityResumed(Activity activity) {}
+    @Override public void onActivitySaveInstanceState(Activity activity, Bundle outState) {}
+    @Override public void onActivityStarted(Activity activity) {}
+    @Override public void onActivityStopped(Activity activity) {}
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/social/facebook/FacebookAuth.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/social/facebook/FacebookAuth.java
@@ -38,7 +38,6 @@ public class FacebookAuth extends ISocialImpl {
     @Override
     public void login() {
         Session session = Session.getActiveSession();
-        Activity activity = getActivity();
         if ( activity == null )
             return;
         if (session != null && !session.isOpened() && !session.isClosed()) {
@@ -57,6 +56,7 @@ public class FacebookAuth extends ISocialImpl {
 
     @Override
     public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+        super.onActivityCreated(activity, savedInstanceState);
         uiHelper = IUiLifecycleHelper.Factory.getInstance(activity, statusCallback);
         uiHelper.onCreate(savedInstanceState);
 
@@ -65,16 +65,19 @@ public class FacebookAuth extends ISocialImpl {
 
     @Override
     public void onActivityDestroyed(Activity activity) {
+        super.onActivityDestroyed(activity);
         uiHelper.onDestroy();
     }
 
     @Override
     public void onActivityPaused(Activity activity) {
+        super.onActivityPaused(activity);
         uiHelper.onPause();
     }
 
     @Override
     public void onActivityResumed(Activity activity) {
+        super.onActivityResumed(activity);
         // For scenarios where the main activity is launched and user
         // session is not null, the session state change notification
         // may not be triggered. Trigger it if it's open/closed.
@@ -88,15 +91,8 @@ public class FacebookAuth extends ISocialImpl {
 
     @Override
     public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+        super.onActivitySaveInstanceState(activity, outState);
         uiHelper.onSaveInstanceState(outState);
-    }
-
-    @Override
-    public void onActivityStarted(Activity activity) {
-    }
-
-    @Override
-    public void onActivityStopped(Activity activity) {
     }
 
     private void onSessionStateChange(Session session, SessionState state,
@@ -115,7 +111,6 @@ public class FacebookAuth extends ISocialImpl {
 
     private void keyHash() {
         try {
-            Activity activity = getActivity();
             if ( activity == null )
                 return;
             PackageInfo info = activity
@@ -144,7 +139,6 @@ public class FacebookAuth extends ISocialImpl {
                 //clear your preferences if saved
             }
         } else {
-            Activity activity = getActivity();
             if ( activity == null )
                 return;
             session = new Session(activity);

--- a/VideoLocker/src/main/java/org/edx/mobile/social/google/GoogleOauth2.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/social/google/GoogleOauth2.java
@@ -52,7 +52,6 @@ public class GoogleOauth2 extends ISocialImpl{
             String[] accountTypes = new String[]{"com.google"};
             Intent intent = AccountPicker.newChooseAccountIntent(null, null,
                     accountTypes, true, null, null, null, null);
-            Activity activity = getActivity();
             if ( activity == null )
                 return;
             // check if play-services are installed
@@ -79,7 +78,6 @@ public class GoogleOauth2 extends ISocialImpl{
         if (mEmail == null) {
             pickUserAccount();
         } else {
-            Activity activity = getActivity();
             if ( activity == null )
                 return;
             new FetchGoogleTokenTask(activity, mEmail, getScopes()).execute();
@@ -136,7 +134,6 @@ public class GoogleOauth2 extends ISocialImpl{
          * GoogleAuthException that may occur.
          */
         protected String fetchToken() throws IOException {
-            Activity activity = getActivity();
             if ( activity == null )
                 return null;
             try {
@@ -192,41 +189,6 @@ public class GoogleOauth2 extends ISocialImpl{
 
     
     @Override
-    public void onActivityCreated(Activity arg0, Bundle arg1) {
-        // nothing to do
-    }
-
-    @Override
-    public void onActivityDestroyed(Activity arg0) {
-        // nothing to do
-    }
-
-    @Override
-    public void onActivityPaused(Activity arg0) {
-        // nothing to do
-    }
-
-    @Override
-    public void onActivityResumed(Activity arg0) {
-        // nothing to do
-    }
-
-    @Override
-    public void onActivitySaveInstanceState(Activity arg0, Bundle arg1) {
-        // nothing to do
-    }
-
-    @Override
-    public void onActivityStarted(Activity arg0) {
-        // nothing to do
-    }
-
-    @Override
-    public void onActivityStopped(Activity arg0) {
-        // nothing to do
-    }
-    
-    @Override
     public void login() {
         pickUserAccount();
     }
@@ -235,7 +197,6 @@ public class GoogleOauth2 extends ISocialImpl{
     public void logout() {
         if (accessToken != null) {
             try {
-                Activity activity = getActivity();
                 if ( activity == null )
                     return;
                 GoogleAuthUtil.clearToken(activity, accessToken);


### PR DESCRIPTION
#193 added validity checks for the signup/login Activities using `ISocial` instances for authentication. That check included checking for destruction using the `isDestroyed()` method, which was introduced in API 17. This caused devices with lower API levels to crash upon authentication.

This pull request fixes this issue by removing the call to that method, and using the lifecycle callbacks to set the `Activity` variable to null upon destruction. This eliminates the need to use a weak reference as well, so that has been removed as well. All the lifecycle callback methods are now defined in the abstract `ISocialImpl` class, so that they don't need a stub definition in all the implementations.

https://openedx.atlassian.net/browse/MA-1113