### PR TITLE
Dates of discussion posts and comments now include year as well after a week has passed

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
@@ -20,7 +20,7 @@ public abstract class DiscussionTextUtils {
                 authorData.getCreatedAt().getTime(),
                 System.currentTimeMillis(),
                 DateUtils.MINUTE_IN_MILLIS,
-                DateUtils.FORMAT_ABBREV_RELATIVE);
+                DateUtils.FORMAT_NUMERIC_DATE|DateUtils.FORMAT_SHOW_YEAR);
 
         final String authorLabel = authorData.getAuthorLabel();
 

--- a/VideoLocker/src/main/java/org/edx/mobile/util/DateUtil.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/DateUtil.java
@@ -14,7 +14,7 @@ public class DateUtil {
     private static final Logger logger = new Logger(DateUtil.class.getName());
 
     /*
-     * Converting Date in string format to Date object and coverting the Current
+     * Converting Date in string format to Date object and converting the Current
      * Stamp
      */
     public static Date convertToDate(String date) {
@@ -104,20 +104,4 @@ public class DateUtil {
             return null;
         }
     }
-
-    /*
-     *  This method tahes a Date object and returns a string that shows how far back in
-     *  time the date was in a concise, readable format. (Ex: 2 weeks ago, 1 month ago)
-     */
-    public static String formatPastDateRelativeToCurrentDate(Date pastDate) {
-        if (pastDate == null) {
-            return "";
-        }
-        return DateUtils.getRelativeTimeSpanString(
-                pastDate.getTime(),
-                System.currentTimeMillis(),
-                DateUtils.MINUTE_IN_MILLIS,
-                DateUtils.FORMAT_ABBREV_RELATIVE).toString();
-    }
-
 }


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-1323

Looks like this now:
![discussion_date_format](https://cloud.githubusercontent.com/assets/1710804/10165181/462e8ea0-66d7-11e5-804e-7b433b1fe8fb.png)

@aleffert @bguertin @1zaman plz review