### PR TITLE
CardView's margins issue fix on thread responses screen

### DIFF
--- a/VideoLocker/res/drawable/discussion_add_comment_background.xml
+++ b/VideoLocker/res/drawable/discussion_add_comment_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <solid android:color="@color/edx_grayscale_neutral_xx_light" />
+
+    <corners
+        android:bottomLeftRadius="@dimen/edx_box_radius"
+        android:bottomRightRadius="@dimen/edx_box_radius"/>
+
+</shape>

--- a/VideoLocker/res/layout/discussion_responses_response_row.xml
+++ b/VideoLocker/res/layout/discussion_responses_response_row.xml
@@ -8,6 +8,7 @@
     android:layout_marginRight="@dimen/discussion_responses_standard_margin"
     android:layout_marginTop="@dimen/discussion_responses_standard_margin"
     app:cardUseCompatPadding="true"
+    app:cardPreventCornerOverlap="false"
     app:cardCornerRadius="@dimen/edx_box_radius">
 
     <LinearLayout
@@ -47,7 +48,7 @@
             android:id="@+id/discussion_responses_comment_relative_layout"
             style="@style/discussion_responses_nested_card_layout"
             android:layout_height="@dimen/discussion_responses_comments_button_height"
-            android:background="@color/edx_grayscale_neutral_xx_light"
+            android:background="@drawable/discussion_add_comment_background"
             android:gravity="center_horizontal|center_vertical">
 
             <include layout="@layout/number_responses_or_comments_layout" />

--- a/VideoLocker/res/layout/discussion_responses_response_row.xml
+++ b/VideoLocker/res/layout/discussion_responses_response_row.xml
@@ -7,6 +7,7 @@
     android:layout_marginLeft="@dimen/discussion_responses_standard_margin"
     android:layout_marginRight="@dimen/discussion_responses_standard_margin"
     android:layout_marginTop="@dimen/discussion_responses_standard_margin"
+    app:cardUseCompatPadding="true"
     app:cardCornerRadius="@dimen/edx_box_radius">
 
     <LinearLayout

--- a/VideoLocker/src/main/java/org/edx/mobile/util/UiUtil.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/UiUtil.java
@@ -5,6 +5,7 @@ import android.content.res.Resources;
 import android.os.Build;
 import android.util.TypedValue;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.TextView;
 
 import org.edx.mobile.R;
@@ -86,5 +87,19 @@ public class UiUtil {
         } else {
             return true;
         }
+    }
+
+    /**
+     * CardView adds extra padding on pre-lollipop devices for shadows
+     * This function removes that extra padding from its margins
+     * @param cardView The CardView that needs adjustments
+     * @return float
+     */
+    public static void adjustCardViewMargins(View cardView) {
+        ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) cardView.getLayoutParams();
+        params.topMargin -= cardView.getPaddingTop();
+        params.leftMargin -= cardView.getPaddingLeft();
+        params.rightMargin -= cardView.getPaddingRight();
+        cardView.setLayoutParams(params);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -93,6 +93,15 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter {
         View discussionResponseRow = LayoutInflater.
                 from(parent.getContext()).
                 inflate(R.layout.discussion_responses_response_row, parent, false);
+        // CardView adds extra padding on pre-lollipop devices for shadows
+        // Since, we've set cardUseCompatPadding to true in the layout file
+        // so we need to deduct the extra padding from margins in any case to get the desired results
+        RecyclerView.LayoutParams params = (RecyclerView.LayoutParams) discussionResponseRow.getLayoutParams();
+        params.topMargin -= discussionResponseRow.getPaddingTop();
+        params.leftMargin -= discussionResponseRow.getPaddingLeft();
+        params.rightMargin -= discussionResponseRow.getPaddingRight();
+        discussionResponseRow.setLayoutParams(params);
+
 
         return new DiscussionResponseViewHolder(discussionResponseRow);
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -20,6 +20,7 @@ import org.edx.mobile.task.VoteCommentTask;
 import org.edx.mobile.task.VoteThreadTask;
 import org.edx.mobile.third_party.iconify.IconView;
 import org.edx.mobile.third_party.iconify.Iconify;
+import org.edx.mobile.util.UiUtil;
 import org.edx.mobile.view.custom.ETextView;
 import org.edx.mobile.view.view_holders.AuthorLayoutViewHolder;
 import org.edx.mobile.view.view_holders.DiscussionSocialLayoutViewHolder;
@@ -96,12 +97,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter {
         // CardView adds extra padding on pre-lollipop devices for shadows
         // Since, we've set cardUseCompatPadding to true in the layout file
         // so we need to deduct the extra padding from margins in any case to get the desired results
-        RecyclerView.LayoutParams params = (RecyclerView.LayoutParams) discussionResponseRow.getLayoutParams();
-        params.topMargin -= discussionResponseRow.getPaddingTop();
-        params.leftMargin -= discussionResponseRow.getPaddingLeft();
-        params.rightMargin -= discussionResponseRow.getPaddingRight();
-        discussionResponseRow.setLayoutParams(params);
-
+        UiUtil.adjustCardViewMargins(discussionResponseRow);
 
         return new DiscussionResponseViewHolder(discussionResponseRow);
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-1322

`CardView` adds extra padding on pre-lollipop devices for shadows which causes margins to be increased. So, we've set that extra padding to appear on lollipop devices as well and have subtracted the extra amount from margins to get the desired results.

Screen looks like this now:
![add_comment_rounded_bottom_bg](https://cloud.githubusercontent.com/assets/1710804/10670109/6c10c5e2-78fd-11e5-9899-d653404aaac5.png)

@aleffert @bguertin @1zaman plz review 