### PR TITLE
Don't focus "about me" text initially

### DIFF
--- a/VideoLocker/res/layout/fragment_form_field_textarea.xml
+++ b/VideoLocker/res/layout/fragment_form_field_textarea.xml
@@ -4,7 +4,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="@dimen/edx_margin">
+    android:padding="@dimen/edx_margin"
+    android:focusableInTouchMode="true"
+    android:descendantFocusability="beforeDescendants">
 
     <EditText
         android:id="@+id/text"


### PR DESCRIPTION
Fixes https://openedx.atlassian.net/browse/MA-1588

Android activities automatically focus the first focusable view when launched. Normally, that means the EditText gets focused. By making the container focusable, it will be focused instead of the EditText.