### PR TITLE
MA-1719 Enroll or View Course in course discovery

### DIFF
--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -33,11 +33,20 @@
     <!-- Title of the course detail page-->
     <string name="course_detail_title">Course Detail</string>
     <!-- Enroll Now button text -->
-    <string name="course_detail_enroll_now_button">Enroll Now</string>
+    <string name="course_detail_enroll_now_button">Enroll now</string>
     <!-- About This Course title -->
-    <string name="about_this_course">About this Course</string>
-    <!-- Enroll Now text-->
-    <string name="enroll_now">Enroll Now</string>
+    <string name="about_this_course">About This Course</string>
+    <!-- Enroll Now button text-->
+    <string name="enroll_now_button_text">Enroll now</string>
+    <!-- View Course button text text-->
+    <string name="view_course_button_text">View course</string>
+    <!-- Floating overlay text shown to user when they succeed at enrolling in a course -->
+    <string name="you_are_now_enrolled">You are now enrolled in this course.</string>
+    <!-- Error shown user attempts to enroll in a course they are already enrolled in -->
+    <string name="already_enrolled">You are already enrolled in this course.</string>
+    <!-- Error message shown when dashboard cannot be shown from course detail view -->
+    <string name="cannot_show_dashboard">Unable to show dashboard.</string>
+
 
 
     <!-- Course Sharing -->
@@ -641,11 +650,7 @@
     <!-- Message shown when enrolling in a course fails-->
     <string name="enrollment_failure">We could not enroll you in this course at this time.</string>
     <!-- Alert dialog button allowing user to repeat their attempted action -->
-    <string name="try_again">Try Again</string>
-    <!-- Floating overlay text shown to user when they succeed at enrolling in a course -->
-    <string name="you_are_now_enrolled">You have enrolled in this course</string>
-    <!-- Error shown user attempts to enroll in a course they are already enrolled in -->
-    <string name="already_enrolled">You are already enrolled in this course</string>
+    <string name="try_again">Try again</string>
     <!-- Error shown when registering an account fails -->
     <string name="sign_up_error">Your account could not be created. Try again later.</string>
 

--- a/VideoLocker/res/values/styles.xml
+++ b/VideoLocker/res/values/styles.xml
@@ -333,7 +333,7 @@
         <item name="android:background">@drawable/edx_enroll_button</item>
         <item name="android:textSize">@dimen/edx_small</item>
         <item name="android:textStyle">bold</item>
-        <item name="android:text">@string/enroll_now</item>
+        <item name="android:text">@string/enroll_now_button_text</item>
     </style>
 
     <style name="edX.Widget.BorderedButton" parent="edX.Widget.Button">

--- a/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
@@ -171,32 +171,28 @@ public abstract class FindCoursesBaseActivity extends BaseFragmentActivity imple
         EnrollForCourseTask enrollForCourseTask = new EnrollForCourseTask(FindCoursesBaseActivity.this,
             courseId, emailOptIn) {
             @Override
-            public void onSuccess(Boolean result) {
+            public void onSuccess(Void result) {
                 isTaskInProgress = false;
-                if(result!=null && result) {
-                    logger.debug("Enrollment successful");
-                    //If the course is successfully enrolled, send a broadcast
-                    // to close the FindCoursesActivity
-                    Intent intent = new Intent();
-                    intent.putExtra("course_id", courseId);
-                    intent.setAction(ACTION_ENROLLED);
-                    sendBroadcast(intent);
+                logger.debug("Enrollment successful");
+                //If the course is successfully enrolled, send a broadcast
+                // to close the FindCoursesActivity
+                Intent intent = new Intent();
+                intent.putExtra("course_id", courseId);
+                intent.setAction(ACTION_ENROLLED);
+                sendBroadcast(intent);
 
-                    // show flying message about the success of Enroll
+                // show flying message about the success of Enroll
 
-                    EnrolledCoursesResponse course = environment.getServiceManager().getCourseById(courseId);
-                    String msg;
-                    if (course == null || course.getCourse() == null ) {
-                        // this means, you were not already enrolled to this course
-                        msg = String.format("%s", context.getString(R.string.you_are_now_enrolled));
-                    }else{
-                        // this means, you were already enrolled to this course
-                        msg = String.format("%s", context.getString(R.string.already_enrolled));
-                    }
-                    EventBus.getDefault().postSticky(new FlyingMessageEvent(msg));
+                EnrolledCoursesResponse course = environment.getServiceManager().getCourseById(courseId);
+                String msg;
+                if (course == null || course.getCourse() == null ) {
+                    // this means, you were not already enrolled to this course
+                    msg = String.format("%s", context.getString(R.string.you_are_now_enrolled));
                 }else{
-                    showEnrollErrorMessage(courseId, emailOptIn);
+                    // this means, you were already enrolled to this course
+                    msg = String.format("%s", context.getString(R.string.already_enrolled));
                 }
+                EventBus.getDefault().postSticky(new FlyingMessageEvent(msg));
             }
 
             @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/course/GetCourseDetailTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/course/GetCourseDetailTask.java
@@ -2,29 +2,27 @@ package org.edx.mobile.course;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
 import com.google.inject.Inject;
 
 import org.edx.mobile.task.Task;
 
-public abstract class GetCourseDetailTask extends
-        Task<CourseDetail> {
+public abstract class GetCourseDetailTask extends Task<CourseDetail> {
 
     @NonNull
-    final String courseId;
+    private final String courseId;
 
     @Inject
     private CourseAPI courseAPI;
 
     public GetCourseDetailTask(@NonNull Context context, @NonNull String courseId) {
         super(context);
+        if (TextUtils.isEmpty(courseId)) throw new IllegalArgumentException();
         this.courseId = courseId;
     }
 
     public CourseDetail call() throws Exception {
-        if (courseId != null) {
-            return courseAPI.getCourseDetail(courseId);
-        }
-        return null;
+        return courseAPI.getCourseDetail(courseId);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/event/EnrolledInCourseEvent.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/event/EnrolledInCourseEvent.java
@@ -1,0 +1,4 @@
+package org.edx.mobile.event;
+
+public class EnrolledInCourseEvent {
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetEnrolledCourseTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetEnrolledCourseTask.java
@@ -1,0 +1,37 @@
+/*
+ * GetEnrolledCourseTask
+ *
+ * This task is used to get the course information for a single course from the api which does not
+ * have an endpoint to retrieve data for a single course. It uses the endpoint that returns a list
+ * of enrolled courses and then parses out the course that matches the given course id.
+ */
+
+package org.edx.mobile.task;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.text.TextUtils;
+
+import org.edx.mobile.model.api.EnrolledCoursesResponse;
+
+public abstract class GetEnrolledCourseTask extends Task<EnrolledCoursesResponse> {
+
+    @NonNull
+    private final String courseId;
+
+    public GetEnrolledCourseTask(@NonNull Context context, @NonNull String courseId) {
+        super(context);
+        if (TextUtils.isEmpty(courseId)) throw new IllegalArgumentException();
+        this.courseId = courseId;
+    }
+
+    @Override
+    public EnrolledCoursesResponse call() throws Exception {
+        for (EnrolledCoursesResponse course : environment.getServiceManager().getEnrolledCourses(false)) {
+            if (course.getCourse().getId().equals(courseId)) {
+                return course;
+            }
+        }
+        throw new RuntimeException("Course not found in enrolled courses response");
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDetailActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDetailActivity.java
@@ -1,3 +1,9 @@
+/*
+ * CourseDetailActivity
+ *
+ * Activity that holds the fragments related to the course detail.
+ */
+
 package org.edx.mobile.view;
 
 import android.content.Context;
@@ -5,16 +11,10 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
-import android.view.View;
-import android.widget.Toast;
 
 import org.edx.mobile.R;
 import org.edx.mobile.base.BaseSingleFragmentActivity;
-import org.edx.mobile.base.CourseDetailBaseFragment;
 import org.edx.mobile.course.CourseDetail;
-import org.edx.mobile.module.analytics.ISegment;
-
-import roboguice.inject.InjectExtra;
 
 public class CourseDetailActivity extends BaseSingleFragmentActivity {
 
@@ -33,10 +33,5 @@ public class CourseDetailActivity extends BaseSingleFragmentActivity {
     @Override
     public Fragment getFirstFragment() {
         return new CourseDetailFragment();
-    }
-
-    public void enrollButtonClicked(View view) {
-        // TODO Enroll Button
-        Toast.makeText(getApplicationContext(), "Enroll Button Clicked", Toast.LENGTH_SHORT).show();
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyCourseListTabFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyCourseListTabFragment.java
@@ -9,6 +9,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import org.edx.mobile.R;
+import org.edx.mobile.event.EnrolledInCourseEvent;
 import org.edx.mobile.exception.AuthException;
 import org.edx.mobile.loader.AsyncTaskResult;
 import org.edx.mobile.loader.CoursesAsyncLoader;
@@ -22,20 +23,25 @@ import org.edx.mobile.services.ServiceManager;
 import java.util.ArrayList;
 import java.util.List;
 
+import de.greenrobot.event.EventBus;
+
 public class MyCourseListTabFragment extends CourseListTabFragment {
 
     private final int MY_COURSE_LOADER_ID = 0x905000;
+
     protected TextView noCourseText;
+    private boolean refreshOnResume;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         environment.getSegment().trackScreenView(ISegment.Screens.MY_COURSES);
+        EventBus.getDefault().register(this);
     }
 
     @Override
     public void handleCourseClick(EnrolledCoursesResponse model) {
-       environment.getRouter().showCourseDashboardTabs(getActivity(), environment.getConfig(), model, false);
+        environment.getRouter().showCourseDashboardTabs(getActivity(), environment.getConfig(), model, false);
     }
 
     @Override
@@ -46,7 +52,7 @@ public class MyCourseListTabFragment extends CourseListTabFragment {
     }
 
     protected void loadData(boolean forceRefresh, boolean showProgress) {
-        if(forceRefresh){
+        if (forceRefresh) {
             Intent clearFriends = new Intent(getActivity(), FetchCourseFriendsService.class);
 
             clearFriends.putExtra(FetchCourseFriendsService.TAG_FORCE_REFRESH, true);
@@ -55,8 +61,8 @@ public class MyCourseListTabFragment extends CourseListTabFragment {
         }
 
         //This Show progress is used to display the progress when a user enrolls in a Course
-        if(showProgress && progressBar!=null){
-                progressBar.setVisibility(View.VISIBLE);
+        if (showProgress && progressBar != null) {
+            progressBar.setVisibility(View.VISIBLE);
         }
 
         Bundle args = new Bundle();
@@ -71,17 +77,15 @@ public class MyCourseListTabFragment extends CourseListTabFragment {
 
     @Override
     public Loader<AsyncTaskResult<List<EnrolledCoursesResponse>>> onCreateLoader(int i, Bundle bundle) {
-
-        return new CoursesAsyncLoader(getActivity(), bundle, environment, environment.getServiceManager()){
+        return new CoursesAsyncLoader(getActivity(), bundle, environment, environment.getServiceManager()) {
             @Override
             protected List<EnrolledCoursesResponse> getCourses(ServiceManager api) throws Exception {
-                List<EnrolledCoursesResponse> response =  api.getEnrolledCourses();
+                List<EnrolledCoursesResponse> response = api.getEnrolledCourses();
                 environment.getNotificationDelegate().syncWithServerForFailure();
                 environment.getNotificationDelegate().checkCourseEnrollment(response);
                 return response;
             }
         };
-
     }
 
     @Override
@@ -96,9 +100,8 @@ public class MyCourseListTabFragment extends CourseListTabFragment {
 
         myCourseList.setVisibility(View.VISIBLE);
 
-        if(result.getEx() != null)
-        {
-            if(result.getEx() instanceof AuthException){
+        if (result.getEx() != null) {
+            if (result.getEx() instanceof AuthException) {
                 PrefManager prefs = new PrefManager(getActivity(), PrefManager.Pref.LOGIN);
                 prefs.clearAuth();
 
@@ -110,9 +113,9 @@ public class MyCourseListTabFragment extends CourseListTabFragment {
 
             ArrayList<EnrolledCoursesResponse> newItems = new ArrayList<EnrolledCoursesResponse>(result.getResult());
 
-            ((MyCoursesListActivity)getActivity()).updateDatabaseAfterDownload(newItems);
+            ((MyCoursesListActivity) getActivity()).updateDatabaseAfterDownload(newItems);
 
-            if(result.getResult().size() == 0){
+            if (result.getResult().size() == 0) {
                 adapter.clear();
             } else {
                 adapter.setItems(newItems);
@@ -130,5 +133,25 @@ public class MyCourseListTabFragment extends CourseListTabFragment {
         adapter.notifyDataSetChanged();
         myCourseList.setVisibility(View.GONE);
         progressBar.setVisibility(View.VISIBLE);
+    }
+
+    @SuppressWarnings("unused")
+    public void onEventMainThread(EnrolledInCourseEvent event) {
+        refreshOnResume = true;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (refreshOnResume) {
+            loadData(false, true);
+            refreshOnResume = false;
+        }
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        EventBus.getDefault().unregister(this);
     }
 }


### PR DESCRIPTION
@bguertin 

Did not update the webview course discovery to take you to the course dashboard. The way they did it was really funky and I'm not sure if I agree with it. It seems like they destroy the webview activity which takes you to the MyCourses activity (since it's the only one on the stack) and then call's it's reload function. https://github.com/edx/edx-app-android/blob/master/VideoLocker/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java#L613

In this PR: In the native find courses, when clicking into a course detail, it checks the cached enrollments list and then see's if the button should be for enrollment or viewing the course. If enroll, enroll the user then take them to the course dashboard, then signal MyCourses to refresh onResume. If only viewing the course, just take them to the course dashboard. Unfortunately, this makes an additional call to the API when the user returns to the MyCourses activity as I did not see a obvious way to update that activity's view. 
