### PR TITLE
Show "Download pending..." until download has started

### DIFF
--- a/VideoLocker/res/values/errors.xml
+++ b/VideoLocker/res/values/errors.xml
@@ -40,7 +40,7 @@
     
     <!-- Download error messages -->
     <!-- Label shown on video list item whose download failed -->
-    <string name="error_download_failed">Download Failed</string>
+    <string name="error_download_failed">Download failed</string>
     <!-- Confirmation message shown when attempting to download a large quantity of video data -->
     <string name="file_size_exceeded">The size of the download exceeds the remaining device storage space.</string>
     <!-- Confirmation message shown when attempting to download a large quantity of video data -->

--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -468,6 +468,8 @@
     <string name="video_download_in_progress">Video Downloads in Progress</string>
     <!-- Message shown a single video download begins -->
     <string name="msg_started_one_video_download">"Downloading 1 Video"</string>
+    <!-- When a video download is about to start and we don't know it's file size yet -->
+    <string name="download_pending">Download pending…</string>
     <!-- Error shown when video download fails -->
     <string name="msg_video_not_downloaded">"Unable to download video"</string>
     <!-- Error shown when video download fails -->

--- a/VideoLocker/src/main/java/org/edx/mobile/model/download/NativeDownloadModel.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/model/download/NativeDownloadModel.java
@@ -2,57 +2,22 @@ package org.edx.mobile.model.download;
 
 /**
  * This class represents a download in the native DownloadManager service.
- * @author rohan
- *
  */
 public class NativeDownloadModel {
 
     public long downloaded;
-    public long size;
+    public long size; // size might be -1 if download has not yet started, or 0 if it has failed
     public String filepath;
     public int status;
     public long dmid;
 
-    public int getPercent() {
-        if (0 == size) {
+    public int getPercentDownloaded() {
+        if (size <= 0) {
             return 0; // Prevent division-by-zero
         }
-        int p = (int) (100 * downloaded / size);
-        return p;
+        return (int) (100 * downloaded / size);
     }
-    
-    /**
-     * Returns size in MB.
-     * @return
-     */
-    public String getSize() {
-        return getMemorySize(size);
-    }
-    
-    /**
-     * Returns size of downloaded bytes in MB.
-     * @return
-     */
-    public String getDownloaded() {
-        return getMemorySize(downloaded);
-    }
-    
-    private String getMemorySize(long bytes) {
-        if (bytes == 0) {
-            return "0KB";
-        }
-        
-        long s = bytes;
-        int gb = (int) (s / (1024f * 1024f * 1024f) );
-        s = s % (1024 * 1024 * 1024) ;
-        int mb = (int) (s / (1024f * 1024f) );
-        s = s % (1024 * 1024) ;
-        int kb = (int) (s / 1024f);
-        int b = (int) (s % 1024);
-        
-        return String.format("%d MB", mb);
-    }
-    
+
     @Override
     public String toString() {
         return String.format("downloaded=%d, size=%d, path=%s", downloaded, size, filepath);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DownloadListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DownloadListActivity.java
@@ -1,5 +1,6 @@
 package org.edx.mobile.view;
 
+import android.app.DownloadManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
@@ -152,36 +153,50 @@ public class DownloadListActivity extends BaseFragmentActivity {
         }
 
         @Override
-        public long getSize() {
-            if (model.size == 0) {
+        @Nullable
+        public Long getTotalByteCount() {
+            if (model.size <= 0) {
+                if (nativeModel.size <= 0) {
+                    return null; // Size not known
+                }
                 return nativeModel.size;
             }
             return model.size;
         }
 
         @Override
+        @NonNull
         public String getTitle() {
             return model.getTitle();
         }
 
         @Override
+        @NonNull
         public String getDuration() {
             return model.getDurationReadable();
         }
 
         @Override
-        public String getDownloaded() {
-            return nativeModel.getDownloaded();
+        public long getDownloadedByteCount() {
+            return nativeModel.downloaded;
         }
 
         @Override
-        public int getStatus() {
-            return nativeModel.status;
+        @NonNull
+        public Status getStatus() {
+            if (nativeModel.status == DownloadManager.STATUS_FAILED) {
+                return Status.FAILED;
+            }
+            if (nativeModel.status == DownloadManager.STATUS_PENDING
+                    || nativeModel.size == -1) {
+                return Status.PENDING;
+            }
+            return Status.DOWNLOADING;
         }
 
         @Override
         public int getPercent() {
-            return nativeModel.getPercent();
+            return nativeModel.getPercentDownloaded();
         }
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/OnlineVideoAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/OnlineVideoAdapter.java
@@ -70,7 +70,7 @@ public abstract class OnlineVideoAdapter extends VideoBaseAdapter<SectionItemInt
                     NativeDownloadModel downloadModel = storage.
                             getNativeDownload(videoData.dmId);
                     if(downloadModel!=null){
-                        int percent = downloadModel.getPercent();
+                        int percent = downloadModel.getPercentDownloaded();
                         if(percent>=0 && percent < 100){
                             holder.progresslayout.setVisibility(View.VISIBLE);
                             holder.download_pw.setProgressPercent(percent);


### PR DESCRIPTION
Fixes https://openedx.atlassian.net/browse/MA-1984

- We'll show "Download pending..." Until the download either starts or fails.
- We now use the same method consistently for formatting file sizes
- We'll still show the downloaded byte count even if the size is unknown

![screenshot_2016-01-26-20-28-26](https://cloud.githubusercontent.com/assets/1685613/12601461/31733074-c46f-11e5-9dcb-aae279205c72.png)
![screenshot_2016-01-26-20-51-06](https://cloud.githubusercontent.com/assets/1685613/12601460/316ffdbe-c46f-11e5-8cf1-2609012fd89b.png)

