### PR TITLE
Add menu icons in courseware "no videos" message

### DIFF
--- a/VideoLocker/res/layout/activity_course_list.xml
+++ b/VideoLocker/res/layout/activity_course_list.xml
@@ -18,16 +18,8 @@
 
             <org.edx.mobile.view.custom.ETextView
                 android:id="@+id/no_course_tv"
-                style="@style/bold_text"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_centerInParent="true"
-                android:gravity="center"
-                android:padding="10dp"
-                android:text="@string/no_courses_to_display"
-                android:textColor="@color/empty_list_text"
-                android:textSize="20sp"
-                android:visibility="gone" />
+                style="@style/empty_content_text"
+                android:text="@string/no_courses_to_display" />
 
             <ProgressBar
                 android:id="@+id/api_spinner"

--- a/VideoLocker/res/layout/fragment_announcement.xml
+++ b/VideoLocker/res/layout/fragment_announcement.xml
@@ -19,15 +19,7 @@
      
      <org.edx.mobile.view.custom.ETextView
         android:id="@+id/no_announcement_tv"
-        style="@style/bold_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:text="@string/no_announcements_to_display"
-        android:padding="20dp"
-        android:layout_centerInParent="true"
-        android:visibility="gone"
-        android:textColor="@color/empty_list_text"
-        android:textSize="20sp" />
+        style="@style/empty_content_text"
+        android:text="@string/no_announcements_to_display" />
     
 </RelativeLayout>

--- a/VideoLocker/res/layout/fragment_course_combined_info.xml
+++ b/VideoLocker/res/layout/fragment_course_combined_info.xml
@@ -204,17 +204,8 @@
 
             <org.edx.mobile.view.custom.ETextView
                 android:id="@+id/no_announcement_tv"
-                style="@style/bold_text"
-                android:layout_marginTop="120dp"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:text="@string/no_announcements_to_display"
-                android:padding="20dp"
-                android:layout_centerInParent="true"
-                android:textColor="@color/empty_list_text"
-                android:textSize="20sp"
-                android:visibility="gone" />
+                style="@style/empty_content_text"
+                android:text="@string/no_announcements_to_display" />
 
         </RelativeLayout>
 

--- a/VideoLocker/res/layout/fragment_course_info.xml
+++ b/VideoLocker/res/layout/fragment_course_info.xml
@@ -19,16 +19,8 @@
       
       <org.edx.mobile.view.custom.ETextView
         android:id="@+id/no_courseinfo_tv"
-        style="@style/bold_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:text="@string/no_information_to_display"
-        android:padding="15dp"
-        android:visibility="gone"
-        android:layout_centerInParent="true"
-        android:textColor="@color/empty_list_text"
-        android:textSize="20sp" />
+        style="@style/empty_content_text"
+        android:text="@string/no_information_to_display" />
     
 
 </RelativeLayout>

--- a/VideoLocker/res/layout/fragment_course_outline.xml
+++ b/VideoLocker/res/layout/fragment_course_outline.xml
@@ -15,7 +15,7 @@
         android:dividerHeight="0dp"
         android:listSelector="@drawable/course_list_item_selector" />
 
-    <org.edx.mobile.view.custom.ETextView
+    <org.edx.mobile.view.custom.EIconTextView
         android:id="@+id/no_chapter_tv"
         style="@style/empty_content_text"
         android:text="@string/no_chapter_text" />

--- a/VideoLocker/res/layout/fragment_course_outline.xml
+++ b/VideoLocker/res/layout/fragment_course_outline.xml
@@ -17,14 +17,6 @@
 
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/no_chapter_tv"
-        style="@style/bold_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:gravity="center"
-        android:padding="10dp"
-        android:text="@string/no_chapter_text"
-        android:textColor="@color/empty_list_text"
-        android:textSize="20sp"
-        android:visibility="gone" />
+        style="@style/empty_content_text"
+        android:text="@string/no_chapter_text" />
 </RelativeLayout>

