### PR TITLE
Restrict download menu item to relevant screens

### DIFF
--- a/VideoLocker/res/menu/download_state.xml
+++ b/VideoLocker/res/menu/download_state.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".base.BaseVideosDownloadStateActivity">
+
+    <item
+        android:id="@+id/download_progress"
+        android:actionLayout="@layout/view_progress_download_btn"
+        android:showAsAction="always"
+        android:title="@string/action_settings" />
+</menu>

--- a/VideoLocker/res/menu/group_summary.xml
+++ b/VideoLocker/res/menu/group_summary.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="org.edx.mobile.view.VideoListActivity">
+
+    <item
+        android:id="@+id/unread_display"
+        android:actionLayout="@layout/view_unread_text"
+        android:showAsAction="always"
+        android:title="@string/unread_text"
+        android:visible="false" />
+</menu>

--- a/VideoLocker/res/menu/main.xml
+++ b/VideoLocker/res/menu/main.xml
@@ -1,40 +1,10 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="org.edx.mobile.MainActivity" >
+    tools:context="org.edx.mobile.MainActivity">
 
     <item
         android:id="@+id/offline"
         android:actionLayout="@layout/view_offline_text"
         android:showAsAction="always"
-        android:title="@string/offline_text"/>
-    
-   <item
-        android:id="@+id/progress_download"
-        android:actionLayout="@layout/view_progress_download_btn"
-        android:showAsAction="always"
-        android:title="@string/action_settings"
-        />
-
-   <item
-        android:id="@+id/delete_checkbox"
-        android:actionLayout="@layout/view_actionbar_checkbox"
-        android:showAsAction="always"
-        android:title="@string/label_delete"/>
-
-    <item
-        android:id="@+id/done_btn"
-        android:actionLayout="@layout/view_done_btn"
-        android:showAsAction="always"
-        android:title="@string/done_text"
-        android:visible="false"
-        />
-
-    <item
-        android:id="@+id/unread_display"
-        android:actionLayout="@layout/view_unread_text"
-        android:showAsAction="always"
-        android:title="@string/unread_text"
-        android:visible="false"
-        />
-   
+        android:title="@string/offline_text" />
 </menu>

--- a/VideoLocker/res/menu/social_friend_picker.xml
+++ b/VideoLocker/res/menu/social_friend_picker.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="org.edx.mobile.view.VideoListActivity">
+
+    <item
+        android:id="@+id/done_btn"
+        android:actionLayout="@layout/view_done_btn"
+        android:showAsAction="always"
+        android:title="@string/done_text" />
+</menu>

--- a/VideoLocker/res/menu/video_list.xml
+++ b/VideoLocker/res/menu/video_list.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="org.edx.mobile.view.VideoListActivity">
+
+    <item
+        android:id="@+id/delete_checkbox"
+        android:actionLayout="@layout/view_actionbar_checkbox"
+        android:showAsAction="always"
+        android:title="@string/label_delete" />
+</menu>

--- a/VideoLocker/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
@@ -1,24 +1,19 @@
 package org.edx.mobile.base;
 
-
-import android.annotation.SuppressLint;
 import android.app.ActionBar;
 import android.content.res.Configuration;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
-import android.os.Message;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
-import android.text.format.DateUtils;
 import android.util.TypedValue;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.View.OnClickListener;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
@@ -35,14 +30,12 @@ import org.edx.mobile.interfaces.NetworkObserver;
 import org.edx.mobile.interfaces.NetworkSubject;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.api.ProfileModel;
-import org.edx.mobile.module.db.DataCallback;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.util.ViewAnimationUtil;
 import org.edx.mobile.view.ICommonUI;
 import org.edx.mobile.view.NavigationFragment;
-import org.edx.mobile.view.custom.ProgressWheel;
 import org.edx.mobile.view.dialog.WebViewDialogFragment;
 
 import java.util.ArrayList;
@@ -51,15 +44,12 @@ import java.util.List;
 import de.greenrobot.event.EventBus;
 import roboguice.activity.RoboFragmentActivity;
 
-public class BaseFragmentActivity extends RoboFragmentActivity implements NetworkSubject, ICommonUI {
+public abstract class BaseFragmentActivity extends RoboFragmentActivity
+        implements NetworkSubject, ICommonUI {
 
     public static final String ACTION_SHOW_MESSAGE_INFO = "ACTION_SHOW_MESSAGE_INFO";
     public static final String ACTION_SHOW_MESSAGE_ERROR = "ACTION_SHOW_MESSAGE_ERROR";
-    // per second callback
-    private static final int MSG_TYPE_TICK = 9302;
 
-    private ProgressWheel totalProgress;
-    private MenuItem progressMenuItem;
     private ActionBarDrawerToggle mDrawerToggle;
     //FIXME - we should not set a separate flag to indicate the status of UI component
     private boolean isUiOnline = true;
@@ -98,9 +88,7 @@ public class BaseFragmentActivity extends RoboFragmentActivity implements Networ
         }
     }
 
-    // This flag is to enable the login and sign-up Activities to be
-    // excluded from the download progress update callback.
-    protected boolean runOnTick = true;
+    private final Handler handler = new Handler();
     protected final Logger logger = new Logger(getClass().getName());
 
     @Override
@@ -124,10 +112,6 @@ public class BaseFragmentActivity extends RoboFragmentActivity implements Networ
 
         pmFeatures.put(PrefManager.Key.ALLOW_SOCIAL_FEATURES, enableSocialFeatures);
 
-
-        if (runOnTick) {
-            handler.sendEmptyMessage(MSG_TYPE_TICK);
-        }
 
         // enabling action bar app icon.
         ActionBar bar = getActionBar();
@@ -197,10 +181,6 @@ public class BaseFragmentActivity extends RoboFragmentActivity implements Networ
     protected void onStop() {
         super.onStop();
         isActivityStarted = false;
-
-        if (runOnTick) {
-            handler.removeMessages(MSG_TYPE_TICK);
-        }
     }
 
     @Override
@@ -288,7 +268,7 @@ public class BaseFragmentActivity extends RoboFragmentActivity implements Networ
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        return super.onCreateOptionsMenu(menu) | createOptionMenu(menu);
+        return super.onCreateOptionsMenu(menu) | createOptionsMenu(menu);
     }
 
     /**
@@ -303,30 +283,9 @@ public class BaseFragmentActivity extends RoboFragmentActivity implements Networ
      *
      * @return Return true if the menu should be displayed.
      */
-    protected boolean createOptionMenu(Menu menu) {
+    protected boolean createOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.main, menu);
-        menu.findItem(R.id.delete_checkbox).setVisible(false);
         menu.findItem(R.id.offline).setVisible(AppConstants.offline_flag);
-        boolean isInitializing = progressMenuItem == null;
-        MenuItem newProgressMenuItem = menu.findItem(R.id.progress_download);
-        View progressView = newProgressMenuItem.getActionView();
-        ProgressWheel newTotalProgress = (ProgressWheel)
-                progressView.findViewById(R.id.progress_wheel);
-        if (progressMenuItem != null) {
-            newProgressMenuItem.setVisible(progressMenuItem.isVisible());
-            newTotalProgress.setProgress(totalProgress.getProgress());
-        }
-        progressMenuItem = newProgressMenuItem;
-        totalProgress = newTotalProgress;
-        progressView.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                environment.getRouter().showDownloads(BaseFragmentActivity.this);
-            }
-        });
-        if (runOnTick && isInitializing) {
-            updateDownloadingProgress();
-        }
         return true;
     }
 
