### PR TITLE
Config explicitly initialised inside the Logger

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -31,7 +31,6 @@ import org.edx.mobile.view.Router;
 
 import java.util.Locale;
 
-import de.greenrobot.event.EventBus;
 import io.fabric.sdk.android.Fabric;
 import roboguice.RoboGuice;
 import uk.co.chrisjenx.calligraphy.CalligraphyConfig;
@@ -44,7 +43,7 @@ public class MainApplication extends MultiDexApplication {
     //FIXME - temporary solution
     public static final boolean RETROFIT_ENABLED = false;
 
-    protected final Logger logger = new Logger(getClass().getName());
+    protected Logger logger;
 
     protected static MainApplication application;
 
@@ -58,6 +57,7 @@ public class MainApplication extends MultiDexApplication {
     public void onCreate() {
         super.onCreate();
         init();
+        logger = new Logger(getClass().getName());
     }
 
     /**

--- a/VideoLocker/src/main/java/org/edx/mobile/logger/Logger.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/logger/Logger.java
@@ -4,24 +4,24 @@ import com.crashlytics.android.Crashlytics;
 import com.google.inject.Inject;
 
 import org.edx.mobile.BuildConfig;
+import org.edx.mobile.base.MainApplication;
 import org.edx.mobile.util.Config;
 
 import java.io.Serializable;
+
+import roboguice.RoboGuice;
 
 /**
  * Created by shahid on 22/1/15.
  */
 public class Logger implements Serializable {
 
-    private String tag;
+    private final String tag;
 
-    @Inject
-    Config config;
-
-    private Logger() {}
+    private final Config config = RoboGuice.getInjector(MainApplication.instance()).getInstance(Config.class);
 
     public Logger(Class<?> cls) {
-        this.tag = cls.getName();
+        this(cls.getName());
     }
 
     public Logger(String tag) {


### PR DESCRIPTION
Fixes: https://openedx.atlassian.net/browse/MA-1969

Since we aren't injecting the Logger class, so we need to explicitly
call RoboGuice's injectMembers function to avoid NullPointers while
logging errors to Crashlytics.

@1zaman @bguertin @BenjiLee plz review