--- a/VideoLocker/res/layout/fragment_handout.xml
+++ b/VideoLocker/res/layout/fragment_handout.xml
@@ -24,15 +24,7 @@
 
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/no_coursehandout_tv"
-        style="@style/bold_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:padding="15dp"
-        android:text="@string/no_handouts_to_display"
-        android:visibility="gone"
-        android:layout_centerInParent="true"
-        android:textColor="@color/empty_list_text"
-        android:textSize="20sp" />
+        style="@style/empty_content_text"
+        android:text="@string/no_handouts_to_display" />
 
 </RelativeLayout>

--- a/VideoLocker/res/layout/fragment_my_all_videos.xml
+++ b/VideoLocker/res/layout/fragment_my_all_videos.xml
@@ -29,13 +29,7 @@
 
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/empty_list_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:gravity="center"
         android:text="@string/no_videos_to_display"
-        android:visibility="gone"
-        style="@style/empty_content_text"
-        android:layout_margin="20dp" />
+        style="@style/empty_content_text" />
 
 </RelativeLayout>

--- a/VideoLocker/res/layout/fragment_my_course_list_tab.xml
+++ b/VideoLocker/res/layout/fragment_my_course_list_tab.xml
@@ -11,16 +11,8 @@
 
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/no_course_tv"
-        style="@style/bold_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:gravity="center"
-        android:padding="10dp"
-        android:text="@string/no_courses_to_display"
-        android:textColor="@color/empty_list_text"
-        android:textSize="20sp"
-        android:visibility="gone" />
+        style="@style/empty_content_text"
+        android:text="@string/no_courses_to_display" />
 
     <android.support.v4.widget.SwipeRefreshLayout
         android:id="@+id/swipe_container"

--- a/VideoLocker/res/layout/fragment_user_profile.xml
+++ b/VideoLocker/res/layout/fragment_user_profile.xml
@@ -136,13 +136,7 @@
 
                 <org.edx.mobile.view.custom.ETextView
                     style="@style/empty_content_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:layout_marginBottom="@dimen/edx_margin"
-                    android:layout_marginLeft="@dimen/edx_margin"
-                    android:layout_marginRight="@dimen/edx_margin"
-                    android:gravity="center"
+                    android:visibility="visible"
                     android:text="@string/profile_consent_needed_explanation" />
 
                 <Button

--- a/VideoLocker/res/layout/fragment_video_list.xml
+++ b/VideoLocker/res/layout/fragment_video_list.xml
@@ -8,13 +8,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/empty_list_view"
         style="@style/empty_content_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:gravity="center"
-        android:text="@string/no_videos_to_display"
-        android:visibility="gone"
-        android:layout_margin="20dp" />
+        android:text="@string/no_videos_to_display" />
 
     <LinearLayout
         android:id="@+id/bottom_panel"

--- a/VideoLocker/res/layout/fragment_video_list_with_player_container.xml
+++ b/VideoLocker/res/layout/fragment_video_list_with_player_container.xml
@@ -8,13 +8,7 @@
     <org.edx.mobile.view.custom.ETextView
         android:id="@+id/empty_list_view"
         style="@style/empty_content_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:gravity="center"
-        android:text="@string/no_videos_to_display"
-        android:visibility="gone"
-        android:padding="15dp" />
+        android:text="@string/no_videos_to_display" />
 
     <LinearLayout
         android:id="@+id/top_panel"

--- a/VideoLocker/res/values/colors.xml
+++ b/VideoLocker/res/values/colors.xml
@@ -91,7 +91,6 @@
     <color name="red_download_failed_text">#fd7575</color>
     <color name="tab_bg">#3E4247</color>
     <color name="delete_panel_bg">#3E4247</color>
-    <color name="empty_list_text">#c8c8c8</color>
     <color name="switch_default_button_color">#C3C3C3</color>
     <color name="switch_default_bg_color">#3C4045</color>
     <color name="switch_disabled_bg_color_off">@color/grey_4</color>

--- a/VideoLocker/res/values/dimens.xml
+++ b/VideoLocker/res/values/dimens.xml
@@ -134,6 +134,7 @@
     <dimen name="button_horizontal_padding">22dp</dimen>
     <dimen name="x_small_icon_margin">5dp</dimen>
     <dimen name="base_icon_margin">7dp</dimen>