@@ -357,7 +316,7 @@ public class BaseFragmentActivity extends RoboFragmentActivity implements Networ
      * Handle options menu item selection. This is called from
      * {@link #onOptionsItemSelected(MenuItem)} to provide a menu
      * selection handler that can be overriden by subclass that override
-     * {@link #createOptionMenu(Menu)}, and should only be used to handle
+     * {@link #createOptionsMenu(Menu)}, and should only be used to handle
      * selections of the menu items that are initialized from that method.
      *
      * @param item The menu item that was selected.
@@ -366,11 +325,6 @@ public class BaseFragmentActivity extends RoboFragmentActivity implements Networ
      *         proceed, true to consume it here.
      */
     protected boolean handleOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.progress_download:
-                environment.getRouter().showDownloads(this);
-                return true;
-        }
         return false;
     }
 
@@ -481,27 +435,6 @@ public class BaseFragmentActivity extends RoboFragmentActivity implements Networ
     }
 
     /**
-     * Callback method to be invoked on regular close intervals. Subclasses
-     * can override it to add their own constant refreshing logic.
-     */
-    protected void onTick() {
-        updateDownloadingProgress();
-    }
-
-    // Initialize or update the downloading progress wheel action view based
-    // on the current state, or hide it if there are no videos downloading.
-    private void updateDownloadingProgress() {
-        if (progressMenuItem == null) return;
-        if (AppConstants.offline_flag ||
-                !environment.getDatabase().isAnyVideoDownloading(null)) {
-            progressMenuItem.setVisible(false);
-        } else {
-            progressMenuItem.setVisible(true);
-            environment.getStorage().getAverageDownloadProgress(averageProgressCallback);
-        }
-    }
-
-    /**
      * Returns true if current orientation is LANDSCAPE, false otherwise.
      */
     protected boolean isLandscape() {
@@ -606,44 +539,6 @@ public class BaseFragmentActivity extends RoboFragmentActivity implements Networ
      * This method is called after {@link #onOnline()} method.
      */
     protected void onConnectedToWifi() {}
-
-    @SuppressLint("HandlerLeak")
-    private final Handler handler = new Handler() {
-        public void handleMessage(Message msg) {
-            switch (msg.what) {
-                case MSG_TYPE_TICK:
-                    // Invoke the onTick() callback continuously
-                    // on intervals of one second.
-                    onTick();
-                    sendEmptyMessageDelayed(MSG_TYPE_TICK, DateUtils.SECOND_IN_MILLIS);
-                    break;
-            }
-        }
-    };
-
-    protected DataCallback<Integer> averageProgressCallback = new DataCallback<Integer>() {
-        @Override
-        public void onResult(Integer result) {
-            int progressPercent = result;
-            if(progressPercent >= 0 && progressPercent <= 100){
-                updateDownloadProgress(progressPercent);
-            }
-        }
-        @Override
-        public void onFail(Exception ex) {
-            logger.error(ex);
-        }
-    };
-
-
-    /**
-     * Update the downloading progress wheel action view.
-     *
-     * @param progressPercent The completed percentage of the total downloads.
-     */
-    protected void updateDownloadProgress(int progressPercent) {
-        totalProgress.setProgressPercent(progressPercent);
-    }
 
     /**
      * Returns user's profile.

--- a/VideoLocker/src/main/java/org/edx/mobile/base/BaseSingleFragmentActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/BaseSingleFragmentActivity.java
@@ -10,7 +10,6 @@ import android.view.View;
 import android.widget.ProgressBar;
 
 import org.edx.mobile.R;
-import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.view.common.MessageType;
 import org.edx.mobile.view.common.TaskProcessCallback;
 import org.edx.mobile.view.custom.ETextView;
@@ -41,11 +40,6 @@ public abstract class BaseSingleFragmentActivity extends BaseFragmentActivity im
         setContentView(R.layout.activity_single_fragment_base);
 
 
-        if(NetworkUtil.isConnected(this)){
-            hideOfflineBar();
-        }else{
-            showOfflineBar();
-        }
     }
 
     @Override
@@ -80,14 +74,12 @@ public abstract class BaseSingleFragmentActivity extends BaseFragmentActivity im
     protected void onOnline() {
         super.onOnline();
         hideOfflineBar();
-        invalidateOptionsMenu();
     }
 
     @Override
     protected void onOffline() {
         super.onOffline();
         showOfflineBar();
-        invalidateOptionsMenu();
     }
 
     private void showOfflineBar(){

--- a/VideoLocker/src/main/java/org/edx/mobile/base/BaseSingleFragmentActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/BaseSingleFragmentActivity.java
@@ -6,8 +6,6 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.widget.DrawerLayout;
-import android.view.Menu;
-import android.view.MenuItem;
 import android.view.View;
 import android.widget.ProgressBar;
 
@@ -74,16 +72,6 @@ public abstract class BaseSingleFragmentActivity extends BaseFragmentActivity im
         fragmentTransaction.add(R.id.my_groups_list_container, singleFragment, FIRST_FRAG_TAG);
         fragmentTransaction.disallowAddToBackStack();
         fragmentTransaction.commit();
-    }
-
-    public boolean onCreateOptionsMenu(Menu menu) {
-        super.onCreateOptionsMenu(menu);
-
-        MenuItem checkBox_menuItem = menu.findItem(R.id.delete_checkbox);
-        checkBox_menuItem.setVisible(false);
-
-        return true;
-
     }
 
     public abstract Fragment getFirstFragment();

--- a/VideoLocker/src/main/java/org/edx/mobile/base/BaseVideosDownloadStateActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/BaseVideosDownloadStateActivity.java
@@ -1,0 +1,85 @@
+package org.edx.mobile.base;
+
+import android.text.format.DateUtils;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+
+import org.edx.mobile.R;
+import org.edx.mobile.module.db.DataCallback;
+import org.edx.mobile.util.AppConstants;
+import org.edx.mobile.view.custom.ProgressWheel;
+
+public abstract class BaseVideosDownloadStateActivity extends BaseFragmentActivity {
+    private ProgressWheel progressWheel;
+    private MenuItem progressMenuItem;
+    private Runnable updateDownloadProgressRunnable;
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        super.onCreateOptionsMenu(menu);
+        getMenuInflater().inflate(R.menu.download_state, menu);
+        MenuItem newProgressMenuItem = menu.findItem(R.id.download_progress);
+        View progressView = newProgressMenuItem.getActionView();
+        ProgressWheel newProgressWheel = (ProgressWheel)
+                progressView.findViewById(R.id.progress_wheel);
+        if (progressMenuItem != null) {
+            newProgressMenuItem.setVisible(progressMenuItem.isVisible());
+            newProgressWheel.setProgress(progressWheel.getProgress());
+        }
+        progressMenuItem = newProgressMenuItem;
+        progressWheel = newProgressWheel;
+        progressView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                environment.getRouter().showDownloads(BaseVideosDownloadStateActivity.this);
+            }
+        });
+        if (updateDownloadProgressRunnable == null) {
+            updateDownloadProgressRunnable = new Runnable() {
+                @Override
+                public void run() {
+                    if (AppConstants.offline_flag ||
+                            !environment.getDatabase().isAnyVideoDownloading(null)) {
+                        progressMenuItem.setVisible(false);
+                    } else {
+                        progressMenuItem.setVisible(true);
+                        environment.getStorage().getAverageDownloadProgress(
+                                new DataCallback<Integer>() {
+                            @Override
+                            public void onResult(Integer result) {
+                                int progressPercent = result;
+                                if (progressPercent >= 0 && progressPercent <= 100) {
+                                    progressWheel.setProgressPercent(progressPercent);
+                                }
+                            }
+                            @Override
+                            public void onFail(Exception ex) {
+                                logger.error(ex);
+                            }
+                        });
+                    }
+                    progressWheel.postDelayed(this, DateUtils.SECOND_IN_MILLIS);
+                }
+            };
+            updateDownloadProgressRunnable.run();
+        }
+        return true;
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        if (updateDownloadProgressRunnable != null) {
+            updateDownloadProgressRunnable.run();
+        }
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        if (updateDownloadProgressRunnable != null) {
+            progressWheel.removeCallbacks(updateDownloadProgressRunnable);
+        }
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/base/BaseVideosDownloadStateActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/BaseVideosDownloadStateActivity.java
@@ -7,7 +7,7 @@ import android.view.View;
 
 import org.edx.mobile.R;
 import org.edx.mobile.module.db.DataCallback;
-import org.edx.mobile.util.AppConstants;
+import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.view.custom.ProgressWheel;
 
 public abstract class BaseVideosDownloadStateActivity extends BaseFragmentActivity {
@@ -39,7 +39,7 @@ public abstract class BaseVideosDownloadStateActivity extends BaseFragmentActivi
             updateDownloadProgressRunnable = new Runnable() {
                 @Override
                 public void run() {
-                    if (AppConstants.offline_flag ||
+                    if (!NetworkUtil.isConnected(BaseVideosDownloadStateActivity.this) ||
                             !environment.getDatabase().isAnyVideoDownloading(null)) {
                         progressMenuItem.setVisible(false);
                     } else {

--- a/VideoLocker/src/main/java/org/edx/mobile/base/CourseDetailBaseFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/CourseDetailBaseFragment.java
@@ -19,7 +19,7 @@ import org.edx.mobile.util.BrowserUtil;
 
 import roboguice.fragment.RoboFragment;
 
-public class CourseDetailBaseFragment extends RoboFragment {
+public abstract class CourseDetailBaseFragment extends RoboFragment {
 
    @Inject
     protected IEdxEnvironment environment;

--- a/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
@@ -7,8 +7,6 @@ import android.content.IntentFilter;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 import android.text.TextUtils;
-import android.view.Menu;
-import android.view.MenuItem;
 import android.view.View;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
@@ -29,8 +27,9 @@ import java.util.Map;
 
 import de.greenrobot.event.EventBus;
 
-public class FindCoursesBaseActivity extends BaseFragmentActivity
-        implements URLInterceptorWebViewClient.IActionListener, URLInterceptorWebViewClient.IPageStatusListener {
+public abstract class FindCoursesBaseActivity extends BaseFragmentActivity implements
+        URLInterceptorWebViewClient.IActionListener,
+        URLInterceptorWebViewClient.IPageStatusListener {
 
     private static final String ACTION_ENROLLED = "ACTION_ENROLLED_TO_COURSE";
 
@@ -106,26 +105,6 @@ public class FindCoursesBaseActivity extends BaseFragmentActivity
         }
         hideLoadingProgress();
         invalidateOptionsMenu();
-    }
-
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        super.onCreateOptionsMenu(menu);
-
-        //Hide the download progress from Action bar
-        MenuItem menuItem = menu.findItem(R.id.progress_download);
-        menuItem.setVisible(false);
-
-        return true;
-    }
-
-    @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
-        //Hide the download progress from Action bar.
-        //This has to be called in onCreateOptions as well
-        MenuItem menuItem = menu.findItem(R.id.progress_download);
-        menuItem.setVisible(false);
-        return true;
     }
 
     /**

--- a/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
@@ -15,8 +15,6 @@ import org.edx.mobile.R;
 import org.edx.mobile.event.FlyingMessageEvent;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.task.EnrollForCourseTask;
-import org.edx.mobile.util.AppConstants;
-import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.view.custom.ETextView;
 import org.edx.mobile.view.custom.URLInterceptorWebViewClient;
 import org.edx.mobile.view.dialog.EnrollmentFailureDialogFragment;
@@ -46,14 +44,6 @@ public abstract class FindCoursesBaseActivity extends BaseFragmentActivity imple
         webview = (WebView) findViewById(R.id.webview);
         offlineBar = findViewById(R.id.offline_bar);
         progressWheel = (ProgressBar) findViewById(R.id.progress_spinner);
-        if (!(NetworkUtil.isConnected(this))) {
-            AppConstants.offline_flag = true;
-            invalidateOptionsMenu();
-            showOfflineMessage();
-            if(offlineBar!=null){
-                offlineBar.setVisibility(View.VISIBLE);
-            }
-        }
 
         setupWebView();
         enableEnrollCallback();
@@ -71,40 +61,38 @@ public abstract class FindCoursesBaseActivity extends BaseFragmentActivity imple
         disableEnrollCallback();
     }
 
+    protected boolean isWebViewLoaded() {
+        return isWebViewLoaded;
+    }
+
     private void setupWebView() {
-        if(webview!=null){
-            isWebViewLoaded = false;
-            URLInterceptorWebViewClient client = new URLInterceptorWebViewClient(this, webview);
+        URLInterceptorWebViewClient client = new URLInterceptorWebViewClient(this, webview);
 
-            // if all the links are to be treated as external
-            client.setAllLinksAsExternal(isAllLinksExternal());
+        // if all the links are to be treated as external
+        client.setAllLinksAsExternal(isAllLinksExternal());
 
-            client.setActionListener(this);
-            client.setPageStatusListener(this);
-        }
+        client.setActionListener(this);
+        client.setPageStatusListener(this);
     }
 
     @Override
     protected void onOnline() {
-        offlineBar.setVisibility(View.GONE);
-        if(isWebViewLoaded){
-            hideOfflineMessage();
-            invalidateOptionsMenu();
-        }else{
-            setupWebView();
+        if (!isWebViewLoaded) {
+            super.onOnline();
+            offlineBar.setVisibility(View.GONE);
             hideOfflineMessage();
         }
     }
 
     @Override
     protected void onOffline() {
-        offlineBar.setVisibility(View.VISIBLE);
-        //If webview is not loaded, then show the offline mode message
-        if(!isWebViewLoaded) {
+        // If the WebView is not loaded, then show the offline mode message
+        if (!isWebViewLoaded) {
+            super.onOffline();
+            offlineBar.setVisibility(View.VISIBLE);
             showOfflineMessage();
+            hideLoadingProgress();
         }
-        hideLoadingProgress();
-        invalidateOptionsMenu();
     }
 
     /**

--- a/VideoLocker/src/main/java/org/edx/mobile/player/PlayerActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/PlayerActivity.java
@@ -8,13 +8,14 @@ import android.support.v4.app.FragmentTransaction;
 import android.view.View;
 
 import org.edx.mobile.R;
-import org.edx.mobile.base.BaseFragmentActivity;
+import org.edx.mobile.base.BaseVideosDownloadStateActivity;
 import org.edx.mobile.model.api.TranscriptModel;
 import org.edx.mobile.model.db.DownloadEntry;
 
 import java.io.File;
 
-public abstract class PlayerActivity extends BaseFragmentActivity implements IPlayerEventCallback {
+public abstract class PlayerActivity extends BaseVideosDownloadStateActivity
+        implements IPlayerEventCallback {
 
     protected final Handler playHandler = new Handler();
     protected Runnable playPending;

--- a/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/VideoListFragment.java
@@ -136,12 +136,10 @@ public class VideoListFragment extends MyVideosBaseFragment {
                 if (offlineBar != null)
                     offlineBar.setVisibility(View.VISIBLE);
                 showDeletePanel(getView());
-                AppConstants.offline_flag = true;
             } else {
                 if (offlineBar != null) {
                     offlineBar.setVisibility(View.GONE);
                 }
-                AppConstants.offline_flag = false;
             }
 
             setAdaptertoVideoList();
@@ -158,7 +156,7 @@ public class VideoListFragment extends MyVideosBaseFragment {
 
     public void setAdaptertoVideoList(){
         if (!myVideosFlag) {
-            if (AppConstants.offline_flag) {
+            if (!NetworkUtil.isConnected(getActivity())) {
                 addDataToOfflineAdapter();
             } else {
                 addDataToOnlineAdapter();
@@ -537,7 +535,7 @@ public class VideoListFragment extends MyVideosBaseFragment {
 
     private void showOpenInBrowserPanel() {
         try {
-            if (!AppConstants.offline_flag) {
+            if (NetworkUtil.isConnected(getActivity())) {
                 if (isPlayerVisible()) {
                     hideOpenInBrowserPanel();
                 } else {
@@ -571,7 +569,6 @@ public class VideoListFragment extends MyVideosBaseFragment {
 
     public void onOffline() {
         if (!isLandscape) {
-            AppConstants.offline_flag = true;
             if (offlineBar != null) {
                 offlineBar.setVisibility(View.VISIBLE);
             }
@@ -596,7 +593,6 @@ public class VideoListFragment extends MyVideosBaseFragment {
     }
 
     public void onOnline() {
-        AppConstants.offline_flag = false;
         if (!isLandscape) {
             if (offlineBar != null) {
                 offlineBar.setVisibility(View.GONE);
@@ -802,7 +798,7 @@ public class VideoListFragment extends MyVideosBaseFragment {
         public void handleMessage(android.os.Message msg) {
             if (msg.what == MSG_UPDATE_PROGRESS) {
                 if (isActivityStarted()) {
-                    if (!AppConstants.offline_flag) {
+                    if (NetworkUtil.isConnected(getActivity())) {
                         if (adapter != null && enrollment!=null && chapterName!=null && lecture!=null) {
                             if(environment.getDatabase().isAnyVideoDownloadingInSubSection(null, enrollment.getCourse().getId(), chapterName, lecture.name)){
                                 adapter.setSelectedPosition(playingVideoIndex);
@@ -1121,7 +1117,7 @@ public class VideoListFragment extends MyVideosBaseFragment {
                 while (videoPos < adapter.getCount()) {
                     SectionItemInterface i = adapter.getItem(videoPos);
                     if (i!=null && i instanceof DownloadEntry) {
-                        if(AppConstants.offline_flag){
+                        if(!NetworkUtil.isConnected(getActivity())){
                             DownloadEntry de = (DownloadEntry) i;
                             if(de.isDownloaded()){
                                 if (callback != null) {
@@ -1163,7 +1159,7 @@ public class VideoListFragment extends MyVideosBaseFragment {
                         SectionItemInterface d = adapter.getItem(i);
                         if (d!=null && d instanceof DownloadEntry) {
                             DownloadEntry de = (DownloadEntry) d;
-                            if(AppConstants.offline_flag){
+                            if(!NetworkUtil.isConnected(getActivity())){
                                 if(de.isDownloaded()){
                                     return true;
                                 }
@@ -1190,7 +1186,7 @@ public class VideoListFragment extends MyVideosBaseFragment {
                 while (videoPos >= 0) {
                     SectionItemInterface i = adapter.getItem(videoPos);
                     if (i!=null && i instanceof DownloadEntry) {
-                        if(AppConstants.offline_flag){
+                        if(!NetworkUtil.isConnected(getActivity())){
                             DownloadEntry de = (DownloadEntry) i;
                             if(de.isDownloaded()){
                                 if (callback != null) {
@@ -1230,7 +1226,7 @@ public class VideoListFragment extends MyVideosBaseFragment {
                         SectionItemInterface d = adapter.getItem(i);
                         if (d!=null && d instanceof DownloadEntry) {
                             DownloadEntry de = (DownloadEntry) d;
-                            if(AppConstants.offline_flag){
+                            if(!NetworkUtil.isConnected(getActivity())){
                                 if(de.isDownloaded()){
                                     return true;
                                 }

--- a/VideoLocker/src/main/java/org/edx/mobile/receivers/NetworkConnectivityReceiver.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/receivers/NetworkConnectivityReceiver.java
@@ -66,7 +66,7 @@ public class NetworkConnectivityReceiver extends RoboBroadcastReceiver {
             segIO.trackUserCellConnection(carrierName, NetworkUtil.isOnZeroRatedNetwork(context, environment.getConfig()));
         }
         NetworkConnectivityChangeEvent event = new NetworkConnectivityChangeEvent();
-        EventBus.getDefault().post(event);
+        EventBus.getDefault().postSticky(event);
 
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/social/SocialLoginDelegate.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/social/SocialLoginDelegate.java
@@ -18,8 +18,8 @@ import org.edx.mobile.social.facebook.FacebookProvider;
 import org.edx.mobile.social.google.GoogleOauth2;
 import org.edx.mobile.social.google.GoogleProvider;
 import org.edx.mobile.task.Task;
-import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.Config;
+import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.util.ResourceUtil;
 import org.edx.mobile.view.ICommonUI;
 
@@ -268,7 +268,7 @@ public class SocialLoginDelegate {
         }
         @Override
         public void onClick(View v) {
-            if (AppConstants.offline_flag) {
+            if (!NetworkUtil.isConnected(activity)) {
                 callback.showErrorMessage(activity.getString(R.string.no_connectivity),
                         activity.getString(R.string.network_not_connected));
             } else {

--- a/VideoLocker/src/main/java/org/edx/mobile/util/AppConstants.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/AppConstants.java
@@ -3,7 +3,6 @@ package org.edx.mobile.util;
 
 public class AppConstants {
     
-    public static boolean offline_flag  = false;
     public static boolean myVideosDeleteMode  = false;
     public static boolean videoListDeleteMode  = false;
 

--- a/VideoLocker/src/main/java/org/edx/mobile/util/NetworkUtil.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/NetworkUtil.java
@@ -188,7 +188,7 @@ public class NetworkUtil {
                 return false;
             }
         } else {
-            if (AppConstants.offline_flag) {
+            if (!isConnected(activity)) {
                 activity.showInfoMessage(activity.getString(R.string.network_not_connected));
                 return false;
             }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
@@ -176,7 +176,7 @@ public abstract  class CourseBaseActivity  extends BaseFragmentActivity implemen
     }
 
     @Override
-    protected boolean createOptionMenu(Menu menu) {
+    protected boolean createOptionsMenu(Menu menu) {
         if (courseComponentId != null) {
             MenuInflater inflater = getMenuInflater();
             inflater.inflate(R.menu.course_detail, menu);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
@@ -22,7 +22,6 @@ import org.edx.mobile.services.CourseManager;
 import org.edx.mobile.task.GetCourseStructureTask;
 import org.edx.mobile.third_party.iconify.IconDrawable;
 import org.edx.mobile.third_party.iconify.Iconify;
-import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.BrowserUtil;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.view.common.MessageType;
@@ -75,18 +74,8 @@ public abstract  class CourseBaseActivity  extends BaseFragmentActivity implemen
         }
         restore(bundle);
 
-        initialize(arg0);
-        blockDrawerFromOpening();
-    }
-
-    protected void initialize(Bundle arg){
         setApplyPrevTransitionOnRestart(true);
-        if (!(NetworkUtil.isConnected(this))) {
-            AppConstants.offline_flag = true;
-            invalidateOptionsMenu();
-            showOfflineMessage();
-
-        }
+        blockDrawerFromOpening();
     }
 
     @Override
@@ -164,9 +153,7 @@ public abstract  class CourseBaseActivity  extends BaseFragmentActivity implemen
     @Override
     protected void onOffline() {
         offlineBar.setVisibility(View.VISIBLE);
-
         hideLoadingProgress();
-        invalidateOptionsMenu();
     }
 
     @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDashboardActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDashboardActivity.java
@@ -3,17 +3,12 @@ package org.edx.mobile.view;
 import android.os.Bundle;
 import android.support.v4.app.FragmentTransaction;
 
-import org.edx.mobile.base.BaseFragmentActivity;
+import org.edx.mobile.base.BaseVideosDownloadStateActivity;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.module.analytics.ISegment;
 
-
-/**
- * TODO - it is just a place holder for now. as we need to use it
- * to navigation to new views.
- */
-public class CourseDashboardActivity extends BaseFragmentActivity {
+public class CourseDashboardActivity extends BaseVideosDownloadStateActivity {
 
     protected Logger logger = new Logger(getClass().getSimpleName());
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDetailInfoActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDetailInfoActivity.java
@@ -13,8 +13,6 @@ import org.edx.mobile.base.BaseFragmentActivity;
 import org.edx.mobile.http.IApi;
 import org.edx.mobile.interfaces.NetworkObserver;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
-import org.edx.mobile.util.AppConstants;
-import org.edx.mobile.util.NetworkUtil;
 
 
 public class CourseDetailInfoActivity extends BaseFragmentActivity {
@@ -42,13 +40,6 @@ public class CourseDetailInfoActivity extends BaseFragmentActivity {
         bundle = savedInstanceState != null ? savedInstanceState :
                 getIntent().getBundleExtra(Router.EXTRA_BUNDLE);
         offlineBar = findViewById(R.id.offline_bar);
-        if (!(NetworkUtil.isConnected(this))) {
-            AppConstants.offline_flag = true;
-            invalidateOptionsMenu();
-            if(offlineBar!=null){
-                offlineBar.setVisibility(View.VISIBLE);
-            }
-        }
 
         courseData = (EnrolledCoursesResponse) bundle
                 .getSerializable(Router.EXTRA_ENROLLMENT);
@@ -105,8 +96,8 @@ public class CourseDetailInfoActivity extends BaseFragmentActivity {
 
     @Override
     protected void onOffline() {
-        AppConstants.offline_flag = true;
-        if(offlineBar!=null){
+        super.onOffline();
+        if (offlineBar != null) {
             offlineBar.setVisibility(View.VISIBLE);
         }
 
@@ -115,7 +106,6 @@ public class CourseDetailInfoActivity extends BaseFragmentActivity {
                 ((NetworkObserver) fragment).onOffline();
             }
         }
-        invalidateOptionsMenu();
     }
 
     @Override
@@ -126,8 +116,8 @@ public class CourseDetailInfoActivity extends BaseFragmentActivity {
 
     @Override
     protected void onOnline() {
-        AppConstants.offline_flag = false;
-        if(offlineBar!=null){
+        super.onOnline();
+        if (offlineBar != null) {
             offlineBar.setVisibility(View.GONE);
         }
 
@@ -136,7 +126,6 @@ public class CourseDetailInfoActivity extends BaseFragmentActivity {
                 ((NetworkObserver) fragment).onOnline();
             }
         }
-        invalidateOptionsMenu();
     }
 
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseLectureListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseLectureListActivity.java
@@ -59,14 +59,6 @@ public class CourseLectureListActivity extends BaseFragmentActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (!(NetworkUtil.isConnected(this))) {
-            AppConstants.offline_flag = true;
-            invalidateOptionsMenu();
-
-            if (offlineBar != null) 
-                offlineBar.setVisibility(View.VISIBLE);
-        }
-
 
         enrollment = (EnrolledCoursesResponse) getIntent().getSerializableExtra(Router.EXTRA_ENROLLMENT);
 
@@ -84,7 +76,7 @@ public class CourseLectureListActivity extends BaseFragmentActivity {
     @Override
     protected void onRestart() {
         super.onRestart();
-        if(AppConstants.offline_flag){
+        if(!NetworkUtil.isConnected(this)){
             finish();
         }
     }
@@ -242,23 +234,21 @@ public class CourseLectureListActivity extends BaseFragmentActivity {
 
     @Override
     protected void onOffline() {
-        AppConstants.offline_flag = true;
-        if(offlineBar!=null){
+        super.onOffline();
+        if (offlineBar != null) {
             offlineBar.setVisibility(View.VISIBLE);
         }
-        invalidateOptionsMenu();
-        if(isActivityVisible){
+        if (isActivityVisible) {
             finish();
         }
     }
 
     @Override
     protected void onOnline() {
-        AppConstants.offline_flag = false;
-        if(offlineBar!=null){
+        super.onOnline();
+        if (offlineBar != null) {
             offlineBar.setVisibility(View.GONE);
         }
-        invalidateOptionsMenu();
     }
 
     private void showOpenInBrowserPanel() {
@@ -359,7 +349,7 @@ public class CourseLectureListActivity extends BaseFragmentActivity {
         public void handleMessage(android.os.Message msg) {
             if (msg.what == MSG_UPDATE_PROGRESS) {
                 if (isActivityStarted()){
-                    if(!AppConstants.offline_flag) {
+                    if(NetworkUtil.isConnected(CourseLectureListActivity.this)) {
                         if (adapter != null && chapter != null && enrollment != null) {
                             if (environment.getDatabase().isAnyVideoDownloadingInSection(null, enrollment.getCourse().getId(), chapter.chapter)){
                                 adapter.notifyDataSetChanged();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -23,7 +23,6 @@ import org.edx.mobile.model.course.HasDownloadEntry;
 import org.edx.mobile.model.db.DownloadEntry;
 import org.edx.mobile.services.CourseManager;
 import org.edx.mobile.services.VideoDownloadHelper;
-import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.view.adapters.CourseOutlineAdapter;
 import org.edx.mobile.view.common.TaskProcessCallback;
@@ -168,8 +167,6 @@ public class CourseOutlineFragment extends MyVideosBaseFragment {
                 }
             });
         }
-
-        AppConstants.offline_flag = !NetworkUtil.isConnected(getActivity());
     }
 
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -217,10 +217,6 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements 
         }
     }
 
-    protected void initialize(Bundle arg){
-        super.initialize(arg);
-    }
-
     private void updateDataModel(){
         unitList.clear();
         if( selectedUnit == null || selectedUnit.getRoot() == null ) {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitVideoFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitVideoFragment.java
@@ -159,17 +159,6 @@ public class CourseUnitVideoFragment extends CourseUnitFragment
 
         if(getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
             isLandscape = false;
-
-
-            if (!(NetworkUtil.isConnected(getActivity()))) {
-
-                AppConstants.offline_flag = true;
-            } else {
-
-                AppConstants.offline_flag = false;
-            }
-
-
         } else {
             isLandscape = true;
             // probably the landscape player view, so hide action bar
@@ -290,7 +279,7 @@ public class CourseUnitVideoFragment extends CourseUnitFragment
                     };
                     MediaConsentUtils.consentToMediaPlayback(getActivity(), dialogCallback, environment.getConfig());
                 }else{
-                    if (  AppConstants.offline_flag ){
+                    if (  !NetworkUtil.isConnected(getActivity()) ){
                         //TODO - should use interface to decouple
                         ((CourseBaseActivity) getActivity())
                             .showOfflineAccessMessage();
@@ -484,7 +473,7 @@ public class CourseUnitVideoFragment extends CourseUnitFragment
 
     private void showOpenInBrowserPanel() {
         try {
-            if (!AppConstants.offline_flag) {
+            if (NetworkUtil.isConnected(getActivity())) {
                 if (isPlayerVisible()) {
                     hideOpenInBrowserPanel();
                 } else {
@@ -518,8 +507,6 @@ public class CourseUnitVideoFragment extends CourseUnitFragment
 
     public void onOffline() {
         if (!isLandscape) {
-            AppConstants.offline_flag = true;
-
             hideOpenInBrowserPanel();
             if (!myVideosFlag) {
 
@@ -529,7 +516,6 @@ public class CourseUnitVideoFragment extends CourseUnitFragment
 
 
     public void onOnline() {
-        AppConstants.offline_flag = false;
         if (!isLandscape) {
 
             if (!myVideosFlag) {
@@ -582,7 +568,7 @@ public class CourseUnitVideoFragment extends CourseUnitFragment
         public void handleMessage(android.os.Message msg) {
             if (msg.what == MSG_UPDATE_PROGRESS) {
                 if (isActivityStarted()) {
-                    if (!AppConstants.offline_flag) {
+                    if (NetworkUtil.isConnected(getActivity())) {
 
                         sendEmptyMessageDelayed(MSG_UPDATE_PROGRESS, 3000);
                     }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseVideoListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseVideoListActivity.java
@@ -119,9 +119,6 @@ public abstract class CourseVideoListActivity  extends CourseBaseActivity implem
     }
 
     @Override
-    protected void updateDownloadProgress(final int progressPercent) {}
-
-    @Override
     public void showProgressDialog(int numDownloads) {}
 
     @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseVideoListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseVideoListActivity.java
@@ -13,7 +13,7 @@ import org.edx.mobile.model.course.CourseComponent;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.services.LastAccessManager;
 import org.edx.mobile.services.VideoDownloadHelper;
-import org.edx.mobile.util.AppConstants;
+import org.edx.mobile.util.NetworkUtil;
 
 /**
  * Created by hanning on 5/15/15.
@@ -48,7 +48,7 @@ public abstract class CourseVideoListActivity  extends CourseBaseActivity implem
     @Override
     public void showLastAccessedView(final String lastAccessedSubSectionId, final String courseId, final View view) {
         if (  isActivityStarted() ) {
-            if (!AppConstants.offline_flag) {
+            if (NetworkUtil.isConnected(this)) {
                 if(courseId!=null && lastAccessedSubSectionId!=null){
                     CourseComponent lastAccessComponent = courseManager.getComponentById(courseId, lastAccessedSubSectionId);
                     if (lastAccessComponent != null) {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DownloadListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DownloadListActivity.java
@@ -3,9 +3,6 @@ package org.edx.mobile.view;
 import android.app.ActionBar;
 import android.os.Bundle;
 import android.os.Handler;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.widget.ListView;
 
@@ -142,36 +139,6 @@ public class DownloadListActivity extends BaseFragmentActivity {
         AppConstants.offline_flag = false;
         offlineBar.setVisibility(View.GONE);
         invalidateOptionsMenu();
-    }
-
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu)
-    {
-        // inflate menu from xml
-        MenuInflater inflater = getMenuInflater();
-        inflater.inflate(R.menu.main, menu);
-
-        MenuItem menuItem = menu.findItem(R.id.progress_download);
-        menuItem.setVisible(false);
-
-        MenuItem offline_tvItem = menu.findItem(R.id.offline);
-        if (AppConstants.offline_flag) {
-            offline_tvItem.setVisible(true);
-        } else {
-            offline_tvItem.setVisible(false);
-        }
-        return true;
-    }
-
-    @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
-        MenuItem menuItem = menu.findItem(R.id.progress_download);
-        menuItem.setVisible(false);
-
-        MenuItem checkBox_menuItem = menu.findItem(R.id.delete_checkbox);
-        checkBox_menuItem.setVisible(false);
-
-        return true;
     }
 
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DownloadListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DownloadListActivity.java
@@ -12,8 +12,6 @@ import org.edx.mobile.model.VideoModel;
 import org.edx.mobile.model.db.DownloadEntry;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.db.DataCallback;
-import org.edx.mobile.util.AppConstants;
-import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.view.adapters.DownloadEntryAdapter;
 
 import java.util.ArrayList;
@@ -47,13 +45,7 @@ public class DownloadListActivity extends BaseFragmentActivity {
 
         environment.getSegment().trackScreenView(ISegment.Screens.DOWNLOADS);
 
-        offlineBar = (View) findViewById(R.id.offline_bar);
-        if (!(NetworkUtil.isConnected(this))) {
-            AppConstants.offline_flag = true;
-            invalidateOptionsMenu();
-            if (offlineBar != null) 
-                offlineBar.setVisibility(View.VISIBLE);
-        }
+        offlineBar = findViewById(R.id.offline_bar);
 
         ListView downloadListView = (ListView) findViewById(R.id.my_downloads_list);
         adapter = new DownloadEntryAdapter(this, environment) {
@@ -123,22 +115,19 @@ public class DownloadListActivity extends BaseFragmentActivity {
     protected void onRestart() {
         super.onRestart();
         handler.sendEmptyMessageDelayed(MSG_UPDATE_PROGRESS, 0);
-        invalidateOptionsMenu();
-    };
+    }
 
 
     @Override
     protected void onOffline() {
-        AppConstants.offline_flag = true;
+        super.onOffline();
         offlineBar.setVisibility(View.VISIBLE);
-        invalidateOptionsMenu();
     }
 
     @Override
     protected void onOnline() {
-        AppConstants.offline_flag = false;
+        super.onOnline();
         offlineBar.setVisibility(View.GONE);
-        invalidateOptionsMenu();
     }
 
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/FindCoursesActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/FindCoursesActivity.java
@@ -12,6 +12,8 @@ import roboguice.inject.ContentView;
 @ContentView(R.layout.activity_find_courses)
 public class FindCoursesActivity extends FindCoursesBaseActivity {
 
+    private WebView webView;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -22,18 +24,15 @@ public class FindCoursesActivity extends FindCoursesBaseActivity {
 
         environment.getSegment().trackScreenView(ISegment.Screens.FIND_COURSES);
 
-        loadCourseSearchUrl();
+        webView = (WebView) findViewById(R.id.webview);
+        webView.loadUrl(environment.getConfig().getEnrollmentConfig().getCourseSearchUrl());
     }
 
     @Override
     protected void onOnline() {
         super.onOnline();
-        loadCourseSearchUrl();
-    }
-
-    private void loadCourseSearchUrl() {
-        String url = environment.getConfig().getEnrollmentConfig().getCourseSearchUrl();
-        WebView webview = (WebView) findViewById(R.id.webview);
-        webview.loadUrl(url);
+        if (!isWebViewLoaded()) {
+            webView.reload();
+        }
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/GroupSummaryActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/GroupSummaryActivity.java
@@ -51,7 +51,9 @@ public class GroupSummaryActivity extends BaseSingleFragmentActivity {
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
 
-        boolean create = super.onCreateOptionsMenu(menu);
+        super.onCreateOptionsMenu(menu);
+
+        getMenuInflater().inflate(R.menu.group_summary, menu);
 
         MenuItem unreadMenuItem = menu.findItem(R.id.unread_display);
 
@@ -68,7 +70,7 @@ public class GroupSummaryActivity extends BaseSingleFragmentActivity {
 
         }
 
-        return create;
+        return true;
 
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/LaunchActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/LaunchActivity.java
@@ -41,9 +41,6 @@ public class LaunchActivity extends BaseFragmentActivity {
             overridePendingTransition(R.anim.no_transition,R.anim.slide_out_to_bottom);
         }
 
-        //The onTick method need not be run in the LaunchActivity
-        runOnTick = false;
-
         EButton sign_in_tv = (EButton) findViewById(R.id.sign_in_tv);
         sign_in_tv.setOnClickListener(new OnClickListener() {
             @Override
@@ -97,7 +94,7 @@ public class LaunchActivity extends BaseFragmentActivity {
 
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    protected boolean createOptionsMenu(Menu menu) {
         // Launch screen doesn't have any menu
         return true;
     }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/LoginActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/LoginActivity.java
@@ -69,8 +69,6 @@ public class LoginActivity extends BaseFragmentActivity implements SocialLoginDe
 
         hideSoftKeypad();
 
-        runOnTick = false;
-
         // setup for social login
         socialLoginDelegate = new SocialLoginDelegate(this, savedInstanceState, this, environment.getConfig());
 
@@ -425,7 +423,7 @@ public class LoginActivity extends BaseFragmentActivity implements SocialLoginDe
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean createOptionsMenu(Menu menu) {
         // Login screen doesn't have any menu
         return true;
     }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/LoginActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/LoginActivity.java
@@ -29,7 +29,6 @@ import org.edx.mobile.social.SocialFactory;
 import org.edx.mobile.social.SocialLoginDelegate;
 import org.edx.mobile.task.LoginTask;
 import org.edx.mobile.task.Task;
-import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.Config;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.util.PropertyUtil;
@@ -84,10 +83,6 @@ public class LoginActivity extends BaseFragmentActivity implements SocialLoginDe
         progressbar = (ProgressBar) findViewById(R.id.login_spinner);
         login_tv = (TextView) findViewById(R.id.login_btn_tv);
 
-        if (!(NetworkUtil.isConnected(this))) {
-            AppConstants.offline_flag = true;
-        }
-
         loginButtonLayout = (RelativeLayout) findViewById(R.id.login_button_layout);
         loginButtonLayout.setOnClickListener(new OnClickListener() {
 
@@ -104,7 +99,7 @@ public class LoginActivity extends BaseFragmentActivity implements SocialLoginDe
             @Override
             public void onClick(View v) {
                 // Calling help dialog
-                if (!AppConstants.offline_flag) {
+                if (NetworkUtil.isConnected(LoginActivity.this)) {
                     showResetPasswordDialog();
                 } else {
                     showNoNetworkDialog();
@@ -247,7 +242,7 @@ public class LoginActivity extends BaseFragmentActivity implements SocialLoginDe
 
     public void callServerForLogin() {
 
-        if (!AppConstants.offline_flag) {
+        if (NetworkUtil.isConnected(this)) {
             emailStr = email_et.getText().toString().trim();
             String passwordStr = password_et.getText().toString().trim();
 
@@ -397,12 +392,13 @@ public class LoginActivity extends BaseFragmentActivity implements SocialLoginDe
 
     @Override
     protected void onOnline() {
-        AppConstants.offline_flag = false;
+        super.onOnline();
+        hideErrorMessage();
     }
 
     @Override
     protected void onOffline() {
-        AppConstants.offline_flag = true;
+        super.onOffline();
         showErrorMessage(getString(R.string.no_connectivity),
                 getString(R.string.network_not_connected), false);
     }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyCoursesListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyCoursesListActivity.java
@@ -10,19 +10,17 @@ import com.facebook.SessionState;
 import com.google.inject.Inject;
 
 import org.edx.mobile.R;
-import org.edx.mobile.interfaces.NetworkObserver;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.module.db.DataCallback;
 import org.edx.mobile.module.facebook.IUiLifecycleHelper;
 import org.edx.mobile.module.notification.NotificationDelegate;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.social.facebook.FacebookProvider;
-import org.edx.mobile.util.AppConstants;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class MyCoursesListActivity extends BaseTabActivity implements NetworkObserver{
+public class MyCoursesListActivity extends BaseTabActivity {
 
     private IUiLifecycleHelper uiLifecycleHelper;
     private PrefManager featuresPref;
@@ -104,21 +102,8 @@ public class MyCoursesListActivity extends BaseTabActivity implements NetworkObs
     }
 
     @Override
-    public void onOffline() {
-        AppConstants.offline_flag = true;
-        invalidateOptionsMenu();
-    }
-
-    @Override
-    public void onOnline() {
-        AppConstants.offline_flag = false;
-        invalidateOptionsMenu();
-    }
-
-    @Override
     protected void onResume() {
         super.onResume();
-        invalidateOptionsMenu();
         uiLifecycleHelper.onResume();
         changeSocialMode(new FacebookProvider().isLoggedIn());
         notificationDelegate.checkAppUpgrade();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyRecentVideosFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyRecentVideosFragment.java
@@ -29,7 +29,6 @@ import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.player.PlayerFragment;
 import org.edx.mobile.player.VideoListFragment.VideoListCallback;
 import org.edx.mobile.util.AppConstants;
-import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.util.ResourceUtil;
 import org.edx.mobile.util.UiUtil;
 import org.edx.mobile.view.adapters.MyRecentVideoAdapter;
@@ -129,11 +128,6 @@ public class MyRecentVideosFragment extends MyVideosBaseFragment {
                 videoListView.setAdapter(adapter);
 
                 showDeletePanel(getView());
-                if (!(NetworkUtil.isConnected(getActivity().getBaseContext()))) {
-                    AppConstants.offline_flag = true;
-                } else {
-                    AppConstants.offline_flag = false;
-                }
 
                 videoListView.setOnItemClickListener(adapter);
             } else {
@@ -287,7 +281,6 @@ public class MyRecentVideosFragment extends MyVideosBaseFragment {
 
     public void onOffline() {
         try{
-            AppConstants.offline_flag = true;
             notifyAdapter();
             videoListView.setOnItemClickListener(adapter);
         }catch(Exception e){
@@ -297,7 +290,6 @@ public class MyRecentVideosFragment extends MyVideosBaseFragment {
 
     protected void onOnline() {
         try{
-            AppConstants.offline_flag = false;
             notifyAdapter();
             videoListView.setOnItemClickListener(adapter);
         }catch(Exception e){

--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyVideosTabActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyVideosTabActivity.java
@@ -329,29 +329,21 @@ public class MyVideosTabActivity extends PlayerActivity implements VideoListCall
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
-        try{
-            MenuItem checkBox_menuItem = menu.findItem(R.id.delete_checkbox);
-            View checkBoxView = checkBox_menuItem.getActionView();
-            myVideocheckBox = (CheckBox) checkBoxView
-                    .findViewById(R.id.select_checkbox);
-            if(videoCheckListener==null) {
-                videoCheckListener = new VideoTabCheckBoxListener();
+        getMenuInflater().inflate(R.menu.video_list, menu);
+        MenuItem checkBox_menuItem = menu.findItem(R.id.delete_checkbox);
+        View checkBoxView = checkBox_menuItem.getActionView();
+        myVideocheckBox = (CheckBox) checkBoxView.findViewById(R.id.select_checkbox);
+        if (videoCheckListener == null) {
+            videoCheckListener = new VideoTabCheckBoxListener();
+        }
+        if (AppConstants.myVideosDeleteMode && !(mCurrentTab
+                .equalsIgnoreCase(getString(R.string.tab_my_all_videos)))) {
+            checkBox_menuItem.setVisible(true);
+            if (AppConstants.myVideosDeleteMode) {
+                myVideocheckBox.setOnCheckedChangeListener(videoCheckListener);
             }
-            if (AppConstants.myVideosDeleteMode && !(mCurrentTab
-                    .equalsIgnoreCase(getString(R.string.tab_my_all_videos)))) {
-                checkBox_menuItem.setVisible(true);
-                //checkBox.setVisibility(View.VISIBLE);
-                if (AppConstants.myVideosDeleteMode) {
-                    myVideocheckBox.setOnCheckedChangeListener(videoCheckListener);
-                }else{
-                    myVideocheckBox.setOnCheckedChangeListener(null);
-                }
-            } else {
-                checkBox_menuItem.setVisible(false);
-                myVideocheckBox.setOnCheckedChangeListener(null);
-            }
-        }catch(Exception e){
-            logger.error(e);
+        } else {
+            checkBox_menuItem.setVisible(false);
         }
         return true;
     }
@@ -365,65 +357,43 @@ public class MyVideosTabActivity extends PlayerActivity implements VideoListCall
             if (isChecked == lastIsChecked) {
                 return;
             }
-            try{
-                lastIsChecked = isChecked;
-                if (mCurrentTab
-                        .equalsIgnoreCase(getString(R.string.tab_my_recent_videos))) {
-                    if (isChecked) {
-                        recentVideosFragment.setAllVideosSectionChecked();
-                        try{
-                            myVideocheckBox.setButtonDrawable(R.drawable.ic_checkbox_active);
-                            //myVideocheckBox.setBackgroundResource(R.drawable.ic_checkbox_active);
-                        }catch(Exception e){
-                            logger.error(e);
-                        }
-
-                    } else {
-                        recentVideosFragment.unsetAllVideosSectionChecked();
-                        myVideocheckBox.setButtonDrawable(R.drawable.ic_checkbox_default);
-                        //myVideocheckBox.setBackgroundResource(R.drawable.ic_checkbox_default);
-                    }
+            lastIsChecked = isChecked;
+            if (mCurrentTab.equalsIgnoreCase(getString(R.string.tab_my_recent_videos))) {
+                if (isChecked) {
+                    recentVideosFragment.setAllVideosSectionChecked();
+                    myVideocheckBox.setButtonDrawable(R.drawable.ic_checkbox_active);
+                } else {
+                    recentVideosFragment.unsetAllVideosSectionChecked();
+                    myVideocheckBox.setButtonDrawable(R.drawable.ic_checkbox_default);
                 }
-            }catch(Exception e){
-                logger.error(e);
             }
         }
     }
 
     @Override
     protected void onOffline() {
-        try{
-            AppConstants.offline_flag = true;
-            if (mCurrentTab
-                    .equalsIgnoreCase(getString(R.string.tab_my_recent_videos))) {
-                recentVideosFragment.onOffline();
-            }
-            if (playerFragment != null) {
-                playerFragment.onOffline();
-            }
-            offlineBar.setVisibility(View.VISIBLE);
-            invalidateOptionsMenu();
-        }catch(Exception ex){
-            logger.error(ex);
+        AppConstants.offline_flag = true;
+        if (mCurrentTab.equalsIgnoreCase(getString(R.string.tab_my_recent_videos))) {
+            recentVideosFragment.onOffline();
         }
+        if (playerFragment != null) {
+            playerFragment.onOffline();
+        }
+        offlineBar.setVisibility(View.VISIBLE);
+        invalidateOptionsMenu();
     }
 
     @Override
     protected void onOnline() {
-        try{
-            AppConstants.offline_flag = false;
-            if (mCurrentTab
-                    .equalsIgnoreCase(getString(R.string.tab_my_recent_videos))) {
-                recentVideosFragment.onOnline();
-            }
-            if (playerFragment != null) {
-                playerFragment.onOnline();
-            }
-            offlineBar.setVisibility(View.GONE);
-            invalidateOptionsMenu();
-        }catch(Exception ex){
-            logger.error(ex);
+        AppConstants.offline_flag = false;
+        if (mCurrentTab.equalsIgnoreCase(getString(R.string.tab_my_recent_videos))) {
+            recentVideosFragment.onOnline();
         }
+        if (playerFragment != null) {
+            playerFragment.onOnline();
+        }
+        offlineBar.setVisibility(View.GONE);
+        invalidateOptionsMenu();
     }
 
     public void showCheckBox() {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyVideosTabActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyVideosTabActivity.java
@@ -23,7 +23,6 @@ import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.player.PlayerActivity;
 import org.edx.mobile.player.VideoListFragment.VideoListCallback;
 import org.edx.mobile.util.AppConstants;
-import org.edx.mobile.util.NetworkUtil;
 
 public class MyVideosTabActivity extends PlayerActivity implements VideoListCallback {
 
@@ -47,12 +46,6 @@ public class MyVideosTabActivity extends PlayerActivity implements VideoListCall
         configureDrawer();
 
         offlineBar = findViewById(R.id.offline_bar);
-
-        if (!(NetworkUtil.isConnected(this))) {
-            AppConstants.offline_flag = true;
-            invalidateOptionsMenu();
-            offlineBar.setVisibility(View.VISIBLE);
-        }
 
         environment.getSegment().trackScreenView(ISegment.Screens.MY_VIDEOS);
 
@@ -372,7 +365,7 @@ public class MyVideosTabActivity extends PlayerActivity implements VideoListCall
 
     @Override
     protected void onOffline() {
-        AppConstants.offline_flag = true;
+        super.onOffline();
         if (mCurrentTab.equalsIgnoreCase(getString(R.string.tab_my_recent_videos))) {
             recentVideosFragment.onOffline();
         }
@@ -380,12 +373,11 @@ public class MyVideosTabActivity extends PlayerActivity implements VideoListCall
             playerFragment.onOffline();
         }
         offlineBar.setVisibility(View.VISIBLE);
-        invalidateOptionsMenu();
     }
 
     @Override
     protected void onOnline() {
-        AppConstants.offline_flag = false;
+        super.onOnline();
         if (mCurrentTab.equalsIgnoreCase(getString(R.string.tab_my_recent_videos))) {
             recentVideosFragment.onOnline();
         }
@@ -393,7 +385,6 @@ public class MyVideosTabActivity extends PlayerActivity implements VideoListCall
             playerFragment.onOnline();
         }
         offlineBar.setVisibility(View.GONE);
-        invalidateOptionsMenu();
     }
 
     public void showCheckBox() {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -69,9 +69,6 @@ public class RegisterActivity extends BaseFragmentActivity
         setContentView(R.layout.activity_register);
         overridePendingTransition(R.anim.slide_in_from_bottom, R.anim.no_transition);
 
-        //The onTick method need not be run in the RegisterActivity
-        runOnTick = false;
-
         environment.getSegment().trackScreenView(ISegment.Screens.LAUNCH_ACTIVITY);
 
         socialLoginDelegate = new SocialLoginDelegate(this, savedInstanceState, this, environment.getConfig());
@@ -417,8 +414,8 @@ public class RegisterActivity extends BaseFragmentActivity
 
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        // Launch screen doesn't have any menu
+    public boolean createOptionsMenu(Menu menu) {
+        // Register screen doesn't have any menu
         return true;
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -38,7 +38,6 @@ import org.edx.mobile.social.SocialFactory;
 import org.edx.mobile.social.SocialLoginDelegate;
 import org.edx.mobile.task.RegisterTask;
 import org.edx.mobile.task.Task;
-import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.util.PropertyUtil;
 import org.edx.mobile.util.ResourceUtil;
@@ -156,8 +155,6 @@ public class RegisterActivity extends BaseFragmentActivity
             customTitle.setText(title);
         }
 
-        AppConstants.offline_flag = !NetworkUtil.isConnected(this);
-
         setupRegistrationForm();
         hideSoftKeypad();
         tryToSetUIInteraction(true);
@@ -254,7 +251,7 @@ public class RegisterActivity extends BaseFragmentActivity
     }
 
     private void createAccount() {
-        if(!AppConstants.offline_flag){
+        if(NetworkUtil.isConnected(this)){
             ScrollView scrollView = (ScrollView) findViewById(R.id.scrollview);
 
             boolean hasError = false;

--- a/VideoLocker/src/main/java/org/edx/mobile/view/SettingsActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/SettingsActivity.java
@@ -2,8 +2,6 @@ package org.edx.mobile.view;
 
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
-import android.view.Menu;
-import android.view.MenuItem;
 
 import org.edx.mobile.R;
 import org.edx.mobile.base.BaseSingleFragmentActivity;
@@ -20,16 +18,6 @@ public class SettingsActivity extends BaseSingleFragmentActivity {
     @Override
     public Fragment getFirstFragment() {
         return new SettingsFragment();
-    }
-
-    public boolean onCreateOptionsMenu(Menu menu) {
-        super.onCreateOptionsMenu(menu);
-
-        MenuItem checkBox_menuItem = menu.findItem(R.id.delete_checkbox);
-        checkBox_menuItem.setVisible(false);
-
-        return true;
-
     }
 
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/SocialFriendPickerFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/SocialFriendPickerFragment.java
@@ -98,10 +98,9 @@ public class SocialFriendPickerFragment extends RoboFragment implements SocialPr
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
+        inflater.inflate(R.menu.social_friend_picker, menu);
 
         doneMenuItem = menu.findItem(R.id.done_btn);
-        doneMenuItem.setVisible(true);
-
         doneMenuItem.getActionView().setOnClickListener(new View.OnClickListener() {
 
             @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/view/VideoListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/VideoListActivity.java
@@ -33,6 +33,7 @@ public class VideoListActivity extends BaseVideosDownloadStateActivity
     private boolean myVideosFlag;
     private CheckBox checkBox;
     private CourseVideoCheckBoxListener checklistener;
+    private View offlineBar;
     private PlayerFragment playerFragment;
     private VideoListFragment listFragment;
     private final Handler playHandler = new Handler();
@@ -66,16 +67,7 @@ public class VideoListActivity extends BaseVideosDownloadStateActivity
             logger.error(ex);
         }
 
-        if(!(NetworkUtil.isConnected(this))){
-            View offlineBar = (View) findViewById(R.id.offline_bar);
-            if (offlineBar != null) 
-                offlineBar.setVisibility(View.VISIBLE);
-
-            AppConstants.offline_flag = true;
-            invalidateOptionsMenu();
-        }else{
-            AppConstants.offline_flag = false;
-        }
+        offlineBar = findViewById(R.id.offline_bar);
 
         listFragment = (VideoListFragment) getSupportFragmentManager()
                 .findFragmentById(R.id.list_fragment);
@@ -285,7 +277,7 @@ public class VideoListActivity extends BaseVideosDownloadStateActivity
 
     @Override
     protected void onOffline() {
-        View offlineBar = findViewById(R.id.offline_bar);
+        super.onOffline();
         if (offlineBar != null) {
             offlineBar.setVisibility(View.VISIBLE);
         }
@@ -301,8 +293,6 @@ public class VideoListActivity extends BaseVideosDownloadStateActivity
             playerFragment.setPrevNxtListners(listFragment.getNextListener(), 
                     listFragment.getPreviousListener());
         }
-
-        invalidateOptionsMenu();
     }
 
     @Override
@@ -321,7 +311,7 @@ public class VideoListActivity extends BaseVideosDownloadStateActivity
 
     @Override
     protected void onOnline() {
-        View offlineBar = findViewById(R.id.offline_bar);
+        super.onOnline();
         if (offlineBar != null) {
             offlineBar.setVisibility(View.GONE);
         }
@@ -336,7 +326,6 @@ public class VideoListActivity extends BaseVideosDownloadStateActivity
             playerFragment.setPrevNxtListners(listFragment.getNextListener(), 
                     listFragment.getPreviousListener());
         }
-        invalidateOptionsMenu();
     }
 
     private class CourseVideoCheckBoxListener implements OnCheckedChangeListener {
@@ -389,7 +378,7 @@ public class VideoListActivity extends BaseVideosDownloadStateActivity
         switch (item.getItemId()) {
         case android.R.id.home:
             hideCheckBox();
-            if(AppConstants.offline_flag){
+            if(!NetworkUtil.isConnected(this)){
                 Intent intent = new Intent();
                 intent.setAction(AppConstants.VIDEOLIST_BACK_PRESSED);
                 sendBroadcast(intent); 
@@ -414,7 +403,7 @@ public class VideoListActivity extends BaseVideosDownloadStateActivity
         if(myVideosFlag){
             listFragment.handleDeleteView();
         } else {
-            if(AppConstants.offline_flag){
+            if(!NetworkUtil.isConnected(this)){
                 listFragment.handleDeleteView();
             }
         }
@@ -446,7 +435,7 @@ public class VideoListActivity extends BaseVideosDownloadStateActivity
     }
 
     public void onBackPressed() {
-        if(AppConstants.offline_flag){
+        if(!NetworkUtil.isConnected(this)){
             Intent intent = new Intent();
             intent.setAction(AppConstants.VIDEOLIST_BACK_PRESSED);
             sendBroadcast(intent);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/VideoListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/VideoListActivity.java
@@ -15,7 +15,7 @@ import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 
 import org.edx.mobile.R;
-import org.edx.mobile.base.BaseFragmentActivity;
+import org.edx.mobile.base.BaseVideosDownloadStateActivity;
 import org.edx.mobile.model.api.TranscriptModel;
 import org.edx.mobile.model.db.DownloadEntry;
 import org.edx.mobile.player.IPlayerEventCallback;
@@ -27,9 +27,8 @@ import org.edx.mobile.util.NetworkUtil;
 
 import java.io.File;
 
-@SuppressWarnings("serial")
-public class VideoListActivity extends BaseFragmentActivity implements
-VideoListCallback, IPlayerEventCallback {
+public class VideoListActivity extends BaseVideosDownloadStateActivity
+        implements VideoListCallback, IPlayerEventCallback {
 
     private boolean myVideosFlag;
     private CheckBox checkBox;
@@ -251,23 +250,14 @@ VideoListCallback, IPlayerEventCallback {
     }
 
     public void showCheckBox() {
-        if (myVideosFlag) {
-            AppConstants.myVideosDeleteMode = true;
-        } else {
-            AppConstants.videoListDeleteMode = true;
-        }
+        AppConstants.myVideosDeleteMode = true;
         invalidateOptionsMenu();
     }
 
     public void hideCheckBox() {
-        if (myVideosFlag) {
-            AppConstants.myVideosDeleteMode = false;
-            if (checkBox != null)
-                checkBox.setChecked(false);
-        } else {
-            AppConstants.videoListDeleteMode = false;
-            if (checkBox != null)
-                checkBox.setChecked(false);
+        AppConstants.myVideosDeleteMode = false;
+        if (checkBox != null) {
+            checkBox.setChecked(false);
         }
         invalidateOptionsMenu();
     }
@@ -359,49 +349,36 @@ VideoListCallback, IPlayerEventCallback {
             }
             lastIsChecked = isChecked;
 
-            if(isChecked){
+            if (isChecked) {
                 listFragment.setAllVideosChecked();
                 checkBox.setButtonDrawable(R.drawable.ic_checkbox_active);
             } else {
                 listFragment.unsetAllVideosChecked();
                 checkBox.setButtonDrawable(R.drawable.ic_checkbox_default);
-                //checkBox.setBackgroundResource(R.drawable.ic_checkbox_default);
             }
         }
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu)
-    {
+    public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
+        getMenuInflater().inflate(R.menu.video_list, menu);
         MenuItem checkBox_menuItem = menu.findItem(R.id.delete_checkbox);
         View checkBoxView = checkBox_menuItem.getActionView();
         checkBox = (CheckBox) checkBoxView.findViewById(R.id.select_checkbox);
 
-        if(checklistener==null) {
+        if (checklistener == null) {
             checklistener = new CourseVideoCheckBoxListener();
         }
 
-        if(myVideosFlag){
-            if(AppConstants.myVideosDeleteMode) {
-                checkBox_menuItem.setVisible(true);
-                checkBox.setVisibility(View.VISIBLE);
-                checkBox.setOnCheckedChangeListener(checklistener);
-            }else{
-                checkBox_menuItem.setVisible(false);
-                checkBox.setVisibility(View.GONE);
-                checkBox.setOnCheckedChangeListener(null);
-            }
-        }else{
-            if(AppConstants.videoListDeleteMode){
-                checkBox_menuItem.setVisible(true);
-                checkBox.setVisibility(View.VISIBLE);
-                checkBox.setOnCheckedChangeListener(checklistener);
-            }else{
-                checkBox_menuItem.setVisible(false);
-                checkBox.setVisibility(View.GONE);
-                checkBox.setOnCheckedChangeListener(null);
-            }
+        if (AppConstants.myVideosDeleteMode) {
+            checkBox_menuItem.setVisible(true);
+            checkBox.setVisibility(View.VISIBLE);
+            checkBox.setOnCheckedChangeListener(checklistener);
+        } else {
+            checkBox_menuItem.setVisible(false);
+            checkBox.setVisibility(View.GONE);
+            checkBox.setOnCheckedChangeListener(null);
         }
         return true;
     }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/ChapterAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/ChapterAdapter.java
@@ -14,7 +14,7 @@ import org.edx.mobile.R;
 import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.model.api.SectionEntry;
 import org.edx.mobile.module.db.DataCallback;
-import org.edx.mobile.util.AppConstants;
+import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.view.custom.ProgressWheel;
 
 public abstract class ChapterAdapter extends BaseListAdapter<SectionEntry> {
@@ -78,7 +78,8 @@ public abstract class ChapterAdapter extends BaseListAdapter<SectionEntry> {
             }
         }
 
-        if (AppConstants.offline_flag) {
+        final Context context = getContext();
+        if (!NetworkUtil.isConnected(context)) {
             holder.progresslayout.setVisibility(View.INVISIBLE);
             holder.no_of_videos.setVisibility(View.GONE);
             holder.bulk_download_videos.setVisibility(View.GONE);
@@ -90,21 +91,21 @@ public abstract class ChapterAdapter extends BaseListAdapter<SectionEntry> {
             {
                 holder.next_arrow.setBackgroundResource(R.drawable.ic_next_default_mirrored);
                 holder.chapterLayout.setBackgroundResource(R.drawable.list_selector);
-                holder.chapterName.setTextColor(getContext().getResources()
+                holder.chapterName.setTextColor(context.getResources()
                         .getColor(R.color.grey_text_mycourse));
             }else{
                 holder.next_arrow
                 .setBackgroundResource(R.drawable.ic_next_deactive_mirrored);
                 holder.chapterLayout
                         .setBackgroundResource(R.color.disabled_chapter_list);
-                holder.chapterName.setTextColor(getContext().getResources()
+                holder.chapterName.setTextColor(context.getResources()
                         .getColor(R.color.light_gray));
             }
 
         } else {
             holder.chapterLayout.setBackgroundResource(R.drawable.list_selector);
             holder.next_arrow.setVisibility(View.GONE);
-            holder.chapterName.setTextColor(getContext().getResources().getColor(
+            holder.chapterName.setTextColor(context.getResources().getColor(
                     R.color.grey_text_mycourse));
         }
     }

--- a/VideoLocker/src/test/java/org/edx/mobile/view/BaseFragmentActivityTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/BaseFragmentActivityTest.java
@@ -31,10 +31,7 @@ import android.widget.TextView;
 import org.edx.mobile.R;
 import org.edx.mobile.base.BaseFragmentActivity;
 import org.edx.mobile.event.FlyingMessageEvent;
-import org.edx.mobile.model.db.DownloadEntry;
-import org.edx.mobile.module.db.IDatabase;
 import org.edx.mobile.module.prefs.PrefManager;
-import org.edx.mobile.util.AppConstants;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.view.dialog.WebViewDialogFragment;
 import org.junit.Test;
@@ -44,7 +41,6 @@ import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowActivity;
 import org.robolectric.shadows.ShadowApplication;
-import org.robolectric.shadows.ShadowView;
 import org.robolectric.shadows.ShadowWebView;
 import org.robolectric.util.ActivityController;
 import org.robolectric.util.Scheduler;
@@ -58,7 +54,7 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 
 // TODO: Test network connectivity change events too, after we manage to mock them
-public class BaseFragmentActivityTest extends UiTest {
+public abstract class BaseFragmentActivityTest extends UiTest {
     /**
      * Method for defining the subclass of {@link BaseFragmentActivity} that
      * is being tested. Should be overridden by subclasses.
@@ -87,15 +83,6 @@ public class BaseFragmentActivityTest extends UiTest {
      */
     protected boolean hasDrawer() {
         return false;
-    }
-
-    /**
-     * Method for defining whether the onTick() method is called periodically
-     *
-     * @return true if onTick() is called
-     */
-    protected boolean runsOnTick() {
-        return true;
     }
 
     /**
@@ -281,16 +268,8 @@ public class BaseFragmentActivityTest extends UiTest {
         Menu menu = Shadows.shadowOf(activity).getOptionsMenu();
         assertNotNull(menu);
         MenuItem offlineItem = menu.findItem(R.id.offline);
+        assertNotNull(offlineItem);
         assertThat(offlineItem).hasTitle(activity.getText(R.string.offline_text));
-        // Can't see any method to confirm action layout source as well
-        MenuItem progressItem = menu.findItem(R.id.progress_download);
-        assertThat(progressItem).hasTitle(activity.getText(R.string.action_settings));
-        MenuItem deleteItem = menu.findItem(R.id.delete_checkbox);
-        assertThat(deleteItem).hasTitle(activity.getText(R.string.label_delete));
-        MenuItem doneItem = menu.findItem(R.id.done_btn);
-        assertThat(doneItem).hasTitle(activity.getText(R.string.done_text));
-        MenuItem unreadDisplayItem = menu.findItem(R.id.unread_display);
-        assertThat(unreadDisplayItem).hasTitle(activity.getText(R.string.unread_text));
     }
 
     /**
@@ -497,68 +476,6 @@ public class BaseFragmentActivityTest extends UiTest {
                 currentActivity, nextActivityClass);
         assertEquals(requestCode, intentForResult.requestCode);
         return intentForResult.intent;
-    }
-
-    /**
-     * Testing download progress menu visibility states and click behaviour
-     * (starting DownloadActivity). Only when both AppConstants.offline_flag
-     * is true and there is a downloading entry in the database, should the
-     * progress bar be visible.
-     */
-    @Test
-    public void downloadProgressViewTest() {
-        assumeTrue(runsOnTick());
-
-        AppConstants.offline_flag = false;
-        assertFalse(Shadows.shadowOf(Robolectric.buildActivity(getActivityClass())
-                        .withIntent(getIntent()).setup().get())
-                .getOptionsMenu()
-                .findItem(R.id.progress_download)
-                .isVisible());
-
-        AppConstants.offline_flag = true;
-        assertFalse(Shadows.shadowOf(Robolectric.buildActivity(getActivityClass())
-                        .withIntent(getIntent()).setup().get())
-                .getOptionsMenu()
-                .findItem(R.id.progress_download)
-                .isVisible());
-
-        IDatabase db = environment.getDatabase();
-        DownloadEntry de = new DownloadEntry();
-        de.username = "unittest";
-        de.title = "title";
-        de.videoId = "videoId-" + System.currentTimeMillis();
-        de.size = 1024;
-        de.duration = 3600;
-        de.filepath = "/fakepath";
-        de.url = "http://fake/url";
-        de.eid = "fake_eid";
-        de.chapter = "fake_chapter";
-        de.section = "fake_section";
-        de.lastPlayedOffset = 0;
-        de.lmsUrl = "http://fake/lms/url";
-        de.isCourseActive = 1;
-        de.downloaded = DownloadEntry.DownloadedState.DOWNLOADING;
-        Long rowId = db.addVideoData(de, null);
-        assertNotNull(rowId);
-        assertThat(rowId).isGreaterThan(0);
-        assertFalse(Shadows.shadowOf(Robolectric.buildActivity(getActivityClass())
-                        .withIntent(getIntent()).setup().get())
-                .getOptionsMenu()
-                .findItem(R.id.progress_download)
-                .isVisible());
-
-        AppConstants.offline_flag = false;
-        BaseFragmentActivity activity =
-                Robolectric.buildActivity(getActivityClass())
-                        .withIntent(getIntent()).setup().get();
-        ShadowActivity shadowActivity = Shadows.shadowOf(activity);
-        assertTrue(shadowActivity
-                .getOptionsMenu()
-                .findItem(R.id.progress_download)
-                .isVisible());
-        assertTrue(shadowActivity.clickMenuItem(R.id.progress_download));
-        assertNextStartedActivity(activity, DownloadListActivity.class);
     }
 
     /**

--- a/VideoLocker/src/test/java/org/edx/mobile/view/BaseVideosDownloadStateActivityTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/BaseVideosDownloadStateActivityTest.java
@@ -1,0 +1,112 @@
+package org.edx.mobile.view;
+
+import android.view.Menu;
+import android.view.MenuItem;
+
+import org.edx.mobile.R;
+import org.edx.mobile.base.BaseVideosDownloadStateActivity;
+import org.edx.mobile.model.db.DownloadEntry;
+import org.edx.mobile.module.db.IDatabase;
+import org.edx.mobile.util.AppConstants;
+import org.junit.Test;
+import org.robolectric.Robolectric;
+import org.robolectric.Shadows;
+import org.robolectric.shadows.ShadowActivity;
+
+import static org.assertj.android.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public abstract class BaseVideosDownloadStateActivityTest extends BaseFragmentActivityTest {
+    /**
+     * Method for defining the subclass of {@link BaseVideosDownloadStateActivity}
+     * that is being tested. Should be overridden by subclasses.
+     *
+     * @return The {@link BaseVideosDownloadStateActivity} subclass that is being
+     *         tested
+     */
+    @Override
+    protected Class<? extends BaseVideosDownloadStateActivity> getActivityClass() {
+        return BaseVideosDownloadStateActivity.class;
+    }
+
+    /**
+     * Testing options menu initialization
+     */
+    @Test
+    @Override
+    public void initializeOptionsMenuTest() {
+        super.initializeOptionsMenuTest();
+        BaseVideosDownloadStateActivity activity =
+                Robolectric.buildActivity(getActivityClass())
+                        .withIntent(getIntent()).setup().get();
+        Menu menu = Shadows.shadowOf(activity).getOptionsMenu();
+        assertNotNull(menu);
+        // Can't see any method to confirm action layout source as well
+        MenuItem progressItem = menu.findItem(R.id.download_progress);
+        assertNotNull(progressItem);
+        assertThat(progressItem).hasTitle(activity.getText(R.string.action_settings));
+    }
+
+    /**
+     * Testing download progress menu visibility states and click behaviour
+     * (starting DownloadActivity). Only when both AppConstants.offline_flag
+     * is true and there is a downloading entry in the database, should the
+     * progress bar be visible.
+     */
+    @Test
+    public void downloadProgressViewTest() {
+        AppConstants.offline_flag = false;
+        assertFalse(Shadows.shadowOf(Robolectric.buildActivity(getActivityClass())
+                .withIntent(getIntent()).setup().get())
+                .getOptionsMenu()
+                .findItem(R.id.download_progress)
+                .isVisible());
+
+        AppConstants.offline_flag = true;
+        assertFalse(Shadows.shadowOf(Robolectric.buildActivity(getActivityClass())
+                .withIntent(getIntent()).setup().get())
+                .getOptionsMenu()
+                .findItem(R.id.download_progress)
+                .isVisible());
+
+        IDatabase db = environment.getDatabase();
+        DownloadEntry de = new DownloadEntry();
+        de.username = "unittest";
+        de.title = "title";
+        de.videoId = "videoId-" + System.currentTimeMillis();
+        de.size = 1024;
+        de.duration = 3600;
+        de.filepath = "/fakepath";
+        de.url = "http://fake/url";
+        de.eid = "fake_eid";
+        de.chapter = "fake_chapter";
+        de.section = "fake_section";
+        de.lastPlayedOffset = 0;
+        de.lmsUrl = "http://fake/lms/url";
+        de.isCourseActive = 1;
+        de.downloaded = DownloadEntry.DownloadedState.DOWNLOADING;
+        Long rowId = db.addVideoData(de, null);
+        assertNotNull(rowId);
+        assertThat(rowId).isGreaterThan(0);
+        assertFalse(Shadows.shadowOf(Robolectric.buildActivity(getActivityClass())
+                .withIntent(getIntent()).setup().get())
+                .getOptionsMenu()
+                .findItem(R.id.download_progress)
+                .isVisible());
+
+        AppConstants.offline_flag = false;
+        BaseVideosDownloadStateActivity activity =
+                Robolectric.buildActivity(getActivityClass())
+                        .withIntent(getIntent()).setup().get();
+        ShadowActivity shadowActivity = Shadows.shadowOf(activity);
+        MenuItem downloadProgressMenuItem = shadowActivity
+                .getOptionsMenu()
+                .findItem(R.id.download_progress);
+        assertTrue(downloadProgressMenuItem.isVisible());
+        assertTrue(downloadProgressMenuItem.getActionView().performClick());
+        assertNextStartedActivity(activity, DownloadListActivity.class);
+    }
+}

--- a/VideoLocker/src/test/java/org/edx/mobile/view/BaseVideosDownloadStateActivityTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/BaseVideosDownloadStateActivityTest.java
@@ -58,14 +58,14 @@ public abstract class BaseVideosDownloadStateActivityTest extends BaseFragmentAc
      */
     @Test
     public void downloadProgressViewTest() {
-        AppConstants.offline_flag = false;
+        connectToNetwork();
         assertFalse(Shadows.shadowOf(Robolectric.buildActivity(getActivityClass())
                 .withIntent(getIntent()).setup().get())
                 .getOptionsMenu()
                 .findItem(R.id.download_progress)
                 .isVisible());
 
-        AppConstants.offline_flag = true;
+        disconnectFromNetwork();
         assertFalse(Shadows.shadowOf(Robolectric.buildActivity(getActivityClass())
                 .withIntent(getIntent()).setup().get())
                 .getOptionsMenu()
@@ -97,7 +97,7 @@ public abstract class BaseVideosDownloadStateActivityTest extends BaseFragmentAc
                 .findItem(R.id.download_progress)
                 .isVisible());
 
-        AppConstants.offline_flag = false;
+        connectToNetwork();
         BaseVideosDownloadStateActivity activity =
                 Robolectric.buildActivity(getActivityClass())
                         .withIntent(getIntent()).setup().get();

--- a/VideoLocker/src/test/java/org/edx/mobile/view/CourseBaseActivityTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/CourseBaseActivityTest.java
@@ -15,7 +15,6 @@ import org.edx.mobile.http.OkHttpUtil;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.model.course.CourseComponent;
 import org.edx.mobile.third_party.iconify.IconDrawable;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.Parameterized.Parameter;
 import org.robolectric.Robolectric;
@@ -161,17 +160,4 @@ public abstract class CourseBaseActivityTest extends BaseFragmentActivityTest {
             assertThat(shareOnWebIcon).isInstanceOf(IconDrawable.class);
         }
     }
-
-    /**
-     * Ignoring download progress menu visibility states testing defined in
-     * {@link BaseFragmentActivityTest}, as since {@link CourseBaseActivity}
-     * overrides the {@link android.app.Activity#onPrepareOptionsMenu(Menu)}
-     * implementation, there is no longer any testable point where onTick() is
-     * called. The correct implementation for it is only provided in the
-     * @{link CourseVideoListActivity} subclass anyway.
-     */
-    @Override
-    @Ignore
-    @Test
-    public void downloadProgressViewTest() {}
 }

--- a/VideoLocker/src/test/java/org/edx/mobile/view/CourseDashboardActivityTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/CourseDashboardActivityTest.java
@@ -20,7 +20,7 @@ import static org.assertj.android.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 
-public class CourseDashboardActivityTest extends BaseFragmentActivityTest {
+public class CourseDashboardActivityTest extends BaseVideosDownloadStateActivityTest {
     /**
      * Method for defining the subclass of {@link CourseDashboardActivity} that
      * is being tested. Should be overridden by subclasses.

--- a/VideoLocker/src/test/java/org/edx/mobile/view/NetworkSubjectTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/NetworkSubjectTest.java
@@ -21,7 +21,7 @@ public class NetworkSubjectTest {
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                { new BaseFragmentActivity() }
+                { new BaseFragmentActivity() {} }
         });
     }
 

--- a/VideoLocker/src/test/java/org/edx/mobile/view/UiTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/UiTest.java
@@ -1,11 +1,19 @@
 package org.edx.mobile.view;
 
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
 import com.google.inject.Injector;
 
 import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.test.http.HttpBaseTestCase;
 import org.junit.Before;
 import org.junit.Ignore;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.Shadows;
+import org.robolectric.shadows.ShadowConnectivityManager;
+import org.robolectric.shadows.ShadowNetworkInfo;
 
 /**
  * Base class for all UI test suites.
@@ -20,12 +28,36 @@ public class UiTest extends HttpBaseTestCase {
         environment = injector.getInstance(IEdxEnvironment.class);
     }
 
-    /**
-     * Ensure login before tests.
-     */
+    // Ensure login before tests.
     @Before
     @Override
     public void login() throws Exception {
         super.login();
+    }
+
+    // Ensure that the state is set to report network connectivity during tests, so that the
+    // UI is set up in the default state without the offline indicators. Any actual downloads
+    // will be performed over the local mock web server,
+    @Before
+    public void connectToNetwork() {
+        ShadowConnectivityManager shadowConnectivityManager = Shadows.shadowOf(
+                (ConnectivityManager) RuntimeEnvironment.application
+                        .getSystemService(Context.CONNECTIVITY_SERVICE));
+        shadowConnectivityManager.setNetworkInfo(ConnectivityManager.TYPE_MOBILE,
+                ShadowNetworkInfo.newInstance(NetworkInfo.DetailedState.CONNECTED,
+                        ConnectivityManager.TYPE_MOBILE, ConnectivityManager.TYPE_MOBILE_MMS,
+                        true, false));
+        // Set the default network to WiFi, as downloads are always allowed over
+        // WiFi regardless of the configuration settings.
+        shadowConnectivityManager.setActiveNetworkInfo(
+                ShadowNetworkInfo.newInstance(NetworkInfo.DetailedState.DISCONNECTED,
+                        ConnectivityManager.TYPE_WIFI, 0, true, true));
+    }
+
+    public void disconnectFromNetwork() {
+        ShadowConnectivityManager shadowConnectivityManager = Shadows.shadowOf(
+                (ConnectivityManager) RuntimeEnvironment.application
+                        .getSystemService(Context.CONNECTIVITY_SERVICE));
+        shadowConnectivityManager.setActiveNetworkInfo(null);
     }
 }


### PR DESCRIPTION
All the various menu items were being defined in `BaseFragmentActivity`, and set invisible by default unless needed by some particular child. This commit unbundles the menus to their appropriate activities, and in the process restricts the download progress wheel menu item to it's appropriate scope. `BaseTabActivity` has been deleted because it caused inconvenience for the new inheritance scheme, and because it was an unneeded abstraction layer that didn't provide much benefit. The test suite hierarchy has been updated to reflect these changes. The base classes are also defined as abstract now.

Previously, the offline menu item display handling was left to each subclass implementation of `BaseFragmentActivity`. This repetitive logic has now been moved inside the base class. It also fixes an issue with the state not being updated on `Activity` resumption, by having `NetworkConnectivityReceiver` post sticky events. Also, the unsafe global static flag for indicating offline state is now removed, and references are replaced with queries to the `NetworkUtil#isConnected()` utility method.  The test suites are also updated to reflect this.

https://openedx.atlassian.net/browse/MA-1665