### PR TITLE
Don't include coverage in "debug" build, only "coverage" build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
 # It comes in handy to see stacktraces from test failures, which otherwise aren't printed
 # P.S. --debug flag prints too many logs that are mostly not needed, which make it exceed the
 #      4mb limit enforced by travis (so use it with caution)
-  - ./gradlew testProdDebugUnitTestCoverage
+  - ./gradlew testProdCoverageUnitTestCoverage
   - ./gradlew copyUnitTestBuildArtifacts
 #  - ./travis-acceptance-tests.sh
 

--- a/VideoLocker/build.gradle
+++ b/VideoLocker/build.gradle
@@ -247,13 +247,12 @@ android {
     buildTypes {
         debug {
             ext.enableCrashlytics = false
-            testCoverageEnabled true
             pseudoLocalesEnabled true // Set device language to "en_XA" to test glyphs, or "ar_XB" to test RTL support
             manifestPlaceholders = [ supportsRtl:"true"]
         }
-        debuggable.initWith(buildTypes.debug)
-        debuggable {
-            testCoverageEnabled = false // Set to "false" to work around debugger issue: https://code.google.com/p/android/issues/detail?id=123771
+        coverage.initWith(buildTypes.debug)
+        coverage {
+            testCoverageEnabled = true // Only set to "true" when needed due to debugger issue: https://code.google.com/p/android/issues/detail?id=123771
         }
 
         release {


### PR DESCRIPTION
I think it's less confusing this way, only the "coverage" build type will include test coverage.