### PR TITLE
Correct title display on course detail screen

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineActivity.java
@@ -38,10 +38,10 @@ public class CourseOutlineActivity extends CourseVideoListActivity {
     public void onResume(){
         super.onResume();
 
-        setTitle(courseData.getCourse().getName());
-
-        if (isOnCourseOutline())
+        if (isOnCourseOutline()) {
+            setTitle(courseData.getCourse().getName());
             LastAccessManager.getSharedInstance().fetchLastAccessed(this, courseData.getCourse().getId());
+        }
     }
 
     @Override


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-1438

Previously, we displayed the the Course Name on subsection level, which is fixed now.

@aleffert @bguertin @1zaman plz review