### PR TITLE
Last accessed view now corresponds to the course section view

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
@@ -336,19 +336,13 @@ public abstract  class CourseBaseActivity  extends BaseFragmentActivity implemen
     }
 
     protected void showLastAccessedView(View v, String title, View.OnClickListener listener) {
-        try{
-            lastAccessBar.setVisibility(View.VISIBLE);
-            //
-            View lastAccessTextView = v == null ? findViewById(R.id.last_access_text) :
-                v.findViewById(R.id.last_access_text);
-            ((TextView)lastAccessTextView).setText(title);
-            View detailButton = v == null ? findViewById(R.id.last_access_button) :
-                v.findViewById(R.id.last_access_button);
-            detailButton.setOnClickListener(listener);
-
-        }catch(Exception e){
-            logger.error(e);
-        }
+        lastAccessBar.setVisibility(View.VISIBLE);
+        View lastAccessTextView = v == null ? findViewById(R.id.last_access_text) :
+            v.findViewById(R.id.last_access_text);
+        ((TextView)lastAccessTextView).setText(title);
+        View detailButton = v == null ? findViewById(R.id.last_access_button) :
+            v.findViewById(R.id.last_access_button);
+        detailButton.setOnClickListener(listener);
     }
 
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineActivity.java
@@ -7,8 +7,10 @@ import android.support.v4.app.FragmentTransaction;
 import com.google.inject.Inject;
 
 import org.edx.mobile.R;
+import org.edx.mobile.base.MainApplication;
 import org.edx.mobile.model.course.BlockPath;
 import org.edx.mobile.model.course.CourseComponent;
+import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.services.CourseManager;
 import org.edx.mobile.services.LastAccessManager;
 
@@ -90,6 +92,15 @@ public class CourseOutlineActivity extends CourseVideoListActivity {
         } else {
              fragment = (CourseOutlineFragment)
                  getSupportFragmentManager().findFragmentByTag(CourseOutlineFragment.TAG);
+        }
+
+        // We need to update LastAccessed Item if we are in CourseSubsection View
+        if (!isOnCourseOutline()) {
+            CourseComponent courseComponent = courseManager.getComponentById(courseData.getCourse().getId(), courseComponentId);
+            String prefName = PrefManager.getPrefNameForLastAccessedBy(getProfile()
+                    .username, courseComponent.getCourseId());
+            final PrefManager prefManager = new PrefManager(MainApplication.instance(), prefName);
+            prefManager.putLastAccessedSubsection(courseComponent.getId(), false);
         }
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -154,11 +154,10 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements 
 
         environment.getDatabase().updateAccess(null, selectedUnit.getId(), true);
 
-        CourseComponent parent = component.getParent();
         String prefName = PrefManager.getPrefNameForLastAccessedBy(getProfile()
             .username, selectedUnit.getCourseId());
         final PrefManager prefManager = new PrefManager(MainApplication.instance(), prefName);
-        prefManager.putLastAccessedSubsection(parent.getId(), false);
+        prefManager.putLastAccessedSubsection(this.selectedUnit.getId(), false);
         Intent resultData = new Intent();
         resultData.putExtra(Router.EXTRA_COURSE_UNIT, selectedUnit);
         setResult(RESULT_OK, resultData);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitVideoFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitVideoFragment.java
@@ -380,7 +380,6 @@ public class CourseUnitVideoFragment extends CourseUnitFragment
 
 
             try {
-                updateLastAccess(video);
                 // capture chapter name
                 if (chapterName == null) {
                     // capture the chapter name of this video
@@ -393,18 +392,6 @@ public class CourseUnitVideoFragment extends CourseUnitFragment
             }
         }catch(Exception ex){
             logger.error(ex);
-        }
-    }
-
-    private void updateLastAccess(DownloadEntry video){
-        try {
-            String prefName = PrefManager.getPrefNameForLastAccessedBy(getProfile()
-                .username, video.eid);
-            PrefManager prefManager = new PrefManager(getActivity(), prefName);
-            VideoResponseModel vrm = environment.getServiceManager().getVideoById(video.eid, video.videoId);
-            prefManager.putLastAccessedSubsection(vrm.getSection().getId(), false);
-        } catch (Exception e) {
-            logger.error(e);
         }
     }
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-912

Previously we had to navigate to Course Unit to register a Last Access item (which was that Course Unit's Subsection). But, I've now matched it with iOS, i.e., if we navigate to a Sub-Section or during our navigation within a Sub-Section's Units, we move onto another section, the new section is registered as the Last Accessed item. 

@aleffert plz review