### PR TITLE
Copy all /oauth2/login/ cookies to WebView

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
@@ -330,9 +330,6 @@ public class PrefManager {
     public static final class Key {
         public static final String PROFILE_JSON = "profile_json";
         public static final String AUTH_JSON = "auth_json";
-        public static final String SESSION_ID = "sessionid";
-        public static final String AUTH_ASSESSMENT_SESSION_ID = "assessment_session_id";
-        public static final String AUTH_ASSESSMENT_SESSION_EXPIRATION = "assessment_session_expiration";
         //TODO- need to rename these constants. causing confusion
         public static final String AUTH_TOKEN_SOCIAL = "facebook_token";
         public static final String AUTH_TOKEN_BACKEND = "google_token";

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitWebviewFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitWebviewFragment.java
@@ -3,7 +3,6 @@ package org.edx.mobile.view;
 import android.annotation.TargetApi;
 import android.os.Build;
 import android.os.Bundle;
-import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -182,18 +181,13 @@ public class CourseUnitWebviewFragment extends CourseUnitFragment{
                 map.put("Authorization", String.format("%s %s", auth.token_type, auth.access_token));
             }
 
-            String sessionId = pref.getString(PrefManager.Key.AUTH_ASSESSMENT_SESSION_ID);
-            long sessionIdExpirationDate = pref.getLong(
-                    PrefManager.Key.AUTH_ASSESSMENT_SESSION_EXPIRATION);
             // Requery the session cookie if unavailable or expired if we are on
             // an API level lesser than Marshmallow (which provides HTTP error
             // codes in the error callback for WebViewClient).
             if (Build.VERSION.SDK_INT < 23 /*Build.VERSION_CODES.M*/ &&
-                    (TextUtils.isEmpty(sessionId) ||
-                            sessionIdExpirationDate < System.currentTimeMillis())) {
+                    EdxCookieManager.getSharedInstance().isSessionCookieMissingOrExpired()) {
                 EdxCookieManager.getSharedInstance().tryToRefreshSessionCookie();
             } else {
-                map.put("Cookie", PrefManager.Key.SESSION_ID + "=" + sessionId );
                 webView.loadUrl(unit.getBlockUrl(), map);
             }
         }


### PR DESCRIPTION
... instead of trying to single out the sessionid cookie; since we don't know it's name ahead of time.

Fixes https://openedx.atlassian.net/browse/MA-1689