### PR TITLE
Document local Font Awesome asset

### DIFF
--- a/VideoLocker/build.gradle
+++ b/VideoLocker/build.gradle
@@ -79,6 +79,12 @@ apiKey=$fabric_key
 
 dependencies {
     compile project (':android-iconify')
+    // Note that we have the Font Awesome TTF file
+    // in the local assets as well, to enable the
+    // graphical layout editor to render it. Since
+    // that is what will be compiled in the APK now,
+    // we need to ensure that it's updated along
+    // with module updates.
     compile project (':android-iconify-fontawesome')
     compile ('com.getbase:floatingactionbutton:1.3.0') {
         exclude module: 'support-annotations'


### PR DESCRIPTION
The Font Awesome TTF file was included in the local assets of the VideoLocker module in #470, in order to enable the graphical layout editor to render it. This commit documents this in the dependency definition for the Font Awesome module for `android-iconify` in `build.gradle`, along with the need to have it kept in sync with module updates.