### PR TITLE
Size of download icon on course outline screen increased a little

### DIFF
--- a/VideoLocker/res/layout/row_course_outline_list.xml
+++ b/VideoLocker/res/layout/row_course_outline_list.xml
@@ -91,19 +91,16 @@
 
         </LinearLayout>
 
-
         <LinearLayout
             android:id="@+id/bulk_download_layout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_centerVertical="true"
             android:layout_marginEnd="2dp"
             android:layout_marginRight="2dp"
             android:background="@android:color/transparent"
             android:paddingEnd="5dp"
             android:paddingRight="5dp"
+            android:gravity="center"
             tools:targetApi="17">
 
             <org.edx.mobile.view.custom.ETextView
@@ -111,12 +108,10 @@
                 style="@style/semibold_text"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_centerVertical="true"
                 android:layout_marginEnd="5dp"
                 android:layout_marginLeft="5dp"
                 android:layout_marginRight="5dp"
                 android:layout_marginStart="5dp"
-                android:gravity="center_vertical"
                 android:textColor="@color/edx_grayscale_neutral_base"
                 android:textSize="15sp"
                 android:visibility="gone"
@@ -125,10 +120,9 @@
 
             <org.edx.mobile.third_party.iconify.IconView
                 android:id="@+id/bulk_download"
-                android:layout_width="15dp"
-                android:layout_height="15dp"
+                android:layout_width="18dp"
+                android:layout_height="18dp"
                 android:baselineAlignBottom="true"
-                android:gravity="center_vertical"
                 android:paddingEnd="1dp"
                 android:paddingLeft="0dp"
                 android:paddingRight="1dp"


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-1274

Looks like this now:
![download_icon](https://cloud.githubusercontent.com/assets/1710804/10136775/9ef06702-660f-11e5-9a92-78a36c9f2681.png)

@aleffert @bguertin @1zaman plz review