### PR TITLE
Lock discussions add buttons while in progress

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
@@ -91,6 +91,8 @@ public class DiscussionAddCommentFragment extends RoboFragment {
     }
 
     private void createComment() {
+        buttonAddComment.setEnabled(false);
+
         if (createCommentTask != null) {
             createCommentTask.cancel(true);
         }
@@ -111,6 +113,7 @@ public class DiscussionAddCommentFragment extends RoboFragment {
             @Override
             public void onException(Exception ex) {
                 logger.error(ex);
+                buttonAddComment.setEnabled(true);
             }
         };
         createCommentTask.execute();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddPostFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddPostFragment.java
@@ -200,7 +200,6 @@ public class DiscussionAddPostFragment extends RoboFragment {
             @Override
             public void onException(Exception ex) {
                 logger.error(ex);
-                //  hideProgress();
                 addPostButton.setEnabled(true);
             }
         };
@@ -234,7 +233,6 @@ public class DiscussionAddPostFragment extends RoboFragment {
             @Override
             public void onException(Exception ex) {
                 logger.error(ex);
-                //  hideProgress();
             }
         };
         getTopicListTask.execute();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
@@ -95,6 +95,8 @@ public class DiscussionAddResponseFragment extends RoboFragment {
     }
 
     private void createComment() {
+        buttonAddComment.setEnabled(false);
+
         if (createCommentTask != null) {
             createCommentTask.cancel(true);
         }
@@ -115,6 +117,7 @@ public class DiscussionAddResponseFragment extends RoboFragment {
             @Override
             public void onException(Exception ex) {
                 logger.error(ex);
+                buttonAddComment.setEnabled(true);
             }
         };
         createCommentTask.execute();


### PR DESCRIPTION
While `DiscussionAddPostFragment` disabled it's add button after usage during the process of adding, this functionality was not implemented for `DiscussionAddResponseFragment` and `DiscussionAddCommentFragment`. This is now fixed by this commit. Also, the commented out code for calling the `hideProgress()` method in `DiscussionAddPostFragment` has been removed, as this logic has been refactored to `BaseSingleFragmentActivity`.

Fixes [MA-1935][].

[MA-1935]: https://openedx.atlassian.net/browse/MA-1935