### PR TITLE
Fix profiles analytics category (now "profiles")

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/module/analytics/ISegment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/analytics/ISegment.java
@@ -232,7 +232,7 @@ public interface ISegment {
         String SETTING_COURSES_VISIBLE_CHANGE = "edx.bi.app.user.share_courses";
 
         String NAVIGATION = "navigation";
-        String PROFILE = "profile";
+        String PROFILE = "profiles";
         String CAMERA = "camera";
         String LIBRARY = "library";
         String SWITCH_OUTLINE_MODE = "edx.bi.app.navigation.switched-mode.clicked";


### PR DESCRIPTION
Changed "profile" to "profiles" to match the spec: https://openedx.atlassian.net/wiki/display/MA/Profile+Analytics

https://openedx.atlassian.net/browse/MA-1675