### PR TITLE
Fix segment OutOfMemory error on compiling for version < Lollipop

### DIFF
--- a/VideoLocker/build.gradle
+++ b/VideoLocker/build.gradle
@@ -84,30 +84,33 @@ dependencies {
     }
     compile fileTree(dir: 'libs', include: '*.jar')
     compile 'com.facebook.android:facebook-android-sdk:3.22.+'
-    compile 'com.google.android.gms:play-services-base:7.5.0'
-    compile 'com.google.android.gms:play-services-plus:7.5.0'
-    compile 'com.google.android.gms:play-services-identity:7.5.0'
-    compile 'com.google.android.gms:play-services-analytics:7.5.0'
-    compile 'com.google.android.gms:play-services-gcm:7.5.0'
-    compile 'com.google.android.gms:play-services-location:7.5.0'
+    compile 'com.google.android.gms:play-services-base:7.8.0'
+    compile 'com.google.android.gms:play-services-plus:7.8.0'
+    compile 'com.google.android.gms:play-services-identity:7.8.0'
+    compile 'com.google.android.gms:play-services-analytics:7.8.0'
+    compile 'com.google.android.gms:play-services-gcm:7.8.0'
+    compile 'com.google.android.gms:play-services-location:7.8.0'
     compile 'com.google.code.gson:gson:2.2.4'
     compile 'de.greenrobot:eventbus:2.4.0'
     compile 'com.squareup.phrase:phrase:1.0.3'
     compile 'com.squareup.okhttp:okhttp:2.5.0'
     compile 'com.squareup.okhttp:okhttp-urlconnection:2.5.0'
     compile 'com.squareup.retrofit:retrofit:1.9.0'
-    compile 'com.android.support:support-v4:22.2.0'
-    compile 'com.android.support:recyclerview-v7:22.2.0'
-    compile 'com.android.support:cardview-v7:22.2.0'
-    compile 'com.android.support:appcompat-v7:22.2.0'
+    compile 'com.android.support:support-v4:22.2.1'
+    compile 'com.android.support:recyclerview-v7:22.2.1'
+    compile 'com.android.support:cardview-v7:22.2.1'
+    compile 'com.android.support:appcompat-v7:22.2.1'
     compile 'com.android.support:multidex:1.0.1'
     compile 'com.github.bumptech.glide:glide:3.6.1'
 
     // Segment Library
-    compile('com.segment.analytics.android:analytics:3.1.8@aar') {
+    compile('com.segment.analytics.android:analytics-core:3.2.0@aar') {
         // following line fixes this error "more than one library with package name com.google.android.gms"
         // https://github.com/segmentio/analytics-android/issues/156
         exclude module: 'play-services-base'
+        transitive = true
+    }
+    compile('com.segment.analytics.android:analytics-integration-google-analytics:3.2.0@aar') {
         transitive = true
     }
 


### PR DESCRIPTION
This PR fixes the OutOfMemory error caused during multidexing that we were getting when we compiled the project to run on android versions less than Lollipop.

It does this, by stripping the Segment library to only include its `core` and `ga-integration` parts.

@aleffert @bguertin @1zaman plz review