+    <dimen name="empty_list_text_max_width">240dp</dimen>
 
     <!--edX typography-->
     <dimen name="edx_xxxx_large">38sp</dimen>

--- a/VideoLocker/res/values/dimens.xml
+++ b/VideoLocker/res/values/dimens.xml
@@ -135,6 +135,7 @@
     <dimen name="x_small_icon_margin">5dp</dimen>
     <dimen name="base_icon_margin">7dp</dimen>
     <dimen name="empty_list_text_max_width">240dp</dimen>
+    <dimen name="empty_list_icon_size">80dp</dimen>
 
     <!--edX typography-->
     <dimen name="edx_xxxx_large">38sp</dimen>

--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -384,7 +384,7 @@
     <!-- Label for mode switch menu item-->
     <string name="assessment_full_course">Full Course</string>
     <!-- Label for empty video in video only mode-->
-    <string name="assessment_empty_video_info">There are no videos in this section. To view other section content, select the Video icon above and switch to full course mode.</string>
+    <string name="assessment_empty_video_info">There are no videos in this section. To view other section content, select {mode_switcher} above and switch to full course mode.</string>
    <!-- Label showing assessment only available on website-->
     <string name="assessment_not_available">This interactive component isn’t yet available on mobile.</string>
     <!-- Label showing assessment only available on website-->

--- a/VideoLocker/res/values/styles.xml
+++ b/VideoLocker/res/values/styles.xml
@@ -290,11 +290,6 @@
         <item name="android:background">@drawable/white_circle</item>
     </style>
 
-    <style name="empty_content_text" parent="bold_text">
-        <item name="android:textColor">@color/empty_list_text</item>
-        <item name="android:textSize">@dimen/edx_x_large</item>
-    </style>
-
     <!-- Styles from the edX style guide will be nested under "edX" -->
     <style name="edX" />
 

--- a/VideoLocker/res/values/text_styles.xml
+++ b/VideoLocker/res/values/text_styles.xml
@@ -111,6 +111,20 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_width">match_parent</item>
     </style>
+
+    <style name="empty_content_text" parent="bold_text">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_margin">@dimen/edx_margin</item>
+        <item name="android:layout_gravity">center</item>
+        <item name="android:layout_centerInParent">true</item>
+        <item name="android:maxWidth">@dimen/empty_list_text_max_width</item>
+        <item name="android:drawablePadding">@dimen/edx_margin</item>
+        <item name="android:gravity">center</item>
+        <item name="android:textColor">@color/edx_grayscale_neutral_dark</item>
+        <item name="android:textSize">@dimen/edx_small</item>
+        <item name="android:visibility">gone</item>
+    </style>
     
     <style name="bold_grey_text" parent="@style/bold_text">
         <item name="android:textColor">@color/grey_text_mycourse</item>
@@ -210,7 +224,7 @@
         <item name="android:text">@string/find_courses_offline_text</item>
         <item name="android:padding">10dp</item>
         <item name="android:layout_centerInParent">true</item>
-        <item name="android:textColor">@color/empty_list_text</item>
+        <item name="android:textColor">@color/edx_grayscale_neutral_dark</item>
         <item name="android:visibility">gone</item>
     </style>
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
@@ -224,12 +224,12 @@ public abstract  class CourseBaseActivity  extends BaseFragmentActivity implemen
                     fullCourseItem.setChecked(true);
                 }
                 popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
