### PR TITLE
Set intrinsic bounds on compound IconDrawable

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionUtils.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionUtils.java
@@ -31,7 +31,7 @@ public abstract class DiscussionUtils {
         Context context = textView.getContext();
         if (isTopicClosed) {
             textView.setText(negativeTextResId);
-            TextViewCompat.setCompoundDrawablesRelative(textView,
+            TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(textView,
                     new IconDrawable(context, FontAwesomeIcons.fa_lock)
                             .sizeRes(context, R.dimen.icon_view_standard_width_height)
                             .colorRes(context, R.color.edx_grayscale_neutral_white_t),
@@ -40,8 +40,8 @@ public abstract class DiscussionUtils {
             creationLayout.setOnClickListener(null);
         } else {
             textView.setText(positiveTextResId);
-            TextViewCompat.setCompoundDrawablesRelative(textView,
-                    new IconDrawable(textView.getContext(), FontAwesomeIcons.fa_plus_circle)
+            TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(textView,
+                    new IconDrawable(context, FontAwesomeIcons.fa_plus_circle)
                             .sizeRes(context, R.dimen.icon_view_standard_width_height)
                             .colorRes(context, R.color.edx_grayscale_neutral_white_t),
                     null, null, null

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
@@ -90,7 +90,7 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
 
         createNewPostTextView.setText(R.string.discussion_post_create_new_post);
         Context context = getActivity();
-        TextViewCompat.setCompoundDrawablesRelative(createNewPostTextView,
+        TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(createNewPostTextView,
                 new IconDrawable(context, FontAwesomeIcons.fa_plus_circle)
                         .sizeRes(context, R.dimen.icon_view_standard_width_height)
                         .colorRes(context, R.color.edx_grayscale_neutral_white_t),


### PR DESCRIPTION
IconDrawable used to set it's own bounds according to it's intrinsic size. This incorrect behaviour was fixed in #407. This pull request modifies the existing `TextView` compound drawable implementations that had been relying on the bounds being preset, to explicitly set them according to the intrinsic size of the drawable.

https://openedx.atlassian.net/browse/MA-1730