### PR TITLE
Remove erroneous tinting of disabled camera icon

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
@@ -3,6 +3,7 @@ package org.edx.mobile.view;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Color;
 import android.graphics.Rect;
 import android.net.Uri;
 import android.os.Bundle;
@@ -30,7 +31,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
-
 import com.joanzapata.iconify.IconDrawable;
 import com.joanzapata.iconify.fonts.FontAwesomeIcons;
 import com.joanzapata.iconify.internal.Animation;
@@ -142,11 +142,11 @@ public class EditUserProfileFragment extends RoboFragment {
         viewHolder = new ViewHolder(view);
         viewHolder.profileImageProgress.setVisibility(View.GONE);
         viewHolder.username.setText(username);
-        TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(viewHolder.changePhoto,
-                new IconDrawable(getActivity(), FontAwesomeIcons.fa_camera)
-                        .colorRes(getActivity(), R.color.disableable_button_text)
-                        .sizeRes(getActivity(), R.dimen.fa_x_small)
-                , null, null, null);
+        final IconDrawable icon = new IconDrawable(getActivity(), FontAwesomeIcons.fa_camera)
+                .colorRes(getActivity(), R.color.disableable_button_text)
+                .sizeRes(getActivity(), R.dimen.fa_x_small);
+        icon.setTint(Color.WHITE);
+        TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(viewHolder.changePhoto, icon, null, null, null);
         viewHolder.changePhoto.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {


### PR DESCRIPTION
`IconDrawable` makes disabled icons half-transparent by default. I think that's silly but I don't know the story behind it. For now, I'm disabling that feature for this one place where I definitely don't want it.

Before
![screen shot 2015-12-02 at 4 14 09 pm](https://cloud.githubusercontent.com/assets/1685613/11544423/bd767a76-990f-11e5-91f2-4755142605d4.png)

After
![screen shot 2015-12-02 at 4 13 41 pm](https://cloud.githubusercontent.com/assets/1685613/11544407/a9cd0f62-990f-11e5-8766-7478f2230530.png)