-                    public boolean onMenuItemClick(MenuItem item) {
+                    public boolean onMenuItemClick(MenuItem popupMenuItem) {
                         boolean currentVideoMode = userPrefManager.isUserPrefVideoModel();
-                        boolean selectedVideoMode = videoOnlyItem == item;
+                        boolean selectedVideoMode = videoOnlyItem == popupMenuItem;
                         if (currentVideoMode != selectedVideoMode) {
                             userPrefManager.setUserPrefVideoModel(selectedVideoMode);
-                            item.setChecked(true);
+                            popupMenuItem.setChecked(true);
                             Icon filterIcon = selectedVideoMode ?
                                     FontAwesomeIcons.fa_list : FontAwesomeIcons.fa_film;
                             item.setIcon(

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -1,7 +1,10 @@
 package org.edx.mobile.view;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -9,8 +12,11 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ListView;
+import android.widget.TextView;
 
 import com.google.inject.Inject;
+import com.joanzapata.iconify.IconDrawable;
+import com.joanzapata.iconify.fonts.FontAwesomeIcons;
 
 import org.edx.mobile.R;
 import org.edx.mobile.base.MyVideosBaseFragment;
@@ -24,9 +30,9 @@ import org.edx.mobile.model.db.DownloadEntry;
 import org.edx.mobile.services.CourseManager;
 import org.edx.mobile.services.VideoDownloadHelper;
 import org.edx.mobile.util.NetworkUtil;
+import org.edx.mobile.util.ResourceUtil;
 import org.edx.mobile.view.adapters.CourseOutlineAdapter;
 import org.edx.mobile.view.common.TaskProcessCallback;
-import org.edx.mobile.view.custom.ETextView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -126,13 +132,28 @@ public class CourseOutlineFragment extends MyVideosBaseFragment {
             view = getView();
         if ( view == null )
             return;
-        ETextView messageView = (ETextView) view.findViewById(R.id.no_chapter_tv);
+        TextView messageView = (TextView) view.findViewById(R.id.no_chapter_tv);
         if(adapter.getCount()==0){
             messageView.setVisibility(View.VISIBLE);
             if ( adapter.hasFilteredUnits() ){
-                messageView.setText(R.string.assessment_empty_video_info);
+                Context context = getActivity();
+                Drawable modeSwitcherDrawable =
+                        new IconDrawable(context, FontAwesomeIcons.fa_list)
+                        .colorRes(context, R.color.edx_grayscale_neutral_light)
+                        .sizeRes(context, R.dimen.empty_list_icon_size);
+                messageView.setCompoundDrawablesWithIntrinsicBounds(
+                        null, modeSwitcherDrawable, null, null);
+                Resources resources = getResources();
+                messageView.setText(ResourceUtil.getFormattedString(resources,
+                        R.string.assessment_empty_video_info, "mode_switcher",
+                        '{' + FontAwesomeIcons.fa_list.key() + " baseline}"));
+                messageView.setContentDescription(ResourceUtil.getFormattedString(resources,
+                        R.string.assessment_empty_video_info, "mode_switcher",
+                        getText(R.string.course_change_mode)));
             } else {
+                messageView.setCompoundDrawables(null, null, null, null);
                 messageView.setText(R.string.no_chapter_text);
+                messageView.setContentDescription(null);
             }
         }else{
             messageView.setVisibility(View.GONE);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/custom/EIconTextView.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/custom/EIconTextView.java
@@ -1,0 +1,41 @@
+package org.edx.mobile.view.custom;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Typeface;
+import android.util.AttributeSet;
+
+import com.joanzapata.iconify.widget.IconTextView;
+
+import org.edx.mobile.R;
+
+public class EIconTextView extends IconTextView {
+    public EIconTextView(Context context) {
+        super(context);
+    }
+
+    public EIconTextView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        processAttrs(context, attrs);
+    }
+
+    public EIconTextView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        processAttrs(context, attrs);
+    }
+
+    private void processAttrs(Context context, AttributeSet attrs) {
+        if (isInEditMode()) return;
+        TypedArray a = context.getTheme().obtainStyledAttributes(
+                attrs, R.styleable.custom_view, 0, 0);
+        // Check for the font attribute and setup font
+        String fontFileName = a.getString(R.styleable.custom_view_font);
+        a.recycle();
+        if (fontFileName == null) {
+            // If font is not defined, then set default font
+            fontFileName = "OpenSans-Regular.ttf";
+        }
+        Typeface font = FontFactory.getInstance().getFont(context, fontFileName);
+        setTypeface(font);
+    }
+}


### PR DESCRIPTION
All empty list error text layouts have been standardized in text styles to correspond to the iOS implementation. Additionally, the courseware "no videos" message has the mode switcher menu icon added at the top and in it's text according to [MA-962][]. Also fixed an issue with the menu icon not changing, that was pointed out in the comments here.

[MA-962]: https://openedx.atlassian.net/browse/MA-962