### PR TITLE
Update request user agents

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/http/HttpManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/HttpManager.java
@@ -1,8 +1,10 @@
 package org.edx.mobile.http;
 
+import android.content.Context;
 import android.net.http.AndroidHttpClient;
 import android.os.Bundle;
 
+import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import org.apache.commons.io.IOUtils;
@@ -34,6 +36,8 @@ import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HTTP;
 import org.apache.http.protocol.HttpContext;
+import org.edx.mobile.BuildConfig;
+import org.edx.mobile.R;
 import org.edx.mobile.logger.Logger;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -49,6 +53,9 @@ import java.util.List;
 public class HttpManager {
     protected final Logger logger = new Logger(getClass().getName());
 
+    @Inject
+    Context context;
+
     /**
      * Executes a GET request to given URL with given parameters.
      * 
@@ -61,9 +68,7 @@ public class HttpManager {
      */
     public HttpResult get(String urlWithAppendedParams, Bundle headers)
             throws ParseException, ClientProtocolException, IOException {
-        DefaultHttpClient client = new DefaultHttpClient();
-        client.getParams().setParameter(CoreProtocolPNames.PROTOCOL_VERSION,
-                HttpVersion.HTTP_1_1);
+        final DefaultHttpClient client = newClient();
         
         HttpGet get = new HttpGet(urlWithAppendedParams);
         AndroidHttpClient.modifyRequestToAcceptGzipResponse(get);
@@ -111,9 +116,7 @@ public class HttpManager {
      */
     public String post(String url, Bundle params, Bundle headers)
             throws ParseException, ClientProtocolException, IOException {
-        HttpClient client = new DefaultHttpClient();
-        client.getParams().setParameter(CoreProtocolPNames.PROTOCOL_VERSION,
-                HttpVersion.HTTP_1_1);
+        final DefaultHttpClient client = newClient();
 
         HttpPost post = new HttpPost(url);
         AndroidHttpClient.modifyRequestToAcceptGzipResponse(post);
@@ -209,9 +212,7 @@ public class HttpManager {
      */
     public String post(String url, String postBody, Bundle headers, boolean isPatchRequest)
             throws ParseException, ClientProtocolException, IOException {
-        HttpClient client = new DefaultHttpClient();
-        client.getParams().setParameter(CoreProtocolPNames.PROTOCOL_VERSION,
-                HttpVersion.HTTP_1_1);
+        final DefaultHttpClient client = newClient();
 
         HttpPost post = null;
         if (isPatchRequest) {
@@ -307,9 +308,7 @@ public class HttpManager {
      */
     public org.apache.http.Header getResponseHeader(String url, Bundle headers)
             throws ParseException, ClientProtocolException, IOException {
-        HttpClient client = new DefaultHttpClient();
-        client.getParams().setParameter(CoreProtocolPNames.PROTOCOL_VERSION,
-                HttpVersion.HTTP_1_1);
+        final DefaultHttpClient client = newClient();
 
         HttpGet get = new HttpGet(url);
 
@@ -337,9 +336,7 @@ public class HttpManager {
 
     public List<HttpCookie> getCookies(String url, Bundle headers, boolean isGet)
         throws ParseException, ClientProtocolException, IOException {
-        HttpClient client = new DefaultHttpClient();
-        client.getParams().setParameter(CoreProtocolPNames.PROTOCOL_VERSION,
-            HttpVersion.HTTP_1_1);
+        final DefaultHttpClient client = newClient();
 
         CookieStore cookieStore = new BasicCookieStore();
         HttpContext localContext = new BasicHttpContext();
@@ -374,5 +371,17 @@ public class HttpManager {
     public static class HttpResult {
         public String body;
         public int statusCode;
+    }
+
+    private DefaultHttpClient newClient() {
+        DefaultHttpClient client = new DefaultHttpClient();
+        client.getParams().setParameter(CoreProtocolPNames.PROTOCOL_VERSION,
+                HttpVersion.HTTP_1_1);
+        client.getParams().setParameter(CoreProtocolPNames.USER_AGENT,
+                System.getProperty("http.agent") + " " +
+                        context.getString(R.string.app_name) + "/" +
+                        BuildConfig.APPLICATION_ID + "/" +
+                        BuildConfig.VERSION_NAME);
+        return client;
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/http/UserAgentInterceptor.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/UserAgentInterceptor.java
@@ -1,0 +1,25 @@
+package org.edx.mobile.http;
+
+import android.support.annotation.NonNull;
+
+import com.squareup.okhttp.Interceptor;
+import com.squareup.okhttp.Response;
+
+import java.io.IOException;
+
+public class UserAgentInterceptor implements Interceptor {
+
+    @NonNull
+    private final String userAgent;
+
+    public UserAgentInterceptor(@NonNull String userAgent) {
+        this.userAgent = userAgent;
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        return chain.proceed(chain.request().newBuilder()
+                .header("User-Agent", userAgent)
+                .build());
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/view/custom/EdxAssessmentWebView.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/custom/EdxAssessmentWebView.java
@@ -2,30 +2,10 @@ package org.edx.mobile.view.custom;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.webkit.WebSettings;
-import android.webkit.WebView;
 
-/**
- * Created by rohan on 3/12/15.
- */
-public class EdxAssessmentWebView extends WebView {
-
+public class EdxAssessmentWebView extends EdxWebView {
     public EdxAssessmentWebView(Context context, AttributeSet attrs) {
         super(context, attrs);
-
-        init(context);
+        getSettings().setSupportZoom(false);
     }
-
-    private void init(Context context) {
-        WebSettings settings = getSettings();
-        settings.setJavaScriptEnabled(true);
-        settings.setLoadWithOverviewMode(true);
-        settings.setBuiltInZoomControls(false);
-        settings.setDisplayZoomControls(false);
-        settings.setLoadWithOverviewMode(true);
-        settings.setSupportZoom(false);
-        settings.setLoadsImagesAutomatically(true);
-
-    }
-
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/custom/EdxWebView.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/custom/EdxWebView.java
@@ -1,27 +1,29 @@
 package org.edx.mobile.view.custom;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
-/**
- * Created by rohan on 3/12/15.
- */
-public class EdxWebView extends WebView {
+import org.edx.mobile.BuildConfig;
+import org.edx.mobile.R;
 
+public class EdxWebView extends WebView {
+    @SuppressLint("SetJavaScriptEnabled")
     public EdxWebView(Context context, AttributeSet attrs) {
         super(context, attrs);
-
-        init();
-    }
-
-    private void init() {
-        WebSettings settings = getSettings();
+        final WebSettings settings = getSettings();
         settings.setJavaScriptEnabled(true);
         settings.setLoadWithOverviewMode(true);
         settings.setBuiltInZoomControls(false);
         settings.setSupportZoom(true);
         settings.setLoadsImagesAutomatically(true);
+        settings.setUserAgentString(
+                settings.getUserAgentString() + " " +
+                        context.getString(R.string.app_name) + "/" +
+                        BuildConfig.APPLICATION_ID + "/" +
+                        BuildConfig.VERSION_NAME
+        );
     }
 }


### PR DESCRIPTION
Fixes https://openedx.atlassian.net/browse/MA-1833

Now user agent will always be set, and the app name/id/version will be appended.

WebView requests will have a user-agent like this:
`Mozilla/5.0 (Linux; Android 5.1; XT1053 Build/LPA23.12-15.5; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36 edX/org.edx.mobile/1.0.09`

API requests (OkHttp and Apache) will have a user-agent like this:
`Dalvik/2.1.0 (Linux; U; Android 5.1; XT1053 Build/LPA23.12-15.5) edX/org.edx.mobile/1.0.09`