### PR TITLE
Handle web-only videos and invalid video URLs

### DIFF
--- a/VideoLocker/res/layout/fragment_course_unit_grade.xml
+++ b/VideoLocker/res/layout/fragment_course_unit_grade.xml
@@ -15,6 +15,7 @@
         app:iconName="fa-laptop" />
 
     <TextView
+        android:id="@+id/not_available_message"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="20dp"
@@ -22,7 +23,7 @@
         android:layout_marginRight="60dp"
         android:gravity="center"
         android:singleLine="false"
-        android:text="@string/assessment_not_available"
+        tools:text="@string/assessment_not_available"
         android:textAlignment="center"
         android:textColor="@color/edx_grayscale_neutral_dark"
         android:textSize="@dimen/edx_base"

--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -475,7 +475,7 @@
     <!-- Error shown when video has flag to indicate it is not available for mobile app -->
     <string name="video_only_on_web_label">This video is currently only on web. Click to view on web.</string>
     <!-- Message to indicate the it is not available for mobile app  -->
-    <string name="video_only_on_web_short">This video can only be played in a browser</string>
+    <string name="video_only_on_web_short">This video isn’t yet available on mobile.</string>
     <!-- Alert dialog title when login fails -->
     <string name="login_error">Sign-in Error</string>
     <!-- Alert dialog title when login fails due to lack of internet -->

