### PR TITLE
Hairline separators made thinner on course dashboard screen

### DIFF
--- a/VideoLocker/res/drawable/rectangle_with_bottom_border_selector.xml
+++ b/VideoLocker/res/drawable/rectangle_with_bottom_border_selector.xml
@@ -6,7 +6,7 @@
         </shape>
     </item>
 
-    <item android:bottom="1dp">
+    <item android:bottom="@dimen/edx_hairline">
         <selector>
             <item android:state_pressed="true">
                 <shape android:shape="rectangle">

--- a/VideoLocker/res/layout-land/activity_myvideos_tab.xml
+++ b/VideoLocker/res/layout-land/activity_myvideos_tab.xml
@@ -34,7 +34,7 @@
 
                     <View
                         android:id="@+id/offline_bar"
-                        style="@style/offline_bar_style"
+                        style="@style/offline_bar"
                         android:visibility="gone" />
 
                     <TabWidget

--- a/VideoLocker/res/layout/activity_course_base.xml
+++ b/VideoLocker/res/layout/activity_course_base.xml
@@ -26,7 +26,7 @@
             <LinearLayout
                 android:id="@+id/offline_bar"
                 android:orientation="vertical"
-                style="@style/offline_msg_bar_style"
+                style="@style/offline_msg_bar"
                 android:gravity="center_vertical"
                 android:visibility="gone">
                 <org.edx.mobile.view.custom.ETextView
@@ -47,7 +47,7 @@
             <LinearLayout
                 android:id="@+id/download_in_progress_bar"
                 android:orientation="vertical"
-                style="@style/download_in_progress_bar_style"
+                style="@style/download_in_progress_bar"
                 android:visibility="gone">
 
                 <LinearLayout
@@ -100,10 +100,9 @@
 
             <LinearLayout
                 android:id="@+id/last_access_bar"
-                style="@style/last_access_bar_style"
                 android:orientation="vertical"
-                android:visibility="gone"
-                tools:visibility="visible">
+                style="@style/last_access_bar"
+                android:visibility="gone">
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -193,7 +192,7 @@
 
                     <org.edx.mobile.view.custom.ETextView
                         android:id="@+id/prev_unit_title"
-                        style="@style/section_lbl_style"
+                        style="@style/section_lbl"
                         android:visibility="gone" />
 
 
@@ -221,7 +220,7 @@
 
                     <org.edx.mobile.view.custom.ETextView
                         android:id="@+id/next_unit_title"
-                        style="@style/section_lbl_style"
+                        style="@style/section_lbl"
                         android:visibility="gone" />
 
                 </LinearLayout>

--- a/VideoLocker/res/layout/activity_coursedetail_tab.xml
+++ b/VideoLocker/res/layout/activity_coursedetail_tab.xml
@@ -11,7 +11,7 @@
 
         <View
             android:id="@+id/offline_bar"
-            style="@style/offline_bar_style"
+            style="@style/offline_bar"
             android:layout_alignParentTop="true"
             android:visibility="gone" />
 

--- a/VideoLocker/res/layout/activity_downloads_list.xml
+++ b/VideoLocker/res/layout/activity_downloads_list.xml
@@ -14,7 +14,7 @@
 
         <View
             android:id="@+id/offline_bar"
-            style="@style/offline_bar_style"
+            style="@style/offline_bar"
             android:visibility="gone" />
     </LinearLayout>
 

--- a/VideoLocker/res/layout/activity_find_course_info.xml
+++ b/VideoLocker/res/layout/activity_find_course_info.xml
@@ -7,7 +7,7 @@
 
     <View
         android:id="@+id/offline_bar"
-        style="@style/offline_bar_style"
+        style="@style/offline_bar"
         android:visibility="gone"
         android:layout_alignParentTop="true"/>
 

--- a/VideoLocker/res/layout/activity_find_courses.xml
+++ b/VideoLocker/res/layout/activity_find_courses.xml
@@ -13,7 +13,7 @@
 
         <View
             android:id="@+id/offline_bar"
-            style="@style/offline_bar_style"
+            style="@style/offline_bar"
             android:visibility="gone"
             android:layout_alignParentTop="true"/>
 

--- a/VideoLocker/res/layout/activity_lecture_list.xml
+++ b/VideoLocker/res/layout/activity_lecture_list.xml
@@ -15,7 +15,7 @@
 
         <View
             android:id="@+id/offline_bar"
-            style="@style/offline_bar_style"
+            style="@style/offline_bar"
             android:visibility="invisible" />
     </LinearLayout>
 

--- a/VideoLocker/res/layout/activity_my_groups_list.xml
+++ b/VideoLocker/res/layout/activity_my_groups_list.xml
@@ -13,7 +13,7 @@
 
         <View
             android:id="@+id/offline_bar"
