### PR TITLE
Fix crash on My Videos module

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyVideosTabActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyVideosTabActivity.java
@@ -313,6 +313,7 @@ public class MyVideosTabActivity extends PlayerActivity implements VideoListCall
             FragmentTransaction ft            =   manager.beginTransaction();
             ft.replace(android.R.id.tabcontent, fragment, tag);
             ft.commit();
+            manager.executePendingTransactions();
             invalidateOptionsMenu();
         } catch(Exception ex) {
             logger.error(ex);


### PR DESCRIPTION
`MyVideosTabActivity` uses manual logic to associate Fragments with `TabHost` tabs in it's tab change listener. However, since the Fragment transactions are performed asynchronously, it can get into an
inconsistent state when tabs are switched fast, causing it to crash. This is now fixed by having all transactions performed synchronously.

Fixes https://openedx.atlassian.net/browse/MA-1963.