### PR TITLE
Pass username and mobile parameters to course list/detail

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/course/CourseAPI.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/course/CourseAPI.java
@@ -31,7 +31,7 @@ public class CourseAPI {
     public
     @NonNull
     CourseList getCourseList(int page) throws RetroHttpException {
-        return courseService.getCourseList(getUsername(), null, true, page);
+        return courseService.getCourseList(getUsername(), true, page);
     }
 
     public

--- a/VideoLocker/src/main/java/org/edx/mobile/course/CourseAPI.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/course/CourseAPI.java
@@ -1,33 +1,50 @@
 package org.edx.mobile.course;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import org.edx.mobile.http.RetroHttpException;
+import org.edx.mobile.model.api.ProfileModel;
+import org.edx.mobile.module.prefs.UserPrefs;
 
 import retrofit.RestAdapter;
-import retrofit.http.Query;
 
 @Singleton
 public class CourseAPI {
 
-    private CourseService courseService;
+    @NonNull
+    private final CourseService courseService;
+    @NonNull
+    private final UserPrefs userPrefs;
+
 
     @Inject
-    public CourseAPI(@NonNull RestAdapter restAdapter) {
+    public CourseAPI(@NonNull RestAdapter restAdapter, @NonNull UserPrefs userPrefs) {
         courseService = restAdapter.create(CourseService.class);
+        this.userPrefs = userPrefs;
     }
 
-    public @NonNull CourseList getCourseList(int page) throws RetroHttpException {
-        return courseService.getCourseList(page);
+    public
+    @NonNull
+    CourseList getCourseList(int page) throws RetroHttpException {
+        return courseService.getCourseList(getUsername(), null, true, page);
     }
 
-    public @NonNull CourseDetail getCourseDetail(@NonNull String courseId) throws RetroHttpException {
+    public
+    @NonNull
+    CourseDetail getCourseDetail(@NonNull String courseId) throws RetroHttpException {
         // Empty courseId will return a 200 for a list of course details, instead of a single course
         if (TextUtils.isEmpty(courseId)) throw new IllegalArgumentException();
-        return courseService.getCourseDetail(courseId);
+        return courseService.getCourseDetail(courseId, getUsername());
+    }
+
+    @Nullable
+    private String getUsername() {
+        final ProfileModel profile = userPrefs.getProfile();
+        return null == profile ? null : profile.username;
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/course/CourseService.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/course/CourseService.java
@@ -7,9 +7,39 @@ import retrofit.http.Path;
 import retrofit.http.Query;
 
 public interface CourseService {
+    /**
+     * @param username (optional):
+     *                 The username of the specified user whose visible courses we
+     *                 want to see. The username is not required only if the API is
+     *                 requested by an Anonymous user.
+     * @param org      (optional):
+     *                 If specified, visible `CourseOverview` objects are filtered
+     *                 such that only those belonging to the organization with the
+     *                 provided org code (e.g., "HarvardX") are returned.
+     *                 Case-insensitive.
+     * @param mobile   (optional):
+     *                 If specified, only visible `CourseOverview` objects that are
+     *                 designated as mobile_available are returned.
+     * @param page     (optional):
+     *                 Which page to fetch. If not given, defaults to page 1
+     */
     @GET("/api/courses/v1/courses/")
-    CourseList getCourseList(@Query("page") int page) throws RetroHttpException;
+    CourseList getCourseList(@Query("username") String username,
+                             @Query("org") String org,
+                             @Query("mobile") boolean mobile,
+                             @Query("page") int page) throws RetroHttpException;
 
+    /**
+     * @param courseId (optional):
+     *                 If specified, visible `CourseOverview` objects are filtered
+     *                 such that only those belonging to the organization with the
+     *                 provided org code (e.g., "HarvardX") are returned.
+     *                 Case-insensitive.
+     * @param username (optional):
+     *                 The username of the specified user whose visible courses we
+     *                 want to see. The username is not required only if the API is
+     *                 requested by an Anonymous user.
+     */
     @GET("/api/courses/v1/courses/{course_id}")
-    CourseDetail getCourseDetail(@Path("course_id") String courseId) throws RetroHttpException;
+    CourseDetail getCourseDetail(@Path("course_id") String courseId, @Query("username") String username) throws RetroHttpException;
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/course/CourseService.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/course/CourseService.java
@@ -12,11 +12,6 @@ public interface CourseService {
      *                 The username of the specified user whose visible courses we
      *                 want to see. The username is not required only if the API is
      *                 requested by an Anonymous user.
-     * @param org      (optional):
-     *                 If specified, visible `CourseOverview` objects are filtered
-     *                 such that only those belonging to the organization with the
-     *                 provided org code (e.g., "HarvardX") are returned.
-     *                 Case-insensitive.
      * @param mobile   (optional):
      *                 If specified, only visible `CourseOverview` objects that are
      *                 designated as mobile_available are returned.
@@ -25,7 +20,6 @@ public interface CourseService {
      */
     @GET("/api/courses/v1/courses/")
     CourseList getCourseList(@Query("username") String username,
-                             @Query("org") String org,
                              @Query("mobile") boolean mobile,
                              @Query("page") int page) throws RetroHttpException;
 

--- a/VideoLocker/src/main/java/org/edx/mobile/course/GetCourseDetailTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/course/GetCourseDetailTask.java
@@ -10,7 +10,8 @@ import org.edx.mobile.task.Task;
 public abstract class GetCourseDetailTask extends
         Task<CourseDetail> {
 
-    @NonNull final String courseId;
+    @NonNull
+    final String courseId;
 
     @Inject
     private CourseAPI courseAPI;
@@ -21,7 +22,7 @@ public abstract class GetCourseDetailTask extends
     }
 
     public CourseDetail call() throws Exception {
-        if(courseId!=null){
+        if (courseId != null) {
             return courseAPI.getCourseDetail(courseId);
         }
         return null;

--- a/VideoLocker/src/main/java/org/edx/mobile/course/GetCourseListTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/course/GetCourseListTask.java
@@ -2,6 +2,7 @@ package org.edx.mobile.course;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.google.inject.Inject;
 

--- a/VideoLocker/src/main/java/org/edx/mobile/course/GetCourseListTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/course/GetCourseListTask.java
@@ -2,7 +2,6 @@ package org.edx.mobile.course;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import com.google.inject.Inject;
 

--- a/VideoLocker/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
@@ -2,6 +2,7 @@ package org.edx.mobile.module.prefs;
 
 import android.content.Context;
 import android.content.SharedPreferences.Editor;
+import android.support.annotation.Nullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -144,6 +145,7 @@ public class PrefManager {
      * Returns current user's profile from the preferences.
      * @return
      */
+    @Nullable
     public ProfileModel getCurrentUserProfile() {
         String json = getString(PrefManager.Key.PROFILE_JSON);
         if (json == null) {

--- a/VideoLocker/src/main/java/org/edx/mobile/module/prefs/UserPrefs.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/prefs/UserPrefs.java
@@ -3,6 +3,7 @@ package org.edx.mobile.module.prefs;
 
 import android.content.Context;
 import android.os.Environment;
+import android.support.annotation.Nullable;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -61,6 +62,7 @@ public class UserPrefs {
         return edxDir;
     }
 
+    @Nullable
     public ProfileModel getProfile() {
         PrefManager pm = new PrefManager(context, PrefManager.Pref.LOGIN);
         return pm.getCurrentUserProfile();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/dialog/NativeFindCoursesFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/dialog/NativeFindCoursesFragment.java
@@ -7,7 +7,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ListView;
-import android.widget.Toast;
 
 import com.google.inject.Inject;
 


### PR DESCRIPTION
Fixes native course discovery which is failing because the "username" parameter is now required.

I also copied the current parameter docs for easy reference.