### PR TITLE
Fix issue with Android Studio not setting up app gradle plugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,10 +1,4 @@
-import org.ajoberstar.grgit.*
-import org.ajoberstar.grgit.exception.*
-
 buildscript {
-    dependencies {
-        classpath 'org.ajoberstar:grgit:1.0.0'
-    }
     repositories {
         mavenCentral()
     }
@@ -38,23 +32,3 @@ repositories {
     mavenCentral()
 }
 
-def edXAppPluginSetup(url, ref) {
-    def buildSrc = project.file('plugins/')
-    buildSrc.mkdirs()
-    def dest = buildSrc.getAbsolutePath() + "/edx-app-gradle-plugin"
-
-    if(!new File(dest).exists()) {
-        Grgit.clone(dir: dest, uri: url, refToCheckout : ref)
-    }
-
-    def grgit = Grgit.open(dir : dest)
-    try {
-        grgit.fetch()
-    }
-    catch(GrgitException e) {
-        println("Could not fetch. This is probably due to lack of an internet connection. Skipping")
-    }
-    grgit.checkout(branch : ref)
-}
-
-edXAppPluginSetup('https://github.com/edx/edx-app-gradle-plugin', '2e0516c8b3c4e0d60bff01491bc66c9f0f2eedf4')

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,1 +1,34 @@
+import org.ajoberstar.grgit.*
+import org.ajoberstar.grgit.exception.*
+
+buildscript {
+    dependencies {
+        classpath 'org.ajoberstar:grgit:1.0.0'
+    }
+    repositories {
+        mavenCentral()
+    }
+}
+
+def edXAppPluginSetup(url, ref) {
+    def buildSrc = new File(rootProject.projectDir, 'plugins')
+    buildSrc.mkdirs()
+    def dest = new File(buildSrc, "edx-app-gradle-plugin")
+
+    if(!dest.exists()) {
+        Grgit.clone(dir: dest, uri: url, refToCheckout : ref)
+    }
+
+    def grgit = Grgit.open(dir : dest)
+    try {
+        grgit.fetch()
+    }
+    catch(GrgitException e) {
+        println("Could not fetch latest version of app gradle plugin. This is probably due to lack of an internet connection. Skipping")
+    }
+    grgit.checkout(branch : ref)
+}
+
+edXAppPluginSetup('https://github.com/edx/edx-app-gradle-plugin', '2e0516c8b3c4e0d60bff01491bc66c9f0f2eedf4')
+
 include "plugins/edx-app-gradle-plugin"


### PR DESCRIPTION
When you first setup an app build, the gradle plugin wasn't loading in
Android Studio and you'd get an error about the module not being
available. We load the plugin dynamically (since we just fetch it from
github and there's no nice easy way to do that) and the code to do that
(in ``src/build.gradle``) was never getting executed.

This isn't a problem with command line builds, but it looks like android
studio is building things in a different order or processing
``settings.gradle`` directly or something, so the code to load the plugin
in ``buildSrc/build.gradle`` wasn't ever triggered. This moves that code
to ``settings.gradle`` which seems to fix the problem.