### PR TITLE
Fix potential null reference access

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineActivity.java
@@ -127,7 +127,7 @@ public class CourseOutlineActivity extends CourseVideoListActivity {
                         BlockPath outlinePath = outlineComp.getPath();
                         BlockPath leafPath = leafComp.getPath();
                         int outlinePathSize = outlinePath.getPath().size();
-                        if (!leafPath.get(outlinePathSize - 1).equals(outlineComp)) {
+                        if (!outlineComp.equals(leafPath.get(outlinePathSize - 1))) {
                             setResult(RESULT_OK, data);
                             finish();
                         } else {


### PR DESCRIPTION
Commit 9ad9df6cec4dc77a275ce50511c7e3d1fbdcb1d3 implemented synchronization of the course unit navigation state to the outline back stack upon returning to it. However the logic it used assumed that the unit block path size would not be smaller than the size of the current outline block path. Therefore it did not allow the possibility of null when getting the block corresponding to the last block in the outline path from the leaf. This commit fixes this issue by reverting the `equals()` operation, and thus allowing the possibility of null as a result of that check.