### PR TITLE
Fix color issues on add post form

### DIFF
--- a/VideoLocker/res/color/edx_brand_primary_selector.xml
+++ b/VideoLocker/res/color/edx_brand_primary_selector.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="false" android:color="@color/edx_brand_primary_light" />
-    <item android:color="@color/edx_brand_primary_base" />
-</selector>

--- a/VideoLocker/res/color/edx_segmented_control_background_selector.xml
+++ b/VideoLocker/res/color/edx_segmented_control_background_selector.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_checked="true" android:color="@color/edx_grayscale_neutral_light" />
-    <item android:color="@color/edx_grayscale_neutral_white" />
-</selector>

--- a/VideoLocker/res/drawable/edx_creation_button.xml
+++ b/VideoLocker/res/drawable/edx_creation_button.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle" android:padding="10dp">
-    <solid android:color="@color/edx_brand_primary_selector"/>
-    <corners android:radius="@dimen/edx_box_radius"/>
-</shape>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/edx_brand_primary_x_light" />
+            <corners android:radius="@dimen/edx_box_radius" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/edx_brand_primary_base" />
+            <corners android:radius="@dimen/edx_box_radius" />
+        </shape>
+    </item>
+</selector>

--- a/VideoLocker/res/drawable/edx_segmented_control_left_background.xml
+++ b/VideoLocker/res/drawable/edx_segmented_control_left_background.xml
@@ -1,14 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="@color/edx_segmented_control_background_selector" />
-    <stroke
-        android:width="@dimen/edx_hairline"
-        android:color="@color/edx_grayscale_neutral_light" />
-    <corners
-        android:bottomLeftRadius="@dimen/edx_box_radius"
-        android:bottomRightRadius="0dp"
-        android:radius="@dimen/edx_box_radius"
-        android:topLeftRadius="@dimen/edx_box_radius"
-        android:topRightRadius="0dp" />
-</shape>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true">
+        <shape
+            android:shape="rectangle">
+            <solid android:color="@color/edx_grayscale_neutral_light" />
+            <stroke
+                android:width="@dimen/edx_hairline"
+                android:color="@color/edx_grayscale_neutral_light" />
+            <corners
+                android:bottomLeftRadius="@dimen/edx_box_radius"
+                android:bottomRightRadius="0dp"
+                android:radius="@dimen/edx_box_radius"
+                android:topLeftRadius="@dimen/edx_box_radius"
+                android:topRightRadius="0dp" />
+        </shape>
+    </item>
+    <item>
+        <shape
+            android:shape="rectangle">
+            <solid android:color="@color/edx_grayscale_neutral_white" />
+            <stroke
+                android:width="@dimen/edx_hairline"
+                android:color="@color/edx_grayscale_neutral_light" />
+            <corners
+                android:bottomLeftRadius="@dimen/edx_box_radius"
+                android:bottomRightRadius="0dp"
+                android:radius="@dimen/edx_box_radius"
+                android:topLeftRadius="@dimen/edx_box_radius"
+                android:topRightRadius="0dp" />
+        </shape>
+    </item>
+</selector>

--- a/VideoLocker/res/drawable/edx_segmented_control_right_background.xml
+++ b/VideoLocker/res/drawable/edx_segmented_control_right_background.xml
@@ -1,14 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="@color/edx_segmented_control_background_selector" />
-    <stroke
-        android:width="@dimen/edx_hairline"
-        android:color="@color/edx_grayscale_neutral_light" />
-    <corners
-        android:bottomLeftRadius="0dp"
-        android:bottomRightRadius="@dimen/edx_box_radius"
-        android:radius="@dimen/edx_box_radius"
-        android:topLeftRadius="0dp"
-        android:topRightRadius="@dimen/edx_box_radius" />
-</shape>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true">
+        <shape
+            android:shape="rectangle">
+            <solid android:color="@color/edx_grayscale_neutral_light" />
+            <stroke
+                android:width="@dimen/edx_hairline"
+                android:color="@color/edx_grayscale_neutral_light" />
+            <corners
+                android:bottomLeftRadius="0dp"
+                android:bottomRightRadius="@dimen/edx_box_radius"
+                android:radius="@dimen/edx_box_radius"
+                android:topLeftRadius="0dp"
+                android:topRightRadius="@dimen/edx_box_radius" />
+        </shape>
+    </item>
+    <item>
+        <shape
+            android:shape="rectangle">
+            <solid android:color="@color/edx_grayscale_neutral_white" />
+            <stroke
+                android:width="@dimen/edx_hairline"
+                android:color="@color/edx_grayscale_neutral_light" />
+            <corners
+                android:bottomLeftRadius="0dp"
+                android:bottomRightRadius="@dimen/edx_box_radius"
+                android:radius="@dimen/edx_box_radius"
+                android:topLeftRadius="0dp"
+                android:topRightRadius="@dimen/edx_box_radius" />
+        </shape>
+    </item>
+</selector>

--- a/VideoLocker/res/layout/fragment_add_post.xml
+++ b/VideoLocker/res/layout/fragment_add_post.xml
@@ -52,7 +52,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/widget_margin">
 
-                <Spinner
+                <android.support.v7.widget.AppCompatSpinner
                     android:id="@+id/topics_spinner"
                     style="@style/edX.Widget.Spinner"
                     android:layout_width="match_parent"

--- a/VideoLocker/res/values/styles.xml
+++ b/VideoLocker/res/values/styles.xml
@@ -1,5 +1,4 @@
-<resources xmlns:tools="http://schemas.android.com/tools"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
 
     <!--
         Base application theme, dependent on API level. This theme is replaced
@@ -16,13 +15,13 @@
     <!-- Application theme. -->
     <style name="AppTheme" parent="AppBaseTheme">
         <!-- All customizations that are NOT specific to a particular API-level can go here. -->
-        
+
     </style>
 
     <!-- A theme for a custom dialog appearance. -->
     <style name="Theme.CustomDialog" parent="android:style/Theme.Dialog">
-        
-        <item name="android:textColor">#faca64</item> 
+
+        <item name="android:textColor">#faca64</item>
     </style>
 
     <!-- the theme applied to the application or activity -->
@@ -41,7 +40,7 @@
 
     <!-- we need to change the color of the drawer arrow toggle -->
     <style name="DrawerArrowStyle" parent="Widget.AppCompat.DrawerArrowToggle">
-         <item name="color">@color/white</item>
+        <item name="color">@color/white</item>
     </style>
 
     <!-- Custom Preview Screen Theme -->
@@ -60,8 +59,7 @@
     </style>
 
     <!-- ActionBar title text -->
-    <style name="MyActionBarTitleText"
-           parent="@android:style/TextAppearance.Holo.Widget.ActionBar.Title">
+    <style name="MyActionBarTitleText" parent="@android:style/TextAppearance.Holo.Widget.ActionBar.Title">
         <item name="android:textSize">18sp</item>
         <item name="android:textColor">@color/white</item>
     </style>
@@ -106,7 +104,7 @@
     <style name="course_header_separator_style" parent="separator_style">
         <item name="android:background">@color/edx_brand_primary_base</item>
     </style>
-    
+
     <!-- Custom menu popup -->
     <style name="CustomPopupMenu" android:parent="Widget.Holo.Light.PopupMenu">
         <item name="android:popupBackground">@drawable/white_rounded_bordered_bg</item>
@@ -117,18 +115,18 @@
         <item name="itemVerticalPadding">@dimen/popupMenuItemVerticalPadding</item>
         <item name="iconDefaultSize">@dimen/popupMenuIconDefaultSize</item>
     </style>
-    
+
     <style name="CustomEdgePopupMenu" parent="@style/CustomPopupMenu">
         <item name="android:dropDownHorizontalOffset">@dimen/popupMenuHorizontalOffset</item>
     </style>
-    
+
     <style name="CustomProgressBar" parent="android:Widget.ProgressBar.Horizontal">
         <item name="android:indeterminateOnly">false</item>
         <item name="android:progressDrawable">@drawable/custom_progress_bar_horizontal_red</item>
         <item name="android:minHeight">3dip</item>
         <item name="android:maxHeight">3dip</item>
     </style>
-    
+
     <style name="default_switch" parent="@style/semibold_text">
         <item name="android:textColor">@color/switch_text_color</item>
         <item name="android:textSize">14sp</item>
@@ -214,6 +212,7 @@
 
     <!-- Styles from the edX style guide will be nested under "edX" -->
     <style name="edX" />
+
     <style name="edX.Widget" />
 
     <style name="edX.Widget.EditText">
@@ -233,6 +232,9 @@
     </style>
 
     <style name="edX.Widget.Spinner" parent="@style/Widget.AppCompat.Spinner">
+        <!-- We're using the default appcompat spinner background, but the margin beside the dropdown arrow is to small -->
+        <!-- Add [edX widget_margin of 10dp] minus [AppCompat background's built-in padding of 7dp] -->
+        <item name="android:layout_marginRight">3dp</item>
     </style>
 
     <style name="edX.Widget.SpinnerContainer">
@@ -240,7 +242,6 @@
     </style>
 
     <style name="edX.Widget.SegmentedControlSegment">
-        <item name="android:background">@color/edx_segmented_control_background_selector</item>
         <item name="android:textColor">@color/edx_segmented_control_text_selector</item>
         <item name="android:textSize">@dimen/edx_x_small</item>
         <item name="android:button">@null</item>
@@ -254,6 +255,7 @@
     <style name="edX.Widget.SegmentedControlSegment.Start" parent="edX.Widget.SegmentedControlSegment">
         <item name="android:background">@drawable/edx_segmented_control_left_background</item>
     </style>
+
     <style name="edX.Widget.SegmentedControlSegment.End" parent="edX.Widget.SegmentedControlSegment">
         <item name="android:background">@drawable/edx_segmented_control_right_background</item>
     </style>

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddPostFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddPostFragment.java
@@ -2,6 +2,7 @@ package org.edx.mobile.view;
 
 import android.os.Bundle;
 import android.support.annotation.StringRes;
+import android.support.v4.view.ViewCompat;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.LayoutInflater;
@@ -122,6 +123,8 @@ public class DiscussionAddPostFragment extends RoboFragment {
         discussionQuestionSegmentedGroup.check(R.id.discussion_radio_button);
 
         getTopicList();
+
+        ViewCompat.setBackgroundTintList(topicsSpinner, getResources().getColorStateList(R.color.edx_grayscale_neutral_dark));
 
         topicsSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
 


### PR DESCRIPTION
Very unfortunately, you can't use color state lists in shapes until API 21 :(
So, I removed them from the new shapes I had defined, instead being forced to duplicate the shapes.

I also added a manual tint setting for the spinner (which is only necessary until we get around to switching our base theme to an AppCompat theme).

And I lightened the disabled button color, since it was still too dark to appear "disabled".