### PR TITLE
Fix RoboGuice injection issues

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/base/CourseDetailBaseFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/CourseDetailBaseFragment.java
@@ -59,7 +59,7 @@ public class CourseDetailBaseFragment extends RoboFragment {
                 openInBrowserTv.setOnClickListener(new OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        new BrowserUtil().open(getActivity(),
+                        BrowserUtil.open(getActivity(),
                                 urlStringBuffer.toString());
                     }
                 });

--- a/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
@@ -81,7 +81,7 @@ public class FindCoursesBaseActivity extends BaseFragmentActivity
                 @Override
                 public void onOpenExternalURL(String url) {
                     // open URL in external browser
-                    new BrowserUtil().open(FindCoursesBaseActivity.this, url);
+                    BrowserUtil.open(FindCoursesBaseActivity.this, url);
                 }
             };
 

--- a/VideoLocker/src/main/java/org/edx/mobile/core/EdxDefaultModule.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/core/EdxDefaultModule.java
@@ -24,6 +24,7 @@ import org.edx.mobile.module.notification.NotificationDelegate;
 import org.edx.mobile.module.notification.ParseNotificationDelegate;
 import org.edx.mobile.module.storage.IStorage;
 import org.edx.mobile.module.storage.Storage;
+import org.edx.mobile.util.BrowserUtil;
 import org.edx.mobile.util.Config;
 
 public class EdxDefaultModule extends AbstractModule {
@@ -74,6 +75,8 @@ public class EdxDefaultModule extends AbstractModule {
         bind(IEdxEnvironment.class).to(EdxEnvironment.class);
 
         bind(LinearLayoutManager.class).toProvider(LinearLayoutManagerProvider.class);
+
+        requestStaticInjection(BrowserUtil.class);
 
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/http/OutboundUrlSpan.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/OutboundUrlSpan.java
@@ -28,7 +28,7 @@ public class OutboundUrlSpan extends URLSpan {
         Context context = widget.getContext();
 
         if(context instanceof FragmentActivity)
-            new BrowserUtil().open((FragmentActivity)context, getURL());
+            BrowserUtil.open((FragmentActivity)context, getURL());
     }
 
     public static Spanned interceptAllLinks(Spanned content){

--- a/VideoLocker/src/main/java/org/edx/mobile/player/PlayerFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/PlayerFragment.java
@@ -101,6 +101,8 @@ public class PlayerFragment extends RoboFragment implements IPlayerListener, Ser
     private TimedTextObject srt;
     private String languageSubtitle;
     private LayoutInflater layoutInflater;
+    @Inject
+    private TranscriptManager transcriptManager;
     private TranscriptModel transcript;
     private DownloadEntry videoEntry;
 
@@ -282,7 +284,7 @@ public class PlayerFragment extends RoboFragment implements IPlayerListener, Ser
                         } else {
                             urlStringBuffer.append( videoEntry.url);
                         }
-                        new BrowserUtil().open(getActivity(),
+                        BrowserUtil.open(getActivity(),
                                 urlStringBuffer.toString());
                     }
 
@@ -513,8 +515,7 @@ public class PlayerFragment extends RoboFragment implements IPlayerListener, Ser
         if (trModel != null)
         {
             this.transcript = trModel;
-            TranscriptManager tm = new TranscriptManager(getActivity());
-            tm.downloadTranscriptsForVideo(trModel);
+            transcriptManager.downloadTranscriptsForVideo(trModel);
             //initializeClosedCaptioning();
         }
 
@@ -867,7 +868,7 @@ public class PlayerFragment extends RoboFragment implements IPlayerListener, Ser
     public void callLMSServer(String url) {
         try{
             if(url!=null){
-                new BrowserUtil().open(getActivity(), url);
+                BrowserUtil.open(getActivity(), url);
             }
         }catch(Exception e){
             logger.error(e);
@@ -1167,8 +1168,7 @@ public class PlayerFragment extends RoboFragment implements IPlayerListener, Ser
             srtList = new LinkedHashMap<String, TimedTextObject>();
             try
             {
-                TranscriptManager tm = new TranscriptManager(getActivity());
-                LinkedHashMap<String, InputStream> localHashMap = tm
+                LinkedHashMap<String, InputStream> localHashMap = transcriptManager
                         .fetchTranscriptsForVideo(transcript,getActivity());
                 
                 if (localHashMap != null){

--- a/VideoLocker/src/main/java/org/edx/mobile/player/TranscriptManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/TranscriptManager.java
@@ -3,6 +3,9 @@ package org.edx.mobile.player;
 import android.content.Context;
 import android.os.Environment;
 
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
 import org.apache.commons.io.IOUtils;
 import org.edx.mobile.R;
 import org.edx.mobile.model.api.TranscriptModel;
@@ -19,12 +22,14 @@ import java.security.NoSuchAlgorithmException;
 import java.util.LinkedHashMap;
 import org.edx.mobile.logger.Logger;
 
+@Singleton
 public class TranscriptManager {
 
     private File transcriptFolder;
     private Context context;
     private final Logger logger = new Logger(getClass().getName());
 
+    @Inject
     public TranscriptManager(Context context) {
         try{
             this.context = context;

--- a/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
@@ -14,6 +14,8 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.google.inject.Inject;
+
 import org.edx.mobile.R;
 import org.edx.mobile.base.MyVideosBaseFragment;
 import org.edx.mobile.interfaces.SectionItemInterface;
@@ -67,6 +69,8 @@ public class VideoListFragment extends MyVideosBaseFragment {
     private DownloadEntry videoModel;
     private boolean downloadAvailable = false;
     private Button deleteButton;
+    @Inject
+    TranscriptManager transcriptManager;
 
     private final Logger logger = new Logger(getClass().getName());
 
@@ -556,7 +560,7 @@ public class VideoListFragment extends MyVideosBaseFragment {
                     openInBrowserTv.setOnClickListener(new OnClickListener() {
                         @Override
                         public void onClick(View v) {
-                            new BrowserUtil().open(getActivity(),
+                            BrowserUtil.open(getActivity(),
                                     urlStringBuffer.toString());
                         }
                     });
@@ -999,8 +1003,7 @@ public class VideoListFragment extends MyVideosBaseFragment {
                 if (reloadListFlag) {
                     adapter.notifyDataSetChanged();
                 }
-                TranscriptManager transManager = new TranscriptManager(getActivity());
-                transManager.downloadTranscriptsForVideo(downloadEntry.transcript);
+                transcriptManager.downloadTranscriptsForVideo(downloadEntry.transcript);
             }
         }catch(Exception e){
             logger.error(e);

--- a/VideoLocker/src/main/java/org/edx/mobile/task/EnqueueDownloadTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/EnqueueDownloadTask.java
@@ -2,6 +2,8 @@ package org.edx.mobile.task;
 
 import android.content.Context;
 
+import com.google.inject.Inject;
+
 import org.edx.mobile.model.db.DownloadEntry;
 import org.edx.mobile.player.TranscriptManager;
 
@@ -10,6 +12,8 @@ import java.util.List;
 public abstract class EnqueueDownloadTask extends Task<Long> {
 
 
+    @Inject
+    TranscriptManager transcriptManager;
     List<DownloadEntry> downloadList;
     public EnqueueDownloadTask(Context context, List<DownloadEntry> downloadList) {
         super(context);
@@ -27,8 +31,7 @@ public abstract class EnqueueDownloadTask extends Task<Long> {
                         if(environment.getStorage().addDownload(de)!=-1){
                             count++;
                         }
-                        TranscriptManager transManager = new TranscriptManager(context);
-                        transManager.downloadTranscriptsForVideo(de.transcript);
+                        transcriptManager.downloadTranscriptsForVideo(de.transcript);
                     }catch(Exception e){
                         logger.error(e);
                     }

--- a/VideoLocker/src/main/java/org/edx/mobile/util/BrowserUtil.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/BrowserUtil.java
@@ -20,8 +20,12 @@ public class BrowserUtil {
 
     private static final String TAG = BrowserUtil.class.getCanonicalName();
 
+    private BrowserUtil() {
+        throw new UnsupportedOperationException();
+    }
+
     @Inject
-    IEdxEnvironment environment;
+    private static IEdxEnvironment environment;
 
     /**
      * Opens given URL in native browser.
@@ -32,7 +36,7 @@ public class BrowserUtil {
      * @param activity
      * @param url
      */
-    public  void open(final FragmentActivity activity, final String url) {
+    public static void open(final FragmentActivity activity, final String url) {
         if (TextUtils.isEmpty(url) || activity == null){
             logger.warn("cannot open URL in browser, either URL or activity parameter is NULL");
             return;
@@ -80,7 +84,7 @@ public class BrowserUtil {
         }
     }
 
-    private  void openInBrowser(FragmentActivity context, String url) {
+    private static void openInBrowser(FragmentActivity context, String url) {
         try {
             Intent intent = new Intent(Intent.ACTION_VIEW);
             intent.addCategory(Intent.CATEGORY_BROWSABLE);

--- a/VideoLocker/src/main/java/org/edx/mobile/util/TranscriptDownloader.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/TranscriptDownloader.java
@@ -11,6 +11,8 @@ import org.edx.mobile.services.ServiceManager;
 
 import java.io.IOException;
 
+import roboguice.RoboGuice;
+
 public abstract class TranscriptDownloader implements Runnable {
 
     private String srtUrl;
@@ -22,6 +24,7 @@ public abstract class TranscriptDownloader implements Runnable {
     public TranscriptDownloader(Context context, String url) {
         this.srtUrl = url;
         this.context = context;
+        RoboGuice.getInjector(context).injectMembers(this);
     }
 
     @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CertificateFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CertificateFragment.java
@@ -82,7 +82,7 @@ public class CertificateFragment extends RoboFragment {
 
             @Override
             public void onOpenExternalURL(String url) {
-                new BrowserUtil().open(getActivity(), url);
+                BrowserUtil.open(getActivity(), url);
             }
         };
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
@@ -319,7 +319,7 @@ public abstract  class CourseBaseActivity  extends BaseFragmentActivity implemen
         //registering popup with OnMenuItemClickListener
         popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
             public boolean onMenuItemClick(MenuItem item) {
-                new BrowserUtil().open(CourseBaseActivity.this, getUrlForWebView());
+                BrowserUtil.open(CourseBaseActivity.this, getUrlForWebView());
                 CourseComponent courseComponent = courseManager.getComponentById(courseData.getCourse().getId(), courseComponentId);
                 environment.getSegment().trackOpenInBrowser(courseComponentId
                         , courseData.getCourse().getId(), courseComponent.isMultiDevice());

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseCombinedInfoFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseCombinedInfoFragment.java
@@ -120,7 +120,7 @@ public class CourseCombinedInfoFragment extends CourseDetailBaseFragment impleme
 
             @Override
             public void onOpenExternalURL(String url) {
-                new BrowserUtil().open(getActivity(), url);
+                BrowserUtil.open(getActivity(), url);
             }
         };
         // treat every link as external link in this view, so that all links will open in external browser

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseHandoutFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseHandoutFragment.java
@@ -67,7 +67,7 @@ public class CourseHandoutFragment extends RoboFragment {
 
             @Override
             public void onOpenExternalURL(String url) {
-                new BrowserUtil().open(getActivity(), url);
+                BrowserUtil.open(getActivity(), url);
             }
         };
 
@@ -105,7 +105,7 @@ public class CourseHandoutFragment extends RoboFragment {
                         webview.setWebViewClient(new WebViewClient(){
                             @Override
                             public boolean shouldOverrideUrlLoading(final WebView view, final String url) {
-                                new BrowserUtil().open(getActivity(), url);
+                                BrowserUtil.open(getActivity(), url);
                                 return true;
                             }
                         });

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseLectureListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseLectureListActivity.java
@@ -277,7 +277,7 @@ public class CourseLectureListActivity extends BaseFragmentActivity {
             openInBrowserTv.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    new BrowserUtil().open(CourseLectureListActivity.this,
+                    BrowserUtil.open(CourseLectureListActivity.this,
                             urlStringBuffer.toString());
                 }
             });

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.java
@@ -48,7 +48,7 @@ public class CourseUnitMobileNotSupportedFragment extends CourseUnitFragment{
         v.findViewById(R.id.view_on_web_button).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                new BrowserUtil().open(getActivity(), unit.getWebUrl());
+                BrowserUtil.open(getActivity(), unit.getWebUrl());
                 environment.getSegment().trackOpenInBrowser(unit.getId()
                         , unit.getCourseId(), unit.isMultiDevice());
             }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitVideoFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitVideoFragment.java
@@ -20,6 +20,8 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.google.inject.Inject;
+
 import org.edx.mobile.R;
 import org.edx.mobile.base.BaseFragmentActivity;
 import org.edx.mobile.logger.Logger;
@@ -76,6 +78,9 @@ public class CourseUnitVideoFragment extends CourseUnitFragment
     private Runnable playPending;
     private final Handler playHandler = new Handler();
     private View messageContainer;
+
+    @Inject
+    TranscriptManager transcriptManager;
 
 
     /**
@@ -499,7 +504,7 @@ public class CourseUnitVideoFragment extends CourseUnitFragment
                     openInBrowserTv.setOnClickListener(new View.OnClickListener() {
                         @Override
                         public void onClick(View v) {
-                            new BrowserUtil().open(getActivity(),
+                            BrowserUtil.open(getActivity(),
                                 urlStringBuffer.toString());
                         }
                     });
@@ -692,8 +697,7 @@ public class CourseUnitVideoFragment extends CourseUnitFragment
                 if (reloadListFlag) {
                     //adapter.notifyDataSetChanged();
                 }
-                TranscriptManager transManager = new TranscriptManager(getActivity());
-                transManager.downloadTranscriptsForVideo(downloadEntry.transcript);
+                transcriptManager.downloadTranscriptsForVideo(downloadEntry.transcript);
 
         }catch(Exception e){
             logger.error(e);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/FriendsInCourseFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/FriendsInCourseFragment.java
@@ -112,7 +112,7 @@ public class FriendsInCourseFragment extends RoboFragment implements LoaderManag
                 @Override
                 public void onClick(View v) {
 
-                    new BrowserUtil().open(getActivity(), courseData.getCourse_url());
+                    BrowserUtil.open(getActivity(), courseData.getCourse_url());
 
                 }
             });

--- a/VideoLocker/src/main/java/org/edx/mobile/view/dialog/DialogFactory.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/dialog/DialogFactory.java
@@ -43,7 +43,7 @@ public class DialogFactory {
         dialog.setMessage(activity.getString(R.string.open_external_url_desc));
         dialog.setPositiveButton(R.string.label_continue, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface d, int which) {
-                new BrowserUtil().open(activity, uri);
+                BrowserUtil.open(activity, uri);
                 d.dismiss();
             }
         });

--- a/VideoLocker/src/main/java/org/edx/mobile/view/dialog/FindCoursesDialogFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/dialog/FindCoursesDialogFragment.java
@@ -54,7 +54,7 @@ public class FindCoursesDialogFragment extends RoboDialogFragment {
                 // or is visible before dismissing the dialog
                 if(!isRemoving() && isVisible()){
                     String url = environment.getConfig().getEnrollmentConfig().getExternalCourseSearchUrl();
-                    new BrowserUtil().open(getActivity(), url);
+                    BrowserUtil.open(getActivity(), url);
                 }
             }
         });

--- a/VideoLocker/src/main/java/org/edx/mobile/view/dialog/WebViewDialogFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/dialog/WebViewDialogFragment.java
@@ -54,7 +54,7 @@ public class WebViewDialogFragment extends DialogFragment {
                     progress.setVisibility(View.GONE);
 
                     // open URL in external browser
-                    new BrowserUtil().open(getActivity(), url);
+                    BrowserUtil.open(getActivity(), url);
                 }
             };
             client.setPageStatusListener(new URLInterceptorWebViewClient.IPageStatusListener() {


### PR DESCRIPTION
RoboGuice was integrated in #273. However, some injections were not set up properly. The null pointer exceptions that were caused by this were swallowed by the assorted generic exception catching blocks that are scattered throughout the codebase. This pull request attempts to fix these issues:

1. `TranscriptDownloader` did not set up RoboGuice to initialize it's injection of the `ServiceManager` instance. This has been fixed. Related to this, `TranscriptManager` has also been converted into a RoboGuice singleton, and injected appropriately.

2. `BrowserUtil` was instantiated manually instead of being injected, and thus it's injection of the `IEdxEnvironment` instance was not being initialized as well. It has now been converted into a static utility method, with the `IEdxEnvironment` instance injected as a static field from our RoboGuice module.

https://openedx.atlassian.net/browse/MA-1114