### PR TITLE
Fixing some UI issues in the last accessed bar.

### DIFF
--- a/VideoLocker/res/layout/activity_course_base.xml
+++ b/VideoLocker/res/layout/activity_course_base.xml
@@ -39,7 +39,9 @@
             <LinearLayout
                 android:id="@+id/last_access_bar"
                 android:orientation="vertical"
-                style="@style/last_access_bar"
+                android:layout_width="match_parent"
+                android:layout_height="50dp"
+                android:background="@color/edx_brand_primary_x_light"
                 android:visibility="gone">
 
                 <LinearLayout
@@ -70,6 +72,8 @@
                             android:id="@+id/last_access_text"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:ellipsize="end"
+                            android:singleLine="true"
                             android:textSize="16sp"
                             tools:text="Course Name"
                             tools:targetApi="17" />

--- a/VideoLocker/res/values/styles.xml
+++ b/VideoLocker/res/values/styles.xml
@@ -123,14 +123,10 @@
         <item name="android:visibility">gone</item>
     </style>
 
-    <style name="last_access_bar">
+    <style name="download_in_progress_bar">
         <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">50dp</item>
-        <item name="android:background">@color/edx_brand_primary_x_light</item>
-    </style>
-
-    <style name="download_in_progress_bar" parent="last_access_bar">
         <item name="android:layout_height">45dp</item>
+        <item name="android:background">@color/edx_brand_primary_x_light</item>
     </style>
 
     <style name="separator_base">


### PR DESCRIPTION
In the last accessed bar: 
* course title is trimmed when it is too long.
* course title is touching the bottom edge of the layout.
* last accessed string is touching the upper edge of the layout.

![1](https://cloud.githubusercontent.com/assets/11036472/12169358/a1a8d53a-b540-11e5-871b-6bec077804c6.png)

**After Solving these issues:**
---------------------------------------------
***UPDATE***
~~https://cloud.githubusercontent.com/assets/11036472/12169360/a7447f08-b540-11e5-9e73-733b53cc91dd.png~~

![3](https://cloud.githubusercontent.com/assets/11036472/12221146/90d76ef8-b796-11e5-964b-82f935cd3c82.png)
