### PR TITLE
Use AppTheme instead of android.R theme for webview dialog

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
@@ -4,6 +4,9 @@ import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.widget.DrawerLayout;
@@ -43,6 +46,10 @@ import de.greenrobot.event.EventBus;
 
 public abstract class BaseFragmentActivity extends BaseAppActivity
         implements NetworkSubject, ICommonUI {
+
+
+    @VisibleForTesting
+    public static final String WEB_VIEW_DIALOG_TAG = "web-view-dialog";
 
     public static final String ACTION_SHOW_MESSAGE_INFO = "ACTION_SHOW_MESSAGE_INFO";
     public static final String ACTION_SHOW_MESSAGE_ERROR = "ACTION_SHOW_MESSAGE_ERROR";
@@ -552,20 +559,13 @@ public abstract class BaseFragmentActivity extends BaseAppActivity
 
     /**
      * Displays a dialog which has a WebView container to display contents of given URL.
-     * @param url String
-     * @param showTitle
-     * @param dialogTitle
      */
-    public void showWebDialog(String url, boolean showTitle, String dialogTitle) {
+    public void showWebDialog(@NonNull String url, @Nullable String dialogTitle) {
         //Show the dialog only if the activity is started. This is to avoid Illegal state
         //exceptions if the dialog fragment tries to show even if the application is not in foreground
         if(isActivityStarted()){
-            WebViewDialogFragment webViewFragment = new WebViewDialogFragment();
-            webViewFragment.setDialogContents(url, showTitle, dialogTitle);
-            webViewFragment.setStyle(DialogFragment.STYLE_NORMAL,
-                    android.R.style.Theme_Black_NoTitleBar_Fullscreen);
-            webViewFragment.setCancelable(false);
-            webViewFragment.show(getSupportFragmentManager(), "web-view-dialog");
+            WebViewDialogFragment.newInstance(url, dialogTitle)
+                    .show(getSupportFragmentManager(), WEB_VIEW_DIALOG_TAG);
         }
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseListTabFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseListTabFragment.java
@@ -210,7 +210,7 @@ public abstract class CourseListTabFragment extends RoboFragment implements Netw
     }
 
     public void showCourseNotListedDialog() {
-        ((BaseFragmentActivity) getActivity()).showWebDialog(getString(R.string.course_not_listed_file_name), false,
+        ((BaseFragmentActivity) getActivity()).showWebDialog(getString(R.string.course_not_listed_file_name),
                 null);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/LoginActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/LoginActivity.java
@@ -8,7 +8,6 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.animation.Animation;
-import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -346,7 +345,7 @@ public class LoginActivity extends BaseFragmentActivity implements SocialLoginDe
 
     public void showEulaDialog() {
         clearDialogs();
-        showWebDialog(getString(R.string.eula_file_link), true,
+        showWebDialog(getString(R.string.eula_file_link),
                 getString(R.string.end_user_title));
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -11,7 +11,6 @@ import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.View;
-import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
@@ -174,13 +173,11 @@ public class RegisterActivity extends BaseFragmentActivity
         if (isInAppEULALink) {
             // show EULA license that is shipped with app
             showWebDialog(getString(R.string.eula_file_link),
-                    true,
                     getString(R.string.end_user_title));
         }
         else {
             // for any other link, open agreement link in a webview container
             showWebDialog(agreement.getLink(),
-                    true,
                     agreement.getText());
         }
     }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/dialog/WebViewDialogFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/dialog/WebViewDialogFragment.java
@@ -1,106 +1,103 @@
 package org.edx.mobile.view.dialog;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AppCompatDialogFragment;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.webkit.WebView;
-import android.widget.Button;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import org.edx.mobile.R;
-import org.edx.mobile.logger.Logger;
 import org.edx.mobile.view.custom.URLInterceptorWebViewClient;
 
-public class WebViewDialogFragment extends DialogFragment {
-    private final Logger logger = new Logger(getClass().getName());
+public class WebViewDialogFragment extends AppCompatDialogFragment {
 
-    private static final String TAG = WebViewDialogFragment.class.getCanonicalName();
+    private static final String ARG_URL = "url";
+    private static final String ARG_TITLE = "title";
 
-    private String fileName;
-    private boolean showTitle;
-    private String dialogTitle;
-    private ProgressBar progress;
-    
-    public WebViewDialogFragment() {
-    }   
-    
-    public void setDialogContents(String fileName, boolean showTitle, String dialogTitle){
-        this.fileName = fileName;
-        this.showTitle = showTitle;
-        this.dialogTitle = dialogTitle;
-    }   
+    public static WebViewDialogFragment newInstance(@NonNull String url, @Nullable String title) {
+        final Bundle args = new Bundle();
+        args.putString(ARG_URL, url);
+        args.putString(ARG_TITLE, title);
+        final WebViewDialogFragment fragment = new WebViewDialogFragment();
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setStyle(DialogFragment.STYLE_NORMAL,
+                R.style.AppTheme_NoActionBar);
+        setCancelable(false);
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
-            Bundle savedInstanceState) {
-
-        View v = inflater.inflate(R.layout.fragment_web_dialog,
+                             Bundle savedInstanceState) {
+        final View view = inflater.inflate(R.layout.fragment_web_dialog,
                 container, false);
 
-        progress = (ProgressBar) v.findViewById(R.id.progress);
+        final ProgressBar progress = (ProgressBar) view.findViewById(R.id.progress);
         progress.setVisibility(View.GONE);
 
-        try{
-            WebView webView = (WebView)v.findViewById(R.id.eula_webView);
-            URLInterceptorWebViewClient client =
-                    new URLInterceptorWebViewClient(getActivity(), webView);
-            client.setPageStatusListener(new URLInterceptorWebViewClient.IPageStatusListener() {
+        final WebView webView = (WebView) view.findViewById(R.id.eula_webView);
+        final URLInterceptorWebViewClient client =
+                new URLInterceptorWebViewClient(getActivity(), webView);
+        client.setPageStatusListener(new URLInterceptorWebViewClient.IPageStatusListener() {
 
-                @Override
-                public void onPageStarted() {
-                    progress.setVisibility(View.VISIBLE);
-                }
-
-                @Override
-                public void onPageFinished() {
-                    progress.setVisibility(View.GONE);
-                }
-
-                @Override
-                public void onPageLoadError() {
-                    progress.setVisibility(View.GONE);
-                }
-
-                @Override
-                public void onPagePartiallyLoaded() {
-                    progress.setVisibility(View.GONE);
-                }
-            });
-
-            if(fileName!=null){
-                webView.loadUrl(fileName);
+            @Override
+            public void onPageStarted() {
+                progress.setVisibility(View.VISIBLE);
             }
-            TextView tv_dialog_title = (TextView)v.findViewById(R.id.tv_dialog_title);
-            View viewSeperator = v.findViewById(R.id.view_seperator);
-            if(showTitle){
-                tv_dialog_title.setVisibility(View.VISIBLE);
-                viewSeperator.setVisibility(View.VISIBLE);
-                if(dialogTitle!=null){
-                    tv_dialog_title.setText(dialogTitle);
-                }
-            }else{
-                tv_dialog_title.setVisibility(View.INVISIBLE);
-                viewSeperator.setVisibility(View.INVISIBLE);
+
+            @Override
+            public void onPageFinished() {
+                progress.setVisibility(View.GONE);
             }
-        }catch(Exception e){
-            logger.error(e);
+
+            @Override
+            public void onPageLoadError() {
+                progress.setVisibility(View.GONE);
+            }
+
+            @Override
+            public void onPagePartiallyLoaded() {
+                progress.setVisibility(View.GONE);
+            }
+        });
+
+
+        webView.loadUrl(getArguments().getString(ARG_URL));
+
+        final TextView tv_dialog_title = (TextView) view.findViewById(R.id.tv_dialog_title);
+        final View viewSeperator = view.findViewById(R.id.view_seperator);
+        final String title = getArguments().getString(ARG_TITLE);
+        if (TextUtils.isEmpty(title)) {
+            tv_dialog_title.setVisibility(View.INVISIBLE);
+            viewSeperator.setVisibility(View.INVISIBLE);
+        } else {
+            tv_dialog_title.setVisibility(View.VISIBLE);
+            viewSeperator.setVisibility(View.VISIBLE);
+            tv_dialog_title.setText(title);
         }
 
-        // Watch for button clicks.
-        Button button = (Button) v.findViewById(R.id.positiveButton);
-        button.setOnClickListener(new OnClickListener() {
+        view.findViewById(R.id.positiveButton).setOnClickListener(new OnClickListener() {
             public void onClick(View v) {
                 //Check if the dialog is not removing(dismissing)
                 // or is visible before dismissing the dialog
-                if(!isRemoving() && isVisible())
+                if (!isRemoving() && isVisible())
                     dismiss();
             }
         });
 
-        return v;
+        return view;
     }
 }

--- a/VideoLocker/src/test/java/org/edx/mobile/view/BaseFragmentActivityTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/BaseFragmentActivityTest.java
@@ -4,9 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
-import android.graphics.Color;
 import android.graphics.Typeface;
-import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.support.annotation.AnimRes;
@@ -25,7 +23,6 @@ import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.webkit.WebView;
 import android.widget.FrameLayout;
-import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.edx.mobile.R;
@@ -484,11 +481,11 @@ public abstract class BaseFragmentActivityTest extends UiTest {
      * @param title The dialog title
      */
     protected static void showWebDialogTest(BaseFragmentActivity activity,
-            String url, boolean showTitle, String title) {
-        activity.showWebDialog(url, showTitle, title);
+            String url, String title) {
+        activity.showWebDialog(url, title);
         FragmentManager fragmentManager = activity.getSupportFragmentManager();
         fragmentManager.executePendingTransactions();
-        Fragment webViewFragment = fragmentManager.findFragmentByTag("web-view-dialog");
+        Fragment webViewFragment = fragmentManager.findFragmentByTag(BaseFragmentActivity.WEB_VIEW_DIALOG_TAG);
         assertNotNull(webViewFragment);
         assertThat(webViewFragment).isInstanceOf(WebViewDialogFragment.class);
         WebViewDialogFragment webViewDialogFragment = (WebViewDialogFragment) webViewFragment;
@@ -502,13 +499,11 @@ public abstract class BaseFragmentActivityTest extends UiTest {
         assertEquals(shadowWebView.getLastLoadedUrl(), url);
         TextView titleView = (TextView) dialogView.findViewById(R.id.tv_dialog_title);
         assertNotNull(titleView);
-        if (showTitle) {
-            assertThat(titleView).isVisible();
-            if (title != null) {
-                assertThat(titleView).hasText(title);
-            }
-        } else {
+        if (TextUtils.isEmpty(title)) {
             assertThat(titleView).isNotVisible();
+        } else {
+            assertThat(titleView).isVisible();
+            assertThat(titleView).hasText(title);
         }
         webViewDialogFragment.dismiss();
         fragmentManager.executePendingTransactions();
@@ -524,10 +519,8 @@ public abstract class BaseFragmentActivityTest extends UiTest {
                         .withIntent(getIntent()).setup().get();
         String url = "https://www.edx.org";
         String title = "title";
-        showWebDialogTest(activity, url, true, title);
-        showWebDialogTest(activity, url, false, null);
-        showWebDialogTest(activity, url, false, title);
-        showWebDialogTest(activity, url, true, null);
+        showWebDialogTest(activity, url, title);
+        showWebDialogTest(activity, url, null);
     }
 
     /**


### PR DESCRIPTION
Fixes https://openedx.atlassian.net/browse/MA-1824

- Using an AppCompat theme pretty much fixes the flickering issue. I also did some other cleanup while I was in there
- No longer hiding the status bar... because that's weird
- I moved the parameters into fragment arguments so that they will actually be retained across activity restarts.
- I moved the dialog initialization into onCreate since we only use it one place, better to keep as little code in our BaseFragmentActivity as possible ;)