### PR TITLE
Fix freeze issue on RecentVideos screen

### DIFF
--- a/VideoLocker/res/layout-land/activity_myvideos_tab.xml
+++ b/VideoLocker/res/layout-land/activity_myvideos_tab.xml
@@ -1,0 +1,66 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:id="@+id/container_player"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="visible"
+        android:orientation="vertical" > 
+    </LinearLayout>
+
+    <android.support.v4.widget.DrawerLayout
+        android:id="@+id/drawer_layout"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:background="@color/grey_act_background" >
+
+        <TabHost
+            android:id="@android:id/tabhost"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" >
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" >
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical" >
+
+                    <View
+                        android:id="@+id/offline_bar"
+                        style="@style/offline_bar"
+                        android:visibility="gone" />
+
+                    <TabWidget
+                        android:id="@android:id/tabs"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="0"
+                        android:background="@color/tab_bg"
+                        android:orientation="horizontal" />
+
+                    <FrameLayout
+                        android:id="@android:id/tabcontent"
+                        android:layout_width="match_parent"
+                        android:layout_height="0dp"
+                        android:layout_weight="1" />
+                </LinearLayout>
+
+                <org.edx.mobile.view.custom.ETextView
+                    android:id="@+id/downloadMessage"
+                    style="@style/downloading_message"
+                    android:text="@string/started_downloading"
+                    android:visibility="gone" />
+            </RelativeLayout>
+        </TabHost>
+
+        <include layout="@layout/navigation_drawer_container" />
+
+    </android.support.v4.widget.DrawerLayout>
+
+</LinearLayout>

--- a/VideoLocker/src/main/java/org/edx/mobile/player/PlayerFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/PlayerFragment.java
@@ -226,7 +226,7 @@ public class PlayerFragment extends RoboFragment implements IPlayerListener, Ser
                 showVideoNotAvailable(VideoNotPlayMessageType.IS_VIDEO_MESSAGE_DISPLAYED);
             }
         } else {
-            player = new Player();
+            if (player == null) player = new Player();
         }
     }
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-1818

#432 deleted the file `layout-land/activity_myvideos_tab.xml` which caused this issue.
So, I've brought it back. Also, #449 removed the `null` check on `PlayerFragment`'s re-initialization (https://github.com/edx/edx-app-android/pull/449/files#diff-f06c48353458aca116f653c06a347fdeL207), which caused the video player to freeze after orientation change, so restored that check as well.

@bguertin @1zaman plz review