### PR TITLE
Delegate course content links to external browsers

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
@@ -18,7 +18,6 @@ import org.edx.mobile.event.FlyingMessageEvent;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.task.EnrollForCourseTask;
 import org.edx.mobile.util.AppConstants;
-import org.edx.mobile.util.BrowserUtil;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.view.custom.ETextView;
 import org.edx.mobile.view.custom.URLInterceptorWebViewClient;
@@ -76,14 +75,7 @@ public class FindCoursesBaseActivity extends BaseFragmentActivity
     private void setupWebView() {
         if(webview!=null){
             isWebViewLoaded = false;
-            URLInterceptorWebViewClient client = new URLInterceptorWebViewClient(webview) {
-
-                @Override
-                public void onOpenExternalURL(String url) {
-                    // open URL in external browser
-                    BrowserUtil.open(FindCoursesBaseActivity.this, url);
-                }
-            };
+            URLInterceptorWebViewClient client = new URLInterceptorWebViewClient(this, webview);
 
             // if all the links are to be treated as external
             client.setAllLinksAsExternal(isAllLinksExternal());

--- a/VideoLocker/src/main/java/org/edx/mobile/util/BrowserUtil.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/BrowserUtil.java
@@ -85,41 +85,32 @@ public class BrowserUtil {
     }
 
     private static void openInBrowser(FragmentActivity context, String url) {
-        try {
-            Intent intent = new Intent(Intent.ACTION_VIEW);
-            intent.addCategory(Intent.CATEGORY_BROWSABLE);
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            intent.setData(Uri.parse(url));
-            context.startActivity(intent);
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.addCategory(Intent.CATEGORY_BROWSABLE);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.setData(Uri.parse(url));
+        context.startActivity(intent);
 
-            try{
-                ISegment segIO =  environment.getSegment();
-                segIO.trackOpenInBrowser(url);
-            }catch(Exception e){
-                logger.error(e);
-            }
+        ISegment segIO =  environment.getSegment();
+        segIO.trackOpenInBrowser(url);
 
-            // apply transition when user gets back from browser
-            if (context instanceof BaseFragmentActivity) {
-                ((BaseFragmentActivity) context).setApplyPrevTransitionOnRestart(true);
-            }
-            
-            // apply transition animation
-            context.overridePendingTransition(R.anim.slide_in_from_end, R.anim.slide_out_to_start);
-            logger.debug("Next transition animation applied");
-        } catch(Exception ex) {
-            logger.error(ex);
+        // apply transition when user gets back from browser
+        if (context instanceof BaseFragmentActivity) {
+            ((BaseFragmentActivity) context).setApplyPrevTransitionOnRestart(true);
         }
+
+        // apply transition animation
+        context.overridePendingTransition(R.anim.slide_in_from_end, R.anim.slide_out_to_start);
+        logger.debug("Next transition animation applied");
     }
 
     public static boolean isUrlOfHost(String url, String host) {
-        try {
-            Uri uri = Uri.parse(url);
-            return (uri.getHost().toString().contains(host));
-        } catch(Exception ex) {
-            logger.error(ex);
+        if (url != null && host != null) {
+            String urlHost = Uri.parse(url).getHost();
+            if (urlHost != null) {
+                return urlHost.matches("^(.+\\.)?" + host + "$");
+            }
         }
-
         return false;
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CertificateFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CertificateFragment.java
@@ -19,7 +19,6 @@ import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.social.facebook.FacebookProvider;
-import org.edx.mobile.util.BrowserUtil;
 import org.edx.mobile.util.SocialUtils;
 import org.edx.mobile.view.custom.URLInterceptorWebViewClient;
 import org.edx.mobile.view.dialog.InstallFacebookDialog;
@@ -78,13 +77,7 @@ public class CertificateFragment extends RoboFragment {
         progressBar = (ProgressBar) view.findViewById(R.id.api_spinner);
 
         webview = (WebView) view.findViewById(R.id.webview);
-        new URLInterceptorWebViewClient(webview) {
-
-            @Override
-            public void onOpenExternalURL(String url) {
-                BrowserUtil.open(getActivity(), url);
-            }
-        };
+        new URLInterceptorWebViewClient(getActivity(), webview);
 
         facebookShare = (LinearLayout) view.findViewById(R.id.share_certificate);
         facebookShare.setOnClickListener( new View.OnClickListener() {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseCombinedInfoFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseCombinedInfoFragment.java
@@ -32,7 +32,6 @@ import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.social.SocialMember;
 import org.edx.mobile.social.facebook.FacebookProvider;
 import org.edx.mobile.task.GetAnnouncementTask;
-import org.edx.mobile.util.BrowserUtil;
 import org.edx.mobile.util.FileUtil;
 import org.edx.mobile.util.SocialUtils;
 import org.edx.mobile.view.custom.EdxWebView;
@@ -116,13 +115,8 @@ public class CourseCombinedInfoFragment extends CourseDetailBaseFragment impleme
         groupLauncher.setOnClickListener(this);
 
         announcementWebView = (EdxWebView) view.findViewById(R.id.announcement_webview);
-        URLInterceptorWebViewClient client = new URLInterceptorWebViewClient(announcementWebView) {
-
-            @Override
-            public void onOpenExternalURL(String url) {
-                BrowserUtil.open(getActivity(), url);
-            }
-        };
+        URLInterceptorWebViewClient client = new URLInterceptorWebViewClient(
+                getActivity(), announcementWebView);
         // treat every link as external link in this view, so that all links will open in external browser
         client.setAllLinksAsExternal(true);
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseHandoutFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseHandoutFragment.java
@@ -8,7 +8,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.WebView;
-import android.webkit.WebViewClient;
 import android.widget.ProgressBar;
 
 import com.google.inject.Inject;
@@ -19,7 +18,6 @@ import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.model.api.HandoutModel;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.task.GetHandoutTask;
-import org.edx.mobile.util.BrowserUtil;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.util.UiUtil;
 import org.edx.mobile.view.custom.URLInterceptorWebViewClient;
@@ -63,13 +61,7 @@ public class CourseHandoutFragment extends RoboFragment {
                 false);
 
         webview = (WebView) view.findViewById(R.id.webview);
-        new URLInterceptorWebViewClient(webview) {
-
-            @Override
-            public void onOpenExternalURL(String url) {
-                BrowserUtil.open(getActivity(), url);
-            }
-        };
+        new URLInterceptorWebViewClient(getActivity(), webview);
 
         return view;
     }
@@ -102,13 +94,6 @@ public class CourseHandoutFragment extends RoboFragment {
                         hideEmptyHandoutMessage();
                         webview.loadDataWithBaseURL(environment.getConfig().getApiHostURL(), result.handouts_html,
                                 "text/html",Encoding.UTF_8.toString(),null);
-                        webview.setWebViewClient(new WebViewClient(){
-                            @Override
-                            public boolean shouldOverrideUrlLoading(final WebView view, final String url) {
-                                BrowserUtil.open(getActivity(), url);
-                                return true;
-                            }
-                        });
                     }else{
                         showEmptyHandoutMessage();
                     }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/dialog/WebViewDialogFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/dialog/WebViewDialogFragment.java
@@ -12,7 +12,6 @@ import android.widget.ProgressBar;
 
 import org.edx.mobile.R;
 import org.edx.mobile.logger.Logger;
-import org.edx.mobile.util.BrowserUtil;
 import org.edx.mobile.view.custom.ETextView;
 import org.edx.mobile.view.custom.URLInterceptorWebViewClient;
 
@@ -47,16 +46,8 @@ public class WebViewDialogFragment extends DialogFragment {
 
         try{
             WebView webView = (WebView)v.findViewById(R.id.eula_webView);
-            URLInterceptorWebViewClient client = new URLInterceptorWebViewClient(webView) {
-
-                @Override
-                public void onOpenExternalURL(String url) {
-                    progress.setVisibility(View.GONE);
-
-                    // open URL in external browser
-                    BrowserUtil.open(getActivity(), url);
-                }
-            };
+            URLInterceptorWebViewClient client =
+                    new URLInterceptorWebViewClient(getActivity(), webView);
             client.setPageStatusListener(new URLInterceptorWebViewClient.IPageStatusListener() {
 
                 @Override


### PR DESCRIPTION
All links in the course content are now delegated to external browsers, using the existing `URLInterceptorWebViewClient` utility client. The utility class has also been cleaned up along with the external methods used in it, and fixed to make it's `Config` injection work.

https://openedx.atlassian.net/browse/MA-1253