-            style="@style/offline_bar_style"
+            style="@style/offline_bar"
             android:visibility="gone"
             android:layout_alignParentTop="true" />
 

--- a/VideoLocker/res/layout/activity_myvideos_tab.xml
+++ b/VideoLocker/res/layout/activity_myvideos_tab.xml
@@ -29,7 +29,7 @@
 
                     <View
                         android:id="@+id/offline_bar"
-                        style="@style/offline_bar_style"
+                        style="@style/offline_bar"
                         android:visibility="gone" />
                     
                     <TabWidget

--- a/VideoLocker/res/layout/activity_single_fragment_base.xml
+++ b/VideoLocker/res/layout/activity_single_fragment_base.xml
@@ -26,7 +26,7 @@
 
             <View
                 android:id="@+id/offline_bar"
-                style="@style/offline_bar_style"
+                style="@style/offline_bar"
                 android:visibility="gone"
                 android:layout_alignParentTop="true" />
 

--- a/VideoLocker/res/layout/activity_video_list.xml
+++ b/VideoLocker/res/layout/activity_video_list.xml
@@ -14,7 +14,7 @@
 
         <View
             android:id="@+id/offline_bar"
-            style="@style/offline_bar_style"
+            style="@style/offline_bar"
             android:visibility="gone" />
     </LinearLayout>
 

--- a/VideoLocker/res/layout/create_new_item_layout.xml
+++ b/VideoLocker/res/layout/create_new_item_layout.xml
@@ -8,10 +8,12 @@
     android:orientation="horizontal"
     tools:showIn="@layout/fragment_discussion_posts">
 
+
     <org.edx.mobile.third_party.iconify.IconView
         android:id="@+id/create_new_icon_view"
-        style="@style/icon_view_standard_size_style"
-        app:iconColor="@color/edx_grayscale_neutral_white_t"
+        style="@style/icon_view_standard_size"
+        android:layout_centerVertical="true"
+        app:iconColor="@color/white"
         app:iconName="fa_plus_circle" />
 
     <TextView
@@ -24,3 +26,4 @@
         android:textSize="@dimen/edx_small"
         tools:text="Create a new item" />
 </LinearLayout>
+

--- a/VideoLocker/res/layout/discussion_response_action_bar_layout.xml
+++ b/VideoLocker/res/layout/discussion_response_action_bar_layout.xml
@@ -4,7 +4,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     tools:showIn="@layout/discussion_responses_response_row">
     <RelativeLayout
-        style="@style/discussion_responses_nested_card_layout_style"
+        style="@style/discussion_responses_nested_card_layout"
         android:layout_height="@dimen/discussion_responses_secondary_actions_bar_height">
 
         <LinearLayout

--- a/VideoLocker/res/layout/discussion_responses_response_row.xml
+++ b/VideoLocker/res/layout/discussion_responses_response_row.xml
@@ -16,7 +16,7 @@
 
         <LinearLayout
             android:id="@+id/discussion_response_body"
-            style="@style/discussion_responses_nested_card_layout_style"
+            style="@style/discussion_responses_nested_card_layout"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:paddingBottom="3dp"
@@ -44,7 +44,7 @@
 
         <RelativeLayout
             android:id="@+id/discussion_responses_comment_relative_layout"
-            style="@style/discussion_responses_nested_card_layout_style"
+            style="@style/discussion_responses_nested_card_layout"
             android:layout_height="@dimen/discussion_responses_comments_button_height"
             android:background="@color/edx_grayscale_neutral_xx_light"
             android:gravity="center_horizontal|center_vertical">

--- a/VideoLocker/res/layout/fragment_course_dashboard.xml
+++ b/VideoLocker/res/layout/fragment_course_dashboard.xml
@@ -35,14 +35,14 @@
                 style="@style/regular_edx_gray_xdark_text"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textSize="10sp"
+                android:textSize="@dimen/edx_xxx_small"
                 tools:text="XX | xx | xxxxx" />
 
         </LinearLayout>
 
     </FrameLayout>
 
-    <View style="@style/grey_separator" />
+    <View style="@style/grey_hairline_separator" />
 
     <ScrollView
         android:layout_width="match_parent"

--- a/VideoLocker/res/layout/fragment_discussion_thread_posts.xml
+++ b/VideoLocker/res/layout/fragment_discussion_thread_posts.xml
@@ -35,7 +35,7 @@
 
             <org.edx.mobile.third_party.iconify.IconView
                 android:id="@+id/discussion_posts_filter_icon_view"
-                style="@style/icon_view_standard_size_style"
+                style="@style/icon_view_standard_size"
                 android:layout_centerVertical="true"
                 app:iconColor="@color/edx_brand_primary_base"
                 app:iconName="fa_filter" />

--- a/VideoLocker/res/layout/fragment_discussion_topics.xml
+++ b/VideoLocker/res/layout/fragment_discussion_topics.xml
@@ -8,7 +8,7 @@
 
     <SearchView
         android:id="@+id/discussion_topics_searchview"
-        style="@style/discussion_topics_search_bar_style"
+        style="@style/discussion_topics_search_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/white"

--- a/VideoLocker/res/layout/fragment_my_course_list_tab.xml
+++ b/VideoLocker/res/layout/fragment_my_course_list_tab.xml
@@ -5,7 +5,7 @@
 
     <View
         android:id="@+id/offline_bar"
-        style="@style/offline_bar_style"
+        style="@style/offline_bar"
         android:layout_alignParentTop="true"
         android:visibility="visible" />
 

--- a/VideoLocker/res/layout/fragment_my_friends_course_list_tab.xml
+++ b/VideoLocker/res/layout/fragment_my_friends_course_list_tab.xml
@@ -5,7 +5,7 @@
 
     <View
         android:id="@+id/offline_bar"
-        style="@style/offline_bar_style"
+        style="@style/offline_bar"
         android:layout_alignParentTop="true"
         android:visibility="visible" />
 

--- a/VideoLocker/res/layout/fragment_video_list_with_player_container.xml
+++ b/VideoLocker/res/layout/fragment_video_list_with_player_container.xml
@@ -27,7 +27,7 @@
 
         <View
             android:id="@+id/offline_bar"
-            style="@style/offline_bar_style"
+            style="@style/offline_bar"
             android:visibility="gone" />
 
     </LinearLayout>

--- a/VideoLocker/res/layout/row_course_dashboard_list.xml
+++ b/VideoLocker/res/layout/row_course_dashboard_list.xml
@@ -28,7 +28,6 @@
         android:layout_width="0dp"
         android:layout_weight="1"
         android:layout_height="wrap_content"
-        android:layout_centerVertical="true"
         android:orientation="vertical"
         android:layout_marginLeft="24dp"
         android:layout_marginStart="24dp"
@@ -39,12 +38,11 @@
             style="@style/regular_edx_gray_xdark_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_centerVertical="true"
             android:ellipsize="end"
             android:singleLine="true"
             tools:text="Course Title"
             android:textDirection="locale"
-            android:textSize="16sp" />
+            android:textSize="@dimen/edx_base" />
 
 
         <org.edx.mobile.view.custom.ETextView
@@ -52,12 +50,11 @@
             style="@style/regular_edx_gray_base_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_centerVertical="true"
             android:ellipsize="end"
             android:singleLine="true"
             tools:text="Course Subtitle"
             android:textDirection="locale"
-            android:textSize="12sp" />
+            android:textSize="@dimen/edx_x_small" />
     </LinearLayout>
 
     <org.edx.mobile.third_party.iconify.IconView

--- a/VideoLocker/res/layout/row_discussion_thread.xml
+++ b/VideoLocker/res/layout/row_discussion_thread.xml
@@ -11,7 +11,7 @@
 
     <org.edx.mobile.third_party.iconify.IconView
         android:id="@+id/discussion_post_type_icon"
-        style="@style/icon_view_standard_size_style"
+        style="@style/icon_view_standard_size"
         android:layout_margin="@dimen/edx_margin"
         app:iconColor="@color/edx_grayscale_neutral_light" />
 

--- a/VideoLocker/res/layout/view_fb_share.xml
+++ b/VideoLocker/res/layout/view_fb_share.xml
@@ -4,7 +4,7 @@
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
     android:textColor="@color/white"
-    style="@style/custom_fb_btn_style"
+    style="@style/custom_fb_btn"
     android:textStyle="bold"
     android:textSize="12sp"
     android:gravity="center_horizontal|center_vertical"

--- a/VideoLocker/res/layout/view_register_spinner.xml
+++ b/VideoLocker/res/layout/view_register_spinner.xml
@@ -9,7 +9,7 @@
 
     <org.edx.mobile.module.registration.view.RegistrationOptionSpinner
         android:id="@+id/input_spinner"
-        style="@style/spinner_style"
+        style="@style/spinner"
         android:layout_height="wrap_content"
         android:textColorHint="@color/hint_grey_text"
         android:paddingLeft="5dp"

--- a/VideoLocker/res/values/styles.xml
+++ b/VideoLocker/res/values/styles.xml
@@ -113,6 +113,15 @@
         <item name="android:background">@color/edx_brand_secondary_base</item>
     </style>
 
+    <style name="hairline_separator_style">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">@dimen/edx_hairline</item>
+    </style>
+
+    <style name="grey_hairline_separator" parent="hairline_separator_style">
+        <item name="android:background">@color/edx_grayscale_neutral_light</item>
+    </style>
+
     <!-- Custom menu popup -->
     <style name="CustomPopupMenu" android:parent="Widget.Holo.Light.PopupMenu">
         <item name="android:popupBackground">@drawable/white_rounded_bordered_bg</item>

--- a/VideoLocker/res/values/styles.xml
+++ b/VideoLocker/res/values/styles.xml
@@ -71,14 +71,14 @@
         <item name="android:background">@drawable/tab_indicator</item>
     </style>
 
-    <style name="offline_bar_style">
+    <style name="offline_bar">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">3dp</item>
         <item name="android:background">@color/red_offline_bar</item>
         <item name="android:visibility">gone</item>
     </style>
 
-    <style name="offline_msg_bar_style">
+    <style name="offline_msg_bar">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">45dp</item>
         <item name="android:background">@color/edx_brand_secondary_x_light</item>
@@ -86,30 +86,30 @@
         <item name="android:visibility">gone</item>
     </style>
 
-    <style name="last_access_bar_style">
+    <style name="last_access_bar">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">50dp</item>
         <item name="android:background">@color/edx_brand_primary_x_light</item>
     </style>
 
-    <style name="download_in_progress_bar_style" parent="last_access_bar_style">
+    <style name="download_in_progress_bar" parent="last_access_bar">
         <item name="android:layout_height">45dp</item>
     </style>
 
-    <style name="separator_style">
+    <style name="separator_base">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">1dp</item>
     </style>
 
-    <style name="blue_separator" parent="separator_style">
+    <style name="blue_separator" parent="separator_base">
         <item name="android:background">@color/edx_brand_primary_base</item>
     </style>
 
-    <style name="grey_separator" parent="separator_style">
+    <style name="grey_separator" parent="separator_base">
         <item name="android:background">@color/edx_grayscale_neutral_light</item>
     </style>
 
-    <style name="red_separator" parent="separator_style">
+    <style name="red_separator" parent="separator_base">
         <item name="android:background">@color/edx_brand_secondary_base</item>
     </style>
 
@@ -149,28 +149,17 @@
         <item name="android:textSize">14sp</item>
     </style>
 
-    <style name="blue_bar_style">
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">3dp</item>
-        <item name="android:background">@color/edx_brand_primary_accent</item>
-    </style>
-
-    <style name="course_detail_style">
-        <item name="android:layout_marginLeft">16dp</item>
-        <item name="android:layout_marginRight">16dp</item>
-    </style>
-
     <style name="add_fab">
         <item name="fab_colorNormal">@color/cyan_3</item>
         <item name="fab_colorPressed">@color/cyan_5</item>
     </style>
 
-    <style name="custom_fb_btn_style">
+    <style name="custom_fb_btn">
         <item name="android:background">@drawable/custom_fb_button_selector</item>
         <item name="android:drawablePadding">2dp</item>
     </style>
 
-    <style name="spinner_style">
+    <style name="spinner">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">40dp</item>
         <item name="android:background">@drawable/spinner_selector</item>
@@ -182,7 +171,7 @@
         <item name="android:actionBarItemBackground">@color/edx_brand_primary_light</item>
     </style>
 
-    <style name="section_lbl_style">
+    <style name="section_lbl">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:maxWidth">150dp</item>
@@ -192,13 +181,13 @@
         <item name="android:layout_marginTop">-5dp</item>
     </style>
 
-    <style name="search_bar_style">
+    <style name="search_bar">
         <item name="android:textColor">@color/black</item>
         <item name="android:textSize">12sp</item>
         <item name="android:layout_height">30dp</item>
     </style>
 
-    <style name="discussion_topics_search_bar_style" parent="search_bar_style">
+    <style name="discussion_topics_search_bar" parent="search_bar">
         <item name="android:queryHint">@string/topics_search</item>
     </style>
 
@@ -209,7 +198,7 @@
         <item name="android:gravity">center</item>
     </style>
 
-    <style name="icon_view_standard_size_style">
+    <style name="icon_view_standard_size">
         <item name="android:layout_width">@dimen/icon_view_standard_width_height</item>
         <item name="android:layout_height">@dimen/icon_view_standard_width_height</item>
     </style>
@@ -221,7 +210,7 @@
         <item name="android:layout_height">wrap_content</item>
     </style>
 
-    <style name="discussion_responses_nested_card_layout_style">
+    <style name="discussion_responses_nested_card_layout">
         <item name="android:layout_width">match_parent</item>
         <item name="android:paddingLeft">@dimen/discussion_responses_box_padding</item>
         <item name="android:paddingRight">@dimen/discussion_responses_box_padding</item>


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-1268

I've removed some unused attributes and standardized some styles as well in this PR.

Looks like this now:
![dashboard](https://cloud.githubusercontent.com/assets/1710804/10161812/0d36cc82-66c0-11e5-8e4e-e064b662a579.png)

@aleffert @bguertin @1zaman plz review