### PR TITLE
Fix issues in DownloadListActivity

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/model/download/NativeDownloadModel.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/model/download/NativeDownloadModel.java
@@ -14,6 +14,9 @@ public class NativeDownloadModel {
     public long dmid;
 
     public int getPercent() {
+        if (0 == size) {
+            return 0; // Prevent division-by-zero
+        }
         int p = (int) (100 * downloaded / size);
         return p;
     }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/DataCallback.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/DataCallback.java
@@ -71,4 +71,17 @@ public abstract class DataCallback<T> implements IDbCallback<T> {
             Looper.loop();
         }
     }
+
+
+    /**
+     * Callback that gets invoked when database operation returns result.
+     * @param result
+     */
+    public abstract void onResult(T result);
+
+    /**
+     * Callback that gets invoked when database operation fails.
+     * @param ex
+     */
+    public abstract void onFail(Exception ex);
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/IDbCallback.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/IDbCallback.java
@@ -7,7 +7,7 @@ package org.edx.mobile.module.db;
  *
  * @param <T> T - Result object type when database operation succeeds.
  */
-interface IDbCallback<T> {
+public interface IDbCallback<T> {
     
     /**
      * Queue processor calls this method. This method call onResult method.
@@ -22,16 +22,4 @@ interface IDbCallback<T> {
      * @param ex
      */
     void sendException(Exception ex);
-    
-    /**
-     * Callback that gets invoked when database operation returns result.
-     * @param result
-     */
-    void onResult(T result);
-    
-    /**
-     * Callback that gets invoked when database operation fails.
-     * @param ex
-     */
-    void onFail(Exception ex);
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/db/ObservableDataCallback.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/db/ObservableDataCallback.java
@@ -1,0 +1,31 @@
+package org.edx.mobile.module.db;
+
+import android.support.annotation.Nullable;
+
+public class ObservableDataCallback<T> extends DataCallback<T> {
+
+    @Nullable
+    IDbCallback<T> observer;
+
+    public ObservableDataCallback() {
+        super(true);
+    }
+
+    @Override
+    public void onResult(T result) {
+        if (null != observer) {
+            observer.sendResult(result);
+        }
+    }
+
+    @Override
+    public void onFail(Exception ex) {
+        if (null != observer) {
+            observer.sendException(ex);
+        }
+    }
+
+    public void setObserver(@Nullable IDbCallback<T> observer) {
+        this.observer = observer;
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DownloadListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DownloadListActivity.java
@@ -2,6 +2,8 @@ package org.edx.mobile.view;
 
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.view.View;
 import android.widget.ListView;
 
@@ -9,17 +11,31 @@ import org.edx.mobile.R;
 import org.edx.mobile.base.BaseFragmentActivity;
 import org.edx.mobile.model.VideoModel;
 import org.edx.mobile.model.db.DownloadEntry;
+import org.edx.mobile.model.download.NativeDownloadModel;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.db.DataCallback;
+import org.edx.mobile.module.db.IDbCallback;
+import org.edx.mobile.module.db.ObservableDataCallback;
 import org.edx.mobile.view.adapters.DownloadEntryAdapter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class DownloadListActivity extends BaseFragmentActivity {
 
+    public static int REFRESH_INTERVAL_IN_MILLISECONDS = 3000;
+
+    @Nullable
     private DownloadEntryAdapter adapter;
+
+    @Nullable
     private View offlineBar;
-    private Handler handler = new Handler();
+
+    @NonNull
+    private final Handler handler = new Handler();
+
+    @NonNull
+    private final ObservableDataCallback<List<DownloadEntryAdapter.Item>> observable = new ObservableDataCallback<>();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -31,18 +47,17 @@ public class DownloadListActivity extends BaseFragmentActivity {
         offlineBar = findViewById(R.id.offline_bar);
 
         adapter = new DownloadEntryAdapter(this, environment) {
-
             @Override
-            public void onItemClicked(DownloadEntry model) {
+            public void onItemClicked(DownloadEntryAdapter.Item model) {
                 // nothing to do here
             }
 
             @Override
-            public void onDeleteClicked(DownloadEntry model) {
-                if (environment.getStorage().removeDownload(model) >= 1) {
-                    // update the list data as one download is removed
-                    adapter.remove(model);
-                    adapter.notifyDataSetChanged();
+            public void onDeleteClicked(DownloadEntryAdapter.Item item) {
+                assert adapter != null;
+                final VideoModel videoModel = ((DownloadItem) item).model;
+                if (environment.getStorage().removeDownload(videoModel) >= 1) {
+                    adapter.remove(item);
                 }
             }
         };
@@ -50,54 +65,123 @@ public class DownloadListActivity extends BaseFragmentActivity {
         downloadListView.setAdapter(adapter);
     }
 
-    private void observeOngoingDownloads() {
-        environment.getDatabase().getListOfOngoingDownloads(new DataCallback<List<VideoModel>>() {
-            @Override
-            public void onResult(final List<VideoModel> result) {
-                if (result != null) {
-                    handler.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            adapter.setItems((List) result);
-                        }
-                    });
-                }
-            }
-
-            @Override
-            public void onFail(Exception ex) {
-                logger.error(ex);
-            }
-        });
-        handler.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                observeOngoingDownloads();
-            }
-        }, 3000);
-    }
-
     @Override
     protected void onResume() {
         super.onResume();
-        observeOngoingDownloads();
+        observable.setObserver(new IDbCallback<List<DownloadEntryAdapter.Item>>() {
+            @Override
+            public void sendResult(List<DownloadEntryAdapter.Item> result) {
+                if (result != null) {
+                    adapter.setItems(result);
+                }
+                fetchOngoingDownloadsAfterDelay();
+            }
+
+            @Override
+            public void sendException(Exception ex) {
+                logger.error(ex);
+                fetchOngoingDownloadsAfterDelay();
+            }
+
+            private void fetchOngoingDownloadsAfterDelay() {
+                handler.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        fetchOngoingDownloads();
+                    }
+                }, REFRESH_INTERVAL_IN_MILLISECONDS);
+            }
+        });
+        fetchOngoingDownloads();
     }
 
     @Override
     protected void onPause() {
         super.onPause();
+        observable.setObserver(null);
         handler.removeCallbacksAndMessages(null);
     }
 
     @Override
     protected void onOffline() {
         super.onOffline();
+        assert offlineBar != null;
         offlineBar.setVisibility(View.VISIBLE);
     }
 
     @Override
     protected void onOnline() {
         super.onOnline();
+        assert offlineBar != null;
         offlineBar.setVisibility(View.GONE);
+    }
+
+    private void fetchOngoingDownloads() {
+        environment.getDatabase().getListOfOngoingDownloads(new DataCallback<List<VideoModel>>(false) {
+            @Override
+            public void onResult(List<VideoModel> result) {
+                final List<DownloadEntryAdapter.Item> downloadItems = new ArrayList<>(result.size());
+                for (VideoModel model : result) {
+                    final DownloadEntry downloadEntry = (DownloadEntry) model;
+                    final NativeDownloadModel nativeModel = environment.getStorage().getNativeDownload(downloadEntry.dmId);
+                    if (null != nativeModel) {
+                        downloadItems.add(new DownloadItem(downloadEntry, nativeModel));
+                    }
+                }
+                observable.sendResult(downloadItems);
+            }
+
+            @Override
+            public void onFail(Exception ex) {
+                observable.sendException(ex);
+            }
+        });
+    }
+
+    private static class DownloadItem implements DownloadEntryAdapter.Item {
+
+        @NonNull
+        private final DownloadEntry model;
+
+        @NonNull
+        private final NativeDownloadModel nativeModel;
+
+        public DownloadItem(@NonNull DownloadEntry model, @NonNull NativeDownloadModel nativeModel) {
+            this.model = model;
+            this.nativeModel = nativeModel;
+        }
+
+        @Override
+        public long getSize() {
+            if (model.size == 0) {
+                return nativeModel.size;
+            }
+            return model.size;
+        }
+
+        @Override
+        public String getTitle() {
+            return model.getTitle();
+        }
+
+        @Override
+        public String getDuration() {
+            return model.getDurationReadable();
+        }
+
+        @Override
+        public String getDownloaded() {
+            return nativeModel.getDownloaded();
+        }
+
+        @Override
+        public int getStatus() {
+            return nativeModel.status;
+        }
+
+        @Override
+        public int getPercent() {
+            return nativeModel.getPercent();
+        }
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DownloadEntryAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DownloadEntryAdapter.java
@@ -2,6 +2,7 @@ package org.edx.mobile.view.adapters;
 
 import android.app.DownloadManager;
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.AdapterView;
@@ -11,100 +12,100 @@ import android.widget.TextView;
 
 import org.edx.mobile.R;
 import org.edx.mobile.core.IEdxEnvironment;
-import org.edx.mobile.model.db.DownloadEntry;
-import org.edx.mobile.model.download.NativeDownloadModel;
-import org.edx.mobile.module.storage.IStorage;
 import org.edx.mobile.util.MemoryUtil;
 
-public abstract class DownloadEntryAdapter extends BaseListAdapter<DownloadEntry> {
-
-    private IStorage storage;
+public abstract class DownloadEntryAdapter extends BaseListAdapter<DownloadEntryAdapter.Item> {
 
     public DownloadEntryAdapter(Context context, IEdxEnvironment environment) {
         super(context, R.layout.row_download_list, environment);
-        this.storage = environment.getStorage();
-    }   
-    
+    }
+
     @Override
-    public void render(BaseViewHolder tag, final DownloadEntry model) {
+    public void render(BaseViewHolder tag, final DownloadEntryAdapter.Item item) {
         ViewHolder holder = (ViewHolder) tag;
 
-        NativeDownloadModel nativeModel = storage.getNativeDownload(model.dmId);
+        holder.title.setText(item.getTitle());
+        holder.duration.setText(item.getDuration());
+        holder.percent.setText(item.getDownloaded() + " / "
+                + MemoryUtil.format(getContext(), item.getSize()));
 
-        holder.title.setText(model.getTitle());
-        holder.duration.setText(model.getDurationReadable());
-        if (nativeModel != null) {
-            if(model.size == 0){
-                holder.percent.setText(nativeModel.getDownloaded() + " / "
-                        + nativeModel.getSize());
-            }else{
-                holder.percent.setText(nativeModel.getDownloaded() + " / "
-                        + MemoryUtil.format(getContext(), model.size));
-            }
+        holder.progress.setProgress(item.getPercent());
+        if (item.getStatus() == DownloadManager.STATUS_FAILED) {
+            holder.error.setVisibility(View.VISIBLE);
+            holder.error.setTag(item);
+            holder.error.setText(getContext()
+                    .getString(R.string.error_download_failed));
 
-            holder.progress.setProgress(nativeModel.getPercent());
-            if (nativeModel.status == DownloadManager.STATUS_FAILED) {
-                holder.error.setVisibility(View.VISIBLE);
-                holder.error.setTag(model);
-                holder.error.setText(getContext()
-                        .getString(R.string.error_download_failed));
+            holder.progress.setProgressDrawable(getContext().getResources()
+                    .getDrawable(
+                            R.drawable.custom_progress_bar_horizontal_red));
+        } else {
+            holder.error.setVisibility(View.GONE);
 
-                holder.progress.setProgressDrawable(getContext().getResources()
-                        .getDrawable(
-                                R.drawable.custom_progress_bar_horizontal_red));
-            } else {
-                holder.error.setVisibility(View.GONE);
-
-                holder.progress
-                .setProgressDrawable(getContext()
-                        .getResources()
-                        .getDrawable(
-                                R.drawable.custom_progress_bar_horizontal_green));
-            }
+            holder.progress
+                    .setProgressDrawable(getContext()
+                            .getResources()
+                            .getDrawable(
+                                    R.drawable.custom_progress_bar_horizontal_green));
         }
 
         holder.cross_image_layout.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                onDeleteClicked(model);
+                onDeleteClicked(item);
             }
         });
     }
 
     @Override
     public BaseViewHolder getTag(View convertView) {
-        ViewHolder holder = new ViewHolder();
-        holder.title = (TextView) convertView.findViewById(R.id.downloads_name);
-        holder.duration = (TextView) convertView
-                .findViewById(R.id.download_time);
-        holder.percent = (TextView) convertView
-                .findViewById(R.id.download_percentage);
-        holder.error = (TextView) convertView
-                .findViewById(R.id.txtDownloadFailed);
-        holder.progress = (ProgressBar) convertView
-                .findViewById(R.id.progressBar);
-        holder.cross_image_layout = (LinearLayout) convertView
-                .findViewById(R.id.close_btn_layout);
-        
-
-        return holder;
+        return new ViewHolder(convertView);
     }
 
     private static class ViewHolder extends BaseViewHolder {
-        TextView title;
-        TextView duration;
-        TextView percent;
-        LinearLayout cross_image_layout;
-        TextView error;
-        ProgressBar progress;
+        final TextView title;
+        final TextView duration;
+        final TextView percent;
+        final LinearLayout cross_image_layout;
+        final TextView error;
+        final ProgressBar progress;
+
+        public ViewHolder(@NonNull View view) {
+            title = (TextView) view.findViewById(R.id.downloads_name);
+            duration = (TextView) view
+                    .findViewById(R.id.download_time);
+            percent = (TextView) view
+                    .findViewById(R.id.download_percentage);
+            error = (TextView) view
+                    .findViewById(R.id.txtDownloadFailed);
+            progress = (ProgressBar) view
+                    .findViewById(R.id.progressBar);
+            cross_image_layout = (LinearLayout) view
+                    .findViewById(R.id.close_btn_layout);
+        }
     }
 
     @Override
     public void onItemClick(AdapterView<?> arg0, View arg1, int position, long arg3) {
-        DownloadEntry model = getItem(position);
-        if(model!=null) onItemClicked(model);
+        DownloadEntryAdapter.Item item = getItem(position);
+        if (item != null) onItemClicked(item);
     }
 
-    public abstract void onItemClicked(DownloadEntry model);
-    public abstract void onDeleteClicked(DownloadEntry model);
+    public abstract void onItemClicked(DownloadEntryAdapter.Item model);
+
+    public abstract void onDeleteClicked(DownloadEntryAdapter.Item model);
+
+    public interface Item {
+        long getSize();
+
+        String getTitle();
+
+        String getDuration();
+
+        String getDownloaded();
+
+        int getStatus();
+
+        int getPercent();
+    }
 }


### PR DESCRIPTION
Re-opening of https://github.com/edx/edx-app-android/pull/547 which was merged prematurely

Additional changes:
- refreshes occur sequentially
- database access moved to background thread
- safeguard against division-by-zero
- observer pattern to prevent leaking activity

Cleanup:
- removed all business logic from adapter
- moved DataCallback onResult/onFail methods into implementation; the interface does not need them.