### PR TITLE
Fix sort/filter popup icon in discussion threads

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/third_party/iconify/IconDrawable.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/third_party/iconify/IconDrawable.java
@@ -301,6 +301,12 @@ public class IconDrawable extends Drawable {
             iconDrawable.setStyle(paint.getStyle());
             iconDrawable.setAutoMirrored(isAutoMirrored());
             iconDrawable.setChangingConfigurations(getChangingConfigurations());
+            // The bounds and level needs to be copied here to work around a bug
+            // in LayerDrawable where it doesn't initialize these properties in
+            // it's children when mutated or cloned. This bug has been fixed in
+            // Lollipop.
+            iconDrawable.setBounds(getBounds());
+            iconDrawable.setLevel(getLevel());
             return iconDrawable;
         }
 


### PR DESCRIPTION
PR #381 changed `IconDrawable` to provide a fake `ConstantState` that was actually bound to the drawable instance, in order to make it work with `LayerDrawable` (used for combining the up and down arrow icons to create the sort icon for discussion threads), which used it to create a new instance of it's children upon mutation regardless of whether they supported it.

This PR works around another bug in `LayerDrawable` before Lollipop, where it didn't initialize the bounds or levels of it's children upon mutation or cloning. The workaround is to copy these properties as part of the `ConstantState` cloning mechanism in `IconDrawable`.

https://openedx.atlassian.net/browse/MA-1218