--- a/VideoLocker/src/main/java/org/edx/mobile/model/course/CourseComponent.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/model/course/CourseComponent.java
@@ -214,7 +214,7 @@ public class CourseComponent implements IBlock, IPathNode {
     /**
      * return all videos blocks under this node
      */
-    public List<HasDownloadEntry> getVideos(){
+    public List<VideoBlockModel> getVideos(){
         List<CourseComponent> videos = new ArrayList<>();
         fetchAllLeafComponents(videos, EnumSet.of(BlockType.VIDEO));
         // Confirm that these are actually VideoBlockModel instances.
@@ -229,21 +229,18 @@ public class CourseComponent implements IBlock, IPathNode {
                 videosIterator.remove();
             }
         }
-        return (List)videos;
+        return (List<VideoBlockModel>)(List)videos;
     }
 
     /**
-     * Returns the count of videos that have the boolean
-     * {@link org.edx.mobile.model.db.DownloadEntry#isVideoForWebOnly} set to <code>false</code>
-     *
-     * @param storage The local storage object to look into
-     * @return The count of videos that are downloadable
+     * @return count of videos that have encoded files available
+     * and {@link VideoData#onlyOnWeb} set to <code>false</code>
      */
-    public int getDownloadableVideosCount(IStorage storage) {
+    public int getDownloadableVideosCount() {
         int downloadableCount = 0;
-        List<HasDownloadEntry> videos = getVideos();
-        for (int i = 0, size = videos.size(); i < size; i++) {
-            if (!videos.get(i).getDownloadEntry(storage).isVideoForWebOnly()) {
+        List<VideoBlockModel> videos = getVideos();
+        for (VideoBlockModel video : videos) {
+            if (video.getData().encodedVideos.getPreferredVideoInfo() != null && !video.getData().onlyOnWeb) {
                 downloadableCount++;
             }
         }

--- a/VideoLocker/src/main/java/org/edx/mobile/model/course/EncodedVideos.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/model/course/EncodedVideos.java
@@ -1,13 +1,13 @@
 package org.edx.mobile.model.course;
 
+import android.support.annotation.Nullable;
+import android.webkit.URLUtil;
+
 import com.google.gson.annotations.SerializedName;
 
 import java.io.Serializable;
 
-/**
- * Created by hanning on 5/19/15.
- */
-public class EncodedVideos implements Serializable{
+public class EncodedVideos implements Serializable {
     @SerializedName("fallback")
     public VideoInfo fallback;
 
@@ -20,14 +20,14 @@ public class EncodedVideos implements Serializable{
     @SerializedName("youtube")
     public VideoInfo youtube;
 
-    public VideoInfo getPreferredVideoInfo(){
-        if ( mobileLow != null )
+    @Nullable
+    public VideoInfo getPreferredVideoInfo() {
+        if (mobileLow != null && URLUtil.isNetworkUrl(mobileLow.url))
             return mobileLow;
-        if ( mobileHigh != null )
+        if (mobileHigh != null && URLUtil.isNetworkUrl(mobileHigh.url))
             return mobileHigh;
-        if ( fallback != null)
+        if (fallback != null && URLUtil.isNetworkUrl(fallback.url))
             return fallback;
-        return new VideoInfo(); //should not be here
+        return null;
     }
-
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/model/course/HasDownloadEntry.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/model/course/HasDownloadEntry.java
@@ -1,12 +1,11 @@
 package org.edx.mobile.model.course;
 
+import android.support.annotation.Nullable;
+
 import org.edx.mobile.model.db.DownloadEntry;
 import org.edx.mobile.module.storage.IStorage;
 
-/**
- * Created by hanning on 5/20/15.
- */
 public interface HasDownloadEntry {
+    @Nullable
     DownloadEntry getDownloadEntry(IStorage storage);
-    long getSize();
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/model/course/VideoBlockModel.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/model/course/VideoBlockModel.java
@@ -1,5 +1,7 @@
 package org.edx.mobile.model.course;
 
+import android.support.annotation.Nullable;
+
 import org.edx.mobile.model.db.DownloadEntry;
 import org.edx.mobile.module.storage.IStorage;
 
@@ -16,16 +18,16 @@ public class VideoBlockModel extends CourseComponent implements HasDownloadEntry
         this.data = (VideoData)blockModel.data;
     }
 
+    @Nullable
     public DownloadEntry getDownloadEntry(IStorage storage) {
+        if (data.encodedVideos.getPreferredVideoInfo() == null) {
+            return null;
+        }
         if ( storage != null ) {
             downloadEntry = (DownloadEntry) storage
-                .getDownloadEntryfromVideoModel(this);
+                .getDownloadEntryFromVideoModel(this);
         }
         return downloadEntry;
-    }
-
-    public long getSize(){
-         return data.encodedVideos.getPreferredVideoInfo().fileSize;
     }
 
     public VideoData getData() {

--- a/VideoLocker/src/main/java/org/edx/mobile/model/course/VideoInfo.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/model/course/VideoInfo.java
@@ -4,9 +4,6 @@ import com.google.gson.annotations.SerializedName;
 
 import java.io.Serializable;
 
-/**
- * Created by hanning on 5/19/15.
- */
 public class VideoInfo implements Serializable{
     @SerializedName("url")
     public String url;

--- a/VideoLocker/src/main/java/org/edx/mobile/module/storage/IStorage.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/storage/IStorage.java
@@ -79,7 +79,7 @@ public interface IStorage {
      * @param block - VidoeBlockModel
      * @return
      */
-    VideoModel getDownloadEntryfromVideoModel(VideoBlockModel block);
+    VideoModel getDownloadEntryFromVideoModel(VideoBlockModel block);
 
     /**
      * Returns NativeDownload Entry for the given DMID

--- a/VideoLocker/src/main/java/org/edx/mobile/module/storage/Storage.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/storage/Storage.java
@@ -250,7 +250,7 @@ public class Storage implements IStorage {
     }
 
     @Override
-    public VideoModel getDownloadEntryfromVideoModel(VideoBlockModel block){
+    public VideoModel getDownloadEntryFromVideoModel(VideoBlockModel block){
         VideoModel video = db.getVideoEntryByVideoId(block.getId(), null);
         if (video != null) {
             return video;

--- a/VideoLocker/src/main/java/org/edx/mobile/services/CourseManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/services/CourseManager.java
@@ -22,6 +22,7 @@ import org.edx.mobile.model.course.HtmlBlockModel;
 import org.edx.mobile.model.course.IBlock;
 import org.edx.mobile.model.course.VideoBlockModel;
 import org.edx.mobile.model.course.VideoData;
+import org.edx.mobile.model.course.VideoInfo;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -149,13 +150,14 @@ public class CourseManager {
         SummaryModel model = new SummaryModel();
         model.setType(videoBlockModel.getType());
         model.setDisplayName(videoBlockModel.getDisplayName());
-        model.setVideoUrl(videoBlockModel.getData().encodedVideos.getPreferredVideoInfo().url);
         model.setDuration((int)videoBlockModel.getData().duration);
-        //FIXME - is this field missing?
-        //model.setOnlyOnWeb(videoBlockModel.);
-       // public boolean onlyOnWeb;
+        model.setOnlyOnWeb(videoBlockModel.getData().onlyOnWeb);
         model.setId(videoBlockModel.getId());
-        model.setSize(videoBlockModel.getSize());
+        final VideoInfo videoInfo = videoBlockModel.getData().encodedVideos.getPreferredVideoInfo();
+        if (null != videoInfo) {
+            model.setVideoUrl(videoInfo.url);
+            model.setSize(videoInfo.fileSize);
+        }
         model.setTranscripts(videoBlockModel.getData().transcripts);
         //FIXME = is this field missing?
        // private EncodingsModel encodings;

--- a/VideoLocker/src/main/java/org/edx/mobile/services/VideoDownloadHelper.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/services/VideoDownloadHelper.java
@@ -56,7 +56,7 @@ public class VideoDownloadHelper {
     ISegment segment;
 
 
-    public void downloadVideos(final List<HasDownloadEntry> model, final FragmentActivity activity,
+    public void downloadVideos(final List<? extends HasDownloadEntry> model, final FragmentActivity activity,
                                final DownloadManagerCallback callback) {
         if (model == null || model.isEmpty()) {
             return;
@@ -81,20 +81,20 @@ public class VideoDownloadHelper {
 
     }
 
-    private void startDownloadVideos(List<HasDownloadEntry> model, FragmentActivity activity, DownloadManagerCallback callback) {
-
+    private void startDownloadVideos(List<? extends HasDownloadEntry> model, FragmentActivity activity, DownloadManagerCallback callback) {
         long downloadSize = 0;
         ArrayList<DownloadEntry> downloadList = new ArrayList<DownloadEntry>();
         int downloadCount = 0;
         for (HasDownloadEntry v : model) {
             DownloadEntry de = v.getDownloadEntry(storage);
-            if (de.downloaded == DownloadEntry.DownloadedState.DOWNLOADING
+            if (null == de
+                    || de.downloaded == DownloadEntry.DownloadedState.DOWNLOADING
                     || de.downloaded == DownloadEntry.DownloadedState.DOWNLOADED
                     || de.isVideoForWebOnly) {
                 continue;
             } else {
                 downloadSize = downloadSize
-                        + v.getSize();
+                        + de.getSize();
                 downloadList.add(de);
                 downloadCount++;
             }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -170,7 +170,7 @@ public class CourseOutlineFragment extends MyVideosBaseFragment {
             adapter = new CourseOutlineAdapter(getActivity(), environment.getDatabase(),
                     environment.getStorage(), new CourseOutlineAdapter.DownloadListener() {
                 @Override
-                public void download(List<HasDownloadEntry> models) {
+                public void download(List<? extends HasDownloadEntry> models) {
                     CourseOutlineActivity activity = (CourseOutlineActivity) getActivity();
                     if (NetworkUtil.verifyDownloadPossible(activity)) {
                         downloadManager.downloadVideos(models, getActivity(),

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.java
@@ -4,8 +4,10 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 
 import org.edx.mobile.R;
+import org.edx.mobile.model.course.BlockType;
 import org.edx.mobile.model.course.CourseComponent;
 import org.edx.mobile.services.ViewPagerDownloadManager;
 import org.edx.mobile.util.BrowserUtil;
@@ -13,7 +15,7 @@ import org.edx.mobile.util.BrowserUtil;
 /**
  *
  */
-public class CourseUnitMobileNotSupportedFragment extends CourseUnitFragment{
+public class CourseUnitMobileNotSupportedFragment extends CourseUnitFragment {
 
     /**
      * Create a new instance of fragment
@@ -45,6 +47,8 @@ public class CourseUnitMobileNotSupportedFragment extends CourseUnitFragment{
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_course_unit_grade, container, false);
+        ((TextView) v.findViewById(R.id.not_available_message)).setText(
+                unit.getType() == BlockType.VIDEO ? R.string.video_only_on_web_short : R.string.assessment_not_available);
         v.findViewById(R.id.view_on_web_button).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -59,7 +63,7 @@ public class CourseUnitMobileNotSupportedFragment extends CourseUnitFragment{
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        if (ViewPagerDownloadManager.instance.inInitialPhase(unit) )
+        if (ViewPagerDownloadManager.instance.inInitialPhase(unit))
             ViewPagerDownloadManager.instance.addTask(this);
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -291,7 +291,7 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements 
             CourseComponent unit = getUnit(pos);
             CourseUnitFragment unitFragment;
             //FIXME - for the video, let's ignore studentViewMultiDevice for now
-            if (unit instanceof VideoBlockModel) {
+            if (unit instanceof VideoBlockModel && ((VideoBlockModel)unit).getData().encodedVideos.getPreferredVideoInfo() != null) {
                 unitFragment = CourseUnitVideoFragment.newInstance((VideoBlockModel) unit);
             } else if (!unit.isMultiDevice()) {
                 unitFragment = CourseUnitMobileNotSupportedFragment.newInstance(unit);

--- a/VideoLocker/src/test/java/org/edx/mobile/test/http/ApiTests.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/http/ApiTests.java
@@ -14,6 +14,7 @@ import org.edx.mobile.model.course.BlockType;
 import org.edx.mobile.model.course.CourseComponent;
 import org.edx.mobile.model.course.HasDownloadEntry;
 import org.edx.mobile.model.course.IBlock;
+import org.edx.mobile.model.course.VideoBlockModel;
 import org.edx.mobile.module.registration.model.RegistrationDescription;
 import org.junit.Test;
 
@@ -283,7 +284,7 @@ public class ApiTests extends HttpBaseTestCase {
         assertSame(courseComponent,
                 courseComponent.getAncestor(EnumSet.of(blockType)));
 
-        List<HasDownloadEntry> videos = courseComponent.getVideos();
+        List<VideoBlockModel> videos = courseComponent.getVideos();
         assertNotNull(videos);
         for (HasDownloadEntry video : videos) {
             assertNotNull(video);


### PR DESCRIPTION
Some videos cannot be played in the app.

Current behaviour:
- The app displays a download button (clicking it has no effect)
- If you try to play it you see a generic "video unavailable" error.

New behaviour:
- No download button will be displayed for these videos.
- If you try to view it, you will see the same "This X isn't yet available on mobile" message as for any other web-only component.
(I tweaked the text to say "This video" instead of "This interactive component" when type == VIDEO)

https://openedx.atlassian.net/browse/MA-1979