### PR TITLE
Fix list selector

### DIFF
--- a/VideoLocker/res/drawable/list_item_selector.xml
+++ b/VideoLocker/res/drawable/list_item_selector.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/edx_grayscale_neutral_light" android:state_pressed="true"/>
-    <item android:drawable="@color/white"/>
+    <item android:drawable="@android:color/transparent"/>
 </selector>


### PR DESCRIPTION
Removes the redundant while color definition for list item selector unpressed state causing spinner
dropdowns to have items displayed with white background if they are unpressed without dismissing the dropdown. This issue was introduced in pull request #499.

https://openedx.atlassian.net/browse/MA-1405