### PR TITLE
Fix discussion sort mappings

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionPostsFilter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionPostsFilter.java
@@ -9,19 +9,33 @@ import org.edx.mobile.interfaces.TextResourceProvider;
  * Filter options for discussion posts.
  */
 public enum DiscussionPostsFilter implements TextResourceProvider {
-    ALL(R.string.discussion_posts_filter_all_posts),
-    UNREAD(R.string.discussion_posts_filter_unread_posts),
-    UNANSWERED(R.string.discussion_posts_filter_unanswered_posts);
+    ALL(R.string.discussion_posts_filter_all_posts, ""),
+    UNREAD(R.string.discussion_posts_filter_unread_posts, "unread"),
+    UNANSWERED(R.string.discussion_posts_filter_unanswered_posts, "unanswered");
 
     @StringRes
     private final int textRes;
+    private final String queryParamValue;
 
-    DiscussionPostsFilter(@StringRes int textRes) {
+    DiscussionPostsFilter(@StringRes int textRes, String queryParamValue) {
         this.textRes = textRes;
+        this.queryParamValue = queryParamValue;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int getTextResource() {
         return textRes;
+    }
+
+    /**
+     * Get the value of the query parameter.
+     *
+     * @return The query parameter string
+     */
+    public String getQueryParamValue() {
+        return queryParamValue;
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionPostsSort.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionPostsSort.java
@@ -9,19 +9,33 @@ import org.edx.mobile.interfaces.TextResourceProvider;
  * Sort options for discussion posts.
  */
 public enum DiscussionPostsSort implements TextResourceProvider {
-    NONE(R.string.discussion_posts_sort_recent_activity),
-    LAST_ACTIVITY_AT(R.string.discussion_posts_sort_most_activity),
-    VOTE_COUNT(R.string.discussion_posts_sort_most_votes);
+    LAST_ACTIVITY_AT(R.string.discussion_posts_sort_recent_activity, "last_activity_at"),
+    COMMENT_COUNT(R.string.discussion_posts_sort_most_activity, "comment_count"),
+    VOTE_COUNT(R.string.discussion_posts_sort_most_votes, "vote_count");
 
     @StringRes
     private final int textRes;
+    private final String queryParamValue;
 
-    DiscussionPostsSort(@StringRes int textRes) {
+    DiscussionPostsSort(@StringRes int textRes, String queryParamValue) {
         this.textRes = textRes;
+        this.queryParamValue = queryParamValue;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int getTextResource() {
         return textRes;
+    }
+
+    /**
+     * Get the value of the query parameter.
+     *
+     * @return The query parameter string
+     */
+    public String getQueryParamValue(){
+        return queryParamValue;
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetFollowingThreadListTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetFollowingThreadListTask.java
@@ -5,11 +5,10 @@ import android.content.Context;
 import org.edx.mobile.discussion.DiscussionPostsFilter;
 import org.edx.mobile.discussion.DiscussionPostsSort;
 import org.edx.mobile.discussion.TopicThreads;
-
 import org.edx.mobile.view.adapters.IPagination;
 
 public abstract class GetFollowingThreadListTask extends
-Task<TopicThreads> {
+        Task<TopicThreads> {
 
     String courseId;
     DiscussionPostsSort orderBy;
@@ -28,24 +27,13 @@ Task<TopicThreads> {
     }
 
 
-
-    public TopicThreads call( ) throws Exception{
+    public TopicThreads call() throws Exception {
         try {
-            if(courseId!=null){
-
-                String view;
-                if (filter == DiscussionPostsFilter.UNREAD) view = "unread";
-                else if (filter == DiscussionPostsFilter.UNANSWERED) view = "unanswered";
-                else view = "";
-
-                String order;
-                if (orderBy == DiscussionPostsSort.LAST_ACTIVITY_AT) order = "last_activity_at";
-                else if (orderBy == DiscussionPostsSort.VOTE_COUNT) order = "vote_count";
-                else order = "";
-
+            if (courseId != null) {
                 int pageSize = pagination.pageSize();
                 int page = pagination.numOfPagesLoaded() + 1;
-                return environment.getDiscussionAPI().getFollowingThreadList(courseId, view, order, pageSize, page);
+                return environment.getDiscussionAPI().getFollowingThreadList(courseId,
+                        filter.getQueryParamValue(), orderBy.getQueryParamValue(), pageSize, page);
             }
         } catch (Exception ex) {
             handle(ex);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
@@ -59,7 +59,7 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
     private DiscussionTopic discussionTopic;
 
     private DiscussionPostsFilter postsFilter = DiscussionPostsFilter.ALL;
-    private DiscussionPostsSort postsSort = DiscussionPostsSort.NONE;
+    private DiscussionPostsSort postsSort = DiscussionPostsSort.LAST_ACTIVITY_AT;
 
     private final Logger logger = new Logger(getClass().getName());
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-1546

>According to the doc https://openedx.atlassian.net/wiki/pages/viewpage.action?spaceKey=MA&title=Discussion+API+Proposal+Q4+2015;

order_by (String, must be one of "last_activity_at", "comment_count", "vote_count"): Order threads by most recent activity, most descendant comments, or most votes, respectively

@aleffert @bguertin @1zaman plz review