### PR TITLE
Null check on video player orientation setting

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/player/PlayerFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/PlayerFragment.java
@@ -747,6 +747,11 @@ public class PlayerFragment extends RoboFragment implements IPlayerListener, Ser
     public void onPrepared() {
         // mark prepared and allow orientation
         isPrepared = true;
+
+        if (getActivity() == null) {
+            return;
+        }
+
         allowSensorOrientation();
 
         if (!isResumed() ||


### PR DESCRIPTION
Orientation setting logic was moved above the visibility check here https://github.com/edx/edx-app-android/pull/449#discussion_r46538847, which caused the `allowSensorOrientation` to be called with `getActivity` being null causing the Null Pointer and resultantly a crash.

https://openedx.atlassian.net/browse/MA-1852

@1zaman plz review again

**NOTE: Due to some rebasing havoc this PR https://github.com/edx/edx-app-android/pull/486 went useless**