### PR TITLE
Use shorter, more generic post attribution

### DIFF
--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -289,12 +289,8 @@
     <string name="discussion_priviledged_author_label_staff">Staff</string>
     <!-- The label to use when indicating a post was authored by a privileged user -->
     <string name="discussion_priviledged_author_attribution">By %s</string>
-    <!-- The label to use when describing the date and author of a discussion thread -->
-    <string name="discussion_thread_attribution">Discussion posted {time} by {author} {author_label}</string>
-    <!-- The label to use when describing the date and author of a discussion question -->
-    <string name="question_thread_attribution">Question posted {time} by {author} {author_label}</string>
-    <!-- The label to use when describing the date and author of a discussion comment -->
-    <string name="comment_attribution">Posted {time} by {author} {author_label}</string>
+    <!-- The date and author of a discussion comment, question, or thread, e.g. "3 days ago by Brian STAFF" -->
+    <string name="post_attribution">{time} by {author} {author_label}</string>
 
     <!--Discussion Responses-->
     <string name="course_discussion_responses_title">Discussion Post</string>

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
@@ -15,18 +15,7 @@ public abstract class DiscussionTextUtils {
     private DiscussionTextUtils() {
     }
 
-    public static CharSequence getAuthorAttributionText(@NonNull final DiscussionThread discussionThread, @NonNull final Resources resources) {
-        return getAuthorAttributionText(discussionThread, resources,
-                discussionThread.getType() == DiscussionThread.ThreadType.DISCUSSION
-                        ? R.string.discussion_thread_attribution
-                        : R.string.question_thread_attribution);
-    }
-
-    public static CharSequence getAuthorAttributionText(@NonNull final DiscussionComment discussionComment, @NonNull final Resources resources) {
-        return getAuthorAttributionText(discussionComment, resources, R.string.comment_attribution);
-    }
-
-    private static CharSequence getAuthorAttributionText(@NonNull final IAuthorData authorData, @NonNull final Resources resources, @StringRes final int stringRes) {
+    public static CharSequence getAuthorAttributionText(@NonNull final IAuthorData authorData, @NonNull final Resources resources) {
         final CharSequence formattedTime = DateUtils.getRelativeTimeSpanString(
                 authorData.getCreatedAt().getTime(),
                 System.currentTimeMillis(),
@@ -35,7 +24,7 @@ public abstract class DiscussionTextUtils {
 
         final String authorLabel = authorData.getAuthorLabel();
 
-        return trim(ResourceUtil.getFormattedString(resources, stringRes, new HashMap<String, CharSequence>() {{
+        return trim(ResourceUtil.getFormattedString(resources, R.string.post_attribution, new HashMap<String, CharSequence>() {{
             put("time", formattedTime);
             put("author", authorData.getAuthor());
             put("author_label", null == authorLabel ? "" : authorLabel.toUpperCase(resources.getConfiguration().locale));


### PR DESCRIPTION
For comment and thread posts. Always use `{time} by {author} {authorLabel}`

https://openedx.atlassian.net/browse/MA-1223