### PR TITLE
Padding added to navigation buttons on the course-units navigation screen

### DIFF
--- a/VideoLocker/res/color/disableable_button_text.xml
+++ b/VideoLocker/res/color/disableable_button_text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_enabled="true" android:color="@color/edx_brand_primary_base" />
-    <item android:color="@color/button_text_disabled" />
+    <item android:color="@color/edx_grayscale_neutral_base" />
 </selector>

--- a/VideoLocker/res/layout/activity_course_base.xml
+++ b/VideoLocker/res/layout/activity_course_base.xml
@@ -158,38 +158,38 @@
                 android:layout_height="0px"
                 android:layout_weight="1"
                 android:id="@+id/fragment_container"
-                android:layout_below="@id/offline_bar">
+                android:layout_below="@id/offline_bar" />
 
-            </RelativeLayout>
-
-            <LinearLayout android:orientation="horizontal"
-                          android:gravity="center"
-                          android:id="@+id/course_unit_nav_bar"
-                          android:measureWithLargestChild="true"
-                          android:layout_width="match_parent"
-                          android:layout_height="@dimen/course_unit_nav_bar_height"
-                          android:padding="1dp"
-                          android:layout_marginLeft="5dp"
-                          android:layout_marginStart="5dp"
-                          android:layout_marginRight="5dp"
-                          android:layout_marginEnd="5dp"
-                          android:background="@drawable/rectangle_with_top_border"
-                          android:visibility="gone"
-                          android:layout_weight="0">
+            <LinearLayout
+                android:id="@+id/course_unit_nav_bar"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/course_unit_nav_bar_height"
+                android:layout_weight="0"
+                android:background="@drawable/rectangle_with_top_border"
+                android:gravity="center"
+                android:measureWithLargestChild="true"
+                android:orientation="horizontal"
+                android:paddingEnd="15dp"
+                android:paddingLeft="15dp"
+                android:paddingRight="15dp"
+                android:paddingStart="15dp"
+                android:visibility="gone"
+                tools:targetApi="17"
+                tools:visibility="visible">
 
                 <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    android:gravity="center_vertical|start">
+                    tools:targetApi="17">
 
-                    <Button
+                    <org.edx.mobile.view.custom.EButton
                         android:id="@+id/goto_prev"
                         android:layout_width="wrap_content"
                         android:layout_height="@dimen/course_unit_nav_bar_btn_height"
-                        android:background="@color/white"
                         android:text="@string/assessment_previous"
-                        android:textColor="?attr/buttonTextColor" />
+                        style="@style/edX.Widget.DisableableButton"
+                        tools:targetApi="17" />
 
                     <org.edx.mobile.view.custom.ETextView
                         android:id="@+id/prev_unit_title"
@@ -204,20 +204,20 @@
                     android:layout_height="0px"
                     android:layout_weight="1" />
 
-
                 <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    android:gravity="center_vertical|end|right">
+                    android:gravity="end"
+                    tools:targetApi="17" >
 
-                    <Button
+                    <org.edx.mobile.view.custom.EButton
                         android:id="@+id/goto_next"
                         android:layout_width="wrap_content"
                         android:layout_height="@dimen/course_unit_nav_bar_btn_height"
-                        android:background="@color/white"
                         android:text="@string/assessment_next"
-                        android:textColor="?attr/buttonTextColor"/>
+                        style="@style/edX.Widget.DisableableButton"
+                        tools:targetApi="17" />
 
                     <org.edx.mobile.view.custom.ETextView
                         android:id="@+id/next_unit_title"

--- a/VideoLocker/res/values/attrs.xml
+++ b/VideoLocker/res/values/attrs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="Theme">
-        <attr name="buttonTextColor" format="color" />
+        <attr name="disableableButtonTextColor" format="color" />
         <attr name="edgePopupMenuStyle" format="reference" />
     </declare-styleable>
 

--- a/VideoLocker/res/values/colors.xml
+++ b/VideoLocker/res/values/colors.xml
@@ -94,7 +94,6 @@
     <color name="video_details_background_transparent">#CC1F2124</color>
     <color name="delete_panel_bg">#3E4247</color>
     <color name="empty_list_text">#c8c8c8</color>
-    <color name="button_text_disabled">@color/edx_grayscale_neutral_base</color>
     <color name="switch_default_button_color">#C3C3C3</color>
     <color name="switch_default_bg_color">#3C4045</color>
     <color name="switch_disabled_bg_color_off">@color/grey_4</color>

--- a/VideoLocker/res/values/styles.xml
+++ b/VideoLocker/res/values/styles.xml
@@ -32,10 +32,11 @@
         <item name="edgePopupMenuStyle">@style/CustomEdgePopupMenu</item>
         <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
         <item name="android:actionBarTabStyle">@style/TabsStyle</item>
-        <item name="buttonTextColor">@color/button_text</item>
+        <item name="disableableButtonTextColor">@color/disableable_button_text</item>
         <item name="android:activatedBackgroundIndicator">@drawable/activated_item_selector</item>
         <item name="android:windowAnimationStyle">@style/EnterExitAnimation.Activity</item>
         <item name="android:dropDownListViewStyle">@style/edX.Widget.SpinnerDropDownListView</item>
+        <item name="android:buttonStyle">@style/edX.Widget.Button</item>
     </style>
 
     <!-- we need to change the color of the drawer arrow toggle -->
@@ -229,6 +230,15 @@
         <item name="android:paddingRight">@dimen/horizontal_input_padding</item>
         <item name="android:paddingBottom">@dimen/vertical_input_padding</item>
         <item name="android:paddingTop">@dimen/vertical_input_padding</item>
+    </style>
+
+    <style name="edX.Widget.Button" parent="@android:style/Widget.Holo.Light.TextView">
+        <item name="android:gravity">center</item>
+        <item name="android:textAppearance">?android:attr/textAppearanceMedium</item>
+    </style>
+
+    <style name="edX.Widget.DisableableButton" parent="edX.Widget.Button">
+        <item name="android:textColor">?attr/disableableButtonTextColor</item>
     </style>
 
     <style name="edX.Widget.CreationButton">


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-1272

Looks like this now:
![course_navigation](https://cloud.githubusercontent.com/assets/1710804/10020175/eb7fa600-615a-11e5-893d-0630944db213.png)

@aleffert @bguertin @1zaman plz review