### PR TITLE
Background explicitly set to white, otherwise it goes grey as defined in the app theme

### DIFF
--- a/VideoLocker/res/layout/fragment_course_combined_info.xml
+++ b/VideoLocker/res/layout/fragment_course_combined_info.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/edx_grayscale_neutral_white_t"
     tools:context="org.edx.mobile.view.CourseCombinedInfoFragment">
 
     <LinearLayout


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-1385

*On Announcements screen*

This was caused due to this change in the app theme:
https://github.com/edx/edx-app-android/pull/368/files#diff-d0a326a6c05d63875048ea9563fded72R28

@aleffert @bguertin @1zaman plz review