### PR TITLE
Smart refreshing & comment counts

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionThread.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionThread.java
@@ -16,6 +16,8 @@
 
 package org.edx.mobile.discussion;
 
+import android.support.annotation.NonNull;
+
 import com.google.gson.annotations.SerializedName;
 
 import java.io.Serializable;
@@ -170,6 +172,18 @@ public class DiscussionThread implements Serializable, IAuthorData {
 
     public boolean isRead() {
         return read;
+    }
+
+    public void incrementCommentCount() {
+        ++this.commentCount;
+    }
+
+    public boolean hasSameId(@NonNull DiscussionThread discussionThread) {
+        return discussionThread.getIdentifier().equals(identifier);
+    }
+
+    public boolean containsComment(@NonNull DiscussionComment comment) {
+        return comment.getThreadId().equals(identifier);
     }
 
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
@@ -131,8 +131,11 @@ public class CourseDiscussionResponsesFragment extends RoboFragment implements C
     }
 
     public void onEventMainThread(DiscussionCommentPostedEvent event) {
-        // TODO: Optimization: Only refresh if it's a reply to this post or a comment on one of its replies
-        getCommentList(true);
+        if (discussionThread.containsComment(event.getComment())) {
+            discussionThread.incrementCommentCount();
+            courseDiscussionResponsesAdapter.notifyDataSetChanged();
+            getCommentList(true);
+        }
     }
 
     /**

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/BaseListAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/BaseListAdapter.java
@@ -31,6 +31,7 @@ public abstract class BaseListAdapter<T> extends ArrayAdapter<T> implements OnIt
     public static final int STATE_NOT_SELECTED = 0;
     public static final int STATE_SELECTED = 1;
     private final int layoutResource;
+    private final List<T> objects;
 
     private SparseIntArray selection = new SparseIntArray(); 
     public static final long MIN_CLICK_INTERVAL = 1000; //in millis
@@ -54,9 +55,14 @@ public abstract class BaseListAdapter<T> extends ArrayAdapter<T> implements OnIt
     }
 
     public BaseListAdapter(Context context, int layoutResourceId, IEdxEnvironment environment) {
-        super(context, layoutResourceId);
+        this(context, layoutResourceId, environment, new ArrayList<T>());
+    }
+
+    private BaseListAdapter(Context context, int layoutResourceId, IEdxEnvironment environment, List<T> list) {
+        super(context, layoutResourceId, list);
         layoutResource = layoutResourceId;
         this.environment = environment;
+        this.objects = list;
     }
     
     /**
@@ -135,6 +141,11 @@ public abstract class BaseListAdapter<T> extends ArrayAdapter<T> implements OnIt
          super.addAll(collection);
          pagination.addPage(collection.size());
          pagination.setHasMorePages(hasMore);
+    }
+
+    public void replace(T item, int position) {
+        objects.set(position, item);
+        notifyDataSetChanged();
     }
 
     public int getCount(){


### PR DESCRIPTION
This implements some TODOs around refreshing post threads after certain events.

This fixes https://openedx.atlassian.net/browse/MA-1187 and https://openedx.atlassian.net/browse/MA-1179

For now, we are updating the comment count in the client. Ideally we would obtain an updated count from the server but the API to fetch a thread's data is not implemented yet (https://openedx.atlassian.net/browse/MA-1182)