### PR TITLE
fixed out of order arguments for last accessed module func

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/services/LastAccessManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/services/LastAccessManager.java
@@ -89,21 +89,24 @@ public class LastAccessManager {
                 //Preference's last accessed is not synched with server,
                 //Sync with server and display the result from server on UI.
                 if(prefModuleId!=null && prefModuleId.length()>0){
-                    syncLastAccessedWithServer(prefManager, view, courseId, prefModuleId, callback);
+                    syncLastAccessedWithServer(prefManager, view, prefModuleId, courseId, callback);
                 }
             }
         }else{
             //There is no Last Accessed module on the server
             if(prefModuleId!=null && prefModuleId.length()>0){
-                syncLastAccessedWithServer(prefManager, view, courseId, prefModuleId, callback);
+                syncLastAccessedWithServer(prefManager, view, prefModuleId, courseId, callback);
             }
         }
         callback.setFetchingLastAccessed( false );
     }
 
 
-    private void syncLastAccessedWithServer(final PrefManager prefManager,final View view,
-                                           String prefModuleId, final String courseId, final LastAccessManagerCallback callback){
+    private void syncLastAccessedWithServer(final PrefManager prefManager,
+                                            final View view,
+                                            String prefModuleId,
+                                            final String courseId,
+                                            final LastAccessManagerCallback callback){
         try{
             SyncLastAccessedTask syncLastAccessTask = new SyncLastAccessedTask(
                 MainApplication.instance(),courseId, prefModuleId) {


### PR DESCRIPTION
@aleffert Not sure if this is the way we want to address this long-term, but this PR still addresses the existing bug.