### PR TITLE
Upgrade Robolectric to 3.1 SNAPSHOT

### DIFF
--- a/VideoLocker/build.gradle
+++ b/VideoLocker/build.gradle
@@ -122,9 +122,9 @@ dependencies {
      testCompile ("org.mockito:mockito-core:1.9.5"){
          exclude group: 'org.hamcrest'
       }
-     testCompile "org.robolectric:robolectric:3.0"
-     testCompile "org.robolectric:shadows-support-v4:3.0"
-     testCompile "org.robolectric:shadows-multidex:3.0"
+     testCompile "org.robolectric:robolectric:3.1-SNAPSHOT"
+     testCompile "org.robolectric:shadows-support-v4:3.1-SNAPSHOT"
+     testCompile "org.robolectric:shadows-multidex:3.1-SNAPSHOT"
     /**
      * Adding the jars statically because the assertj-android
      * module is only available in Maven Central as an AAR,

--- a/VideoLocker/src/test/java/org/edx/mobile/view/CourseBaseActivityTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/CourseBaseActivityTest.java
@@ -102,7 +102,6 @@ public abstract class CourseBaseActivityTest extends BaseFragmentActivityTest {
      * Testing functionality upon receiving a DownloadEvent
      */
     @Test
-    @Ignore // Hangs indefinitely. Fixed in https://github.com/robolectric/robolectric/pull/2017
     public void downloadEventTest() {
         CourseBaseActivity activity =
                 Robolectric.buildActivity(getActivityClass())


### PR DESCRIPTION
It looks like the Robolectric 3.1 SNAPSHOT artifact is working fine now. Upgrade to it so that we can fix the test that was blocked by the [issue](robolectric/robolectric#2017) with infinitely repeating animations permanently blocking the test, and disabled in #351.