### PR TITLE
Use LinearLayout dividers on dashboard to simplify style

### DIFF
--- a/VideoLocker/res/drawable/light_selectable_box_overlay.xml
+++ b/VideoLocker/res/drawable/light_selectable_box_overlay.xml
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_pressed="true">
-        <shape android:shape="rectangle">
-            <solid android:color="@color/transparent_white_10" />
-        </shape>
-    </item>
-    <item>
-        <shape android:shape="rectangle">
-            <solid android:color="@android:color/transparent" />
-        </shape>
-    </item>
+    <item android:state_pressed="true" android:drawable="@color/transparent_white_10" />
+    <item android:drawable="@android:color/transparent" />
 </selector>

--- a/VideoLocker/res/drawable/rectangle_with_bottom_border_selector.xml
+++ b/VideoLocker/res/drawable/rectangle_with_bottom_border_selector.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@color/edx_grayscale_neutral_light" />
-    <item android:bottom="@dimen/edx_hairline"
-          android:drawable="@drawable/list_item_selector" />
-</layer-list>

--- a/VideoLocker/res/drawable/selectable_box_overlay.xml
+++ b/VideoLocker/res/drawable/selectable_box_overlay.xml
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_pressed="true">
-        <shape android:shape="rectangle">
-            <solid android:color="@color/transparent_white_10" />
-        </shape>
-    </item>
-    <item>
-        <shape android:shape="rectangle">
-            <solid android:color="@android:color/transparent" />
-        </shape>
-    </item>
+    <item android:drawable="@color/transparent_white_10" android:state_pressed="true" />
+    <item android:drawable="@android:color/transparent" />
 </selector>

--- a/VideoLocker/res/layout/fragment_course_dashboard.xml
+++ b/VideoLocker/res/layout/fragment_course_dashboard.xml
@@ -85,7 +85,9 @@
             android:id="@+id/dashboard_detail"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:divider="@drawable/edx_divider"
+            android:showDividers="middle|end">
         </LinearLayout>
 
     </LinearLayout>

--- a/VideoLocker/res/layout/row_course_dashboard_list.xml
+++ b/VideoLocker/res/layout/row_course_dashboard_list.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    android:id="@+id/chapter_row_layout"
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/chapter_row_layout"
     android:layout_width="match_parent"
     android:layout_height="@dimen/dashboard_nav_element_height"
-    android:background="@drawable/rectangle_with_bottom_border_selector"
+    android:background="@drawable/list_item_selector"
     android:gravity="center_vertical"
     android:orientation="horizontal"
-    android:paddingLeft="@dimen/dashboard_nav_element_left_margin"
-    android:paddingStart="@dimen/dashboard_nav_element_left_margin"
-    android:paddingRight="@dimen/dashboard_nav_element_right_margin"
     android:paddingEnd="@dimen/dashboard_nav_element_right_margin"
+    android:paddingLeft="@dimen/dashboard_nav_element_left_margin"
+    android:paddingRight="@dimen/dashboard_nav_element_right_margin"
+    android:paddingStart="@dimen/dashboard_nav_element_left_margin"
     tools:targetApi="17">
 
     <org.edx.mobile.view.custom.IconImageViewXml
@@ -21,7 +20,7 @@
         android:layout_height="@dimen/fa_xx_large"
         android:baselineAlignBottom="true"
         android:gravity="center_vertical"
-        app:iconColor="@color/edx_grayscale_neutral_light"/>
+        app:iconColor="@color/edx_grayscale_neutral_light" />
 
     <LinearLayout
         style="@style/regular_grey_text"
@@ -42,7 +41,7 @@
             android:singleLine="true"
             android:textDirection="locale"
             android:textSize="@dimen/edx_base"
-            tools:text="Course Title"/>
+            tools:text="Course Title" />
 
 
         <TextView
@@ -54,7 +53,7 @@
             android:singleLine="true"
             android:textDirection="locale"
             android:textSize="@dimen/edx_x_small"
-            tools:text="Course Subtitle"/>
+            tools:text="Course Subtitle" />
     </LinearLayout>
 
     <org.edx.mobile.view.custom.IconImageViewXml
@@ -63,6 +62,6 @@
         android:baselineAlignBottom="true"
         android:gravity="center_vertical"
         app:iconColor="@color/edx_grayscale_neutral_light"
-        app:iconName="fa-angle-right"/>
+        app:iconName="fa-angle-right" />
 
 </LinearLayout>


### PR DESCRIPTION
Eliminates the need for `rectangle_with_bottom_border_selector`. One less selector style to worry about.