### PR TITLE
Update OkHttp to 2.5.0 release

### DIFF
--- a/VideoLocker/build.gradle
+++ b/VideoLocker/build.gradle
@@ -89,8 +89,8 @@ dependencies {
     compile 'com.google.code.gson:gson:2.2.4'
     compile 'de.greenrobot:eventbus:2.4.0'
     compile 'com.squareup.phrase:phrase:1.0.3'
-    compile 'com.squareup.okhttp:okhttp:2.5.0-SNAPSHOT'
-    compile 'com.squareup.okhttp:okhttp-urlconnection:2.5.0-SNAPSHOT'
+    compile 'com.squareup.okhttp:okhttp:2.5.0'
+    compile 'com.squareup.okhttp:okhttp-urlconnection:2.5.0'
     compile 'com.squareup.retrofit:retrofit:1.9.0'
     compile 'com.android.support:support-v4:21.1.0'
     compile 'com.android.support:recyclerview-v7:21.0.0'
@@ -141,7 +141,7 @@ dependencies {
     testCompile("org.mockito:mockito-core:1.9.5") {
         exclude group: 'org.hamcrest'
     }
-    testCompile 'com.squareup.okhttp:mockwebserver:2.5.0-SNAPSHOT'
+    testCompile 'com.squareup.okhttp:mockwebserver:2.5.0'
 }
 
 configurations {


### PR DESCRIPTION
OkHttp 2.5.0 has been released, along with it's URLConnection and MockWebServer modules. This commit updates our Gradle dependencies to use the release instead of the snapshot which is no longer available.