### PR TITLE
Fix Config NPE in Logger

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/logger/Logger.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/logger/Logger.java
@@ -1,24 +1,12 @@
 package org.edx.mobile.logger;
 
-import com.crashlytics.android.Crashlytics;
-import com.google.inject.Inject;
-
-import org.edx.mobile.BuildConfig;
-import org.edx.mobile.util.Config;
-
 import java.io.Serializable;
 
-/**
- * Created by shahid on 22/1/15.
- */
+import de.greenrobot.event.EventBus;
+
 public class Logger implements Serializable {
 
-    private String tag;
-
-    @Inject
-    Config config;
-
-    private Logger() {}
+    private final String tag;
 
     public Logger(Class<?> cls) {
         this.tag = cls.getName();
@@ -30,6 +18,7 @@ public class Logger implements Serializable {
 
     /**
      * Prints the stack trace for the given throwable instance for debug build.
+     *
      * @param ex
      */
     public void error(Throwable ex) {
@@ -38,16 +27,16 @@ public class Logger implements Serializable {
 
     /**
      * Prints the stack trace for the given throwable instance for debug build.
-     * Also, submits the crash report (only for release build) to Fabric if submitCrashReport is true.
+     * Also, submits the crash report if submitCrashReport is true.
+     *
      * @param ex
      * @param submitCrashReport
      */
     public void error(Throwable ex, boolean submitCrashReport) {
         LogUtil.error(this.tag, "", ex);
 
-        if (submitCrashReport
-                &&  config.getFabricConfig().isEnabled()) {
-            Crashlytics.logException(ex);
+        if (submitCrashReport) {
+            EventBus.getDefault().post(new CrashReportEvent(ex));
         }
     }
 
@@ -57,5 +46,17 @@ public class Logger implements Serializable {
 
     public void debug(String log) {
         LogUtil.debug(this.tag, log);
+    }
+
+    public static class CrashReportEvent {
+        private final Throwable error;
+
+        public CrashReportEvent(Throwable error) {
+            this.error = error;
+        }
+
+        public Throwable getError() {
+            return error;
+        }
     }
 }

--- a/VideoLocker/src/test/java/org/edx/mobile/test/http/HttpBaseTestCase.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/http/HttpBaseTestCase.java
@@ -73,7 +73,6 @@ public class HttpBaseTestCase extends BaseTestCase {
 
         super.setUp();
 
-
         String oAuthClientId = config.getOAuthClientId();
         String testAccount = config.getTestAccountConfig().getName();
         shouldSkipTest = TextUtils.isEmpty( oAuthClientId ) || TextUtils.isEmpty(testAccount);


### PR DESCRIPTION
- Removes circular dependency between Config <-> Logger
- Consolidates Crashlytics initialization into one place.
- Ensures Crashlytics.logException is not called until Fabric has been initialized.

Fixes https://openedx.atlassian.net/browse/MA-1969