### PR TITLE
Always use Glide when loading profile image view

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
@@ -232,7 +232,9 @@ public class EditUserProfileFragment extends RoboFragment {
     @SuppressWarnings("unused")
     public void onEventMainThread(@NonNull ProfilePhotoUpdatedEvent event) {
         if (null == event.getUri()) {
-            viewHolder.profileImage.setImageResource(R.drawable.xsie);
+            Glide.with(this)
+                    .load(R.drawable.xsie)
+                    .into(viewHolder.profileImage);
         } else {
             Glide.with(this)
                     .load(event.getUri())
@@ -240,7 +242,6 @@ public class EditUserProfileFragment extends RoboFragment {
                     .diskCacheStrategy(DiskCacheStrategy.NONE)
                     .into(viewHolder.profileImage);
         }
-
     }
 
     public class ViewHolder {
@@ -282,7 +283,9 @@ public class EditUserProfileFragment extends RoboFragment {
                         .load(account.getProfileImage().getImageUrlLarge())
                         .into(viewHolder.profileImage);
             } else {
-                viewHolder.profileImage.setImageResource(R.drawable.xsie);
+                Glide.with(EditUserProfileFragment.this)
+                        .load(R.drawable.xsie)
+                        .into(viewHolder.profileImage);
             }
 
             final Gson gson = new GsonBuilder().serializeNulls().create();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/NavigationFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/NavigationFragment.java
@@ -111,7 +111,9 @@ public class NavigationFragment extends RoboFragment {
                     .load(profileImage.getImageUrlLarge())
                     .into(imageView);
         } else {
-            imageView.setImageResource(R.drawable.xsie);
+            Glide.with(NavigationFragment.this)
+                    .load(R.drawable.xsie)
+                    .into(imageView);
         }
     }
 
@@ -376,7 +378,9 @@ public class NavigationFragment extends RoboFragment {
     public void onEventMainThread(@NonNull ProfilePhotoUpdatedEvent event) {
         if (event.getUsername().equalsIgnoreCase(profile.username)) {
             if (null == event.getUri()) {
-                imageView.setImageResource(R.drawable.xsie);
+                Glide.with(NavigationFragment.this)
+                        .load(R.drawable.xsie)
+                        .into(imageView);
             } else {
                 Glide.with(NavigationFragment.this)
                         .load(event.getUri())

--- a/VideoLocker/src/main/java/org/edx/mobile/view/UserProfileFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/UserProfileFragment.java
@@ -165,9 +165,11 @@ public class UserProfileFragment extends RoboFragment {
     public void onEventMainThread(@NonNull ProfilePhotoUpdatedEvent event) {
         if (event.getUsername().equalsIgnoreCase(username)) {
             if (null == event.getUri()) {
-                viewHolder.profileImage.setImageResource(R.drawable.xsie);
+                Glide.with(UserProfileFragment.this)
+                        .load(R.drawable.xsie)
+                        .into(viewHolder.profileImage);
             } else {
-                Glide.with(viewHolder.profileImage.getContext())
+                Glide.with(UserProfileFragment.this)
                         .load(event.getUri())
                         .skipMemoryCache(true) // URI is re-used in subsequent events; disable caching
                         .diskCacheStrategy(DiskCacheStrategy.NONE)
@@ -197,11 +199,13 @@ public class UserProfileFragment extends RoboFragment {
             viewHolder.profileHeaderContent.setVisibility(View.VISIBLE);
 
             if (account.getProfileImage().hasImage()) {
-                Glide.with(viewHolder.profileImage.getContext())
+                Glide.with(UserProfileFragment.this)
                         .load(account.getProfileImage().getImageUrlFull())
                         .into(viewHolder.profileImage);
             } else {
-                viewHolder.profileImage.setImageResource(R.drawable.xsie);
+                Glide.with(UserProfileFragment.this)
+                        .load(R.drawable.xsie)
+                        .into(viewHolder.profileImage);
             }
 
             if (account.requiresParentalConsent() || account.getAccountPrivacy() == Account.Privacy.PRIVATE) {


### PR DESCRIPTION
Fixes https://openedx.atlassian.net/browse/MA-1913 which is due to the mixing of synchronous (`setImageResource`) and asynchronous (Glide `load`) methods of setting the ImageView's image. 

Safest solution, I think, is to use Glide always.