### PR TITLE
Handle case where local session cookie becomes invalid

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/services/EdxCookieManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/services/EdxCookieManager.java
@@ -53,8 +53,6 @@ public class EdxCookieManager {
         }
         PrefManager pref = new PrefManager(MainApplication.instance(), PrefManager.Pref.LOGIN);
         pref.put(PrefManager.Key.AUTH_ASSESSMENT_SESSION_ID, "");
-        //we can not get the expiration date from cookie, so just set it to expire for one day
-        pref.put(PrefManager.Key.AUTH_ASSESSMENT_SESSION_EXPIRATION, -1);
 
     }
 
@@ -92,18 +90,12 @@ public class EdxCookieManager {
                         EventBus.getDefault().post(new SessionIdRefreshEvent(false));
                         return;
                     }
-                    long currentTime = new Date().getTime();
+                    
                     for (HttpCookie cookie : result) {
                         if (cookie.getName().equals(PrefManager.Key.SESSION_ID)) {
                             clearWebWiewCookie(context);
                             PrefManager pref = new PrefManager(MainApplication.instance(), PrefManager.Pref.LOGIN);
                             pref.put(PrefManager.Key.AUTH_ASSESSMENT_SESSION_ID, cookie.getValue());
-                            long maxAgeInSecond = cookie.getMaxAge();
-                            if ( maxAgeInSecond == 0 ){
-                                pref.put(PrefManager.Key.AUTH_ASSESSMENT_SESSION_EXPIRATION, 0);
-                            } else {
-                                pref.put(PrefManager.Key.AUTH_ASSESSMENT_SESSION_EXPIRATION, currentTime + maxAgeInSecond * 1000);
-                            }
                             EventBus.getDefault().post(new SessionIdRefreshEvent(true));
                             break;
                         }


### PR DESCRIPTION
Even if we have a cookie in the cookie store, it may not be valid. This
change ensures that we always have a valid cookie, by just fetching one
right before we load (this is a pretty unfortunate way to solve this
problem, since it involes making more requests than we would like). We
should probably not bother doing this if we *just* fetched a cookie.
Filed ?filter=1440://openedx.atlassian.net/browse/MA-1153 to follow up.

Also as that ticket says, in the long term we should adopt the new API
that lets you listen for actual HTTP responses.

JIRA: https://openedx.atlassian.net/browse/MA-1006