### PR TITLE
Fix video player callback not being re-registered

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyVideosTabActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyVideosTabActivity.java
@@ -79,6 +79,7 @@ public class MyVideosTabActivity extends PlayerActivity implements VideoListCall
         // Wait until MyRecentVideosFragment.onResume() has been called so that its adapter has been filled
         // Wait until PlayerFragment.onActivityCreated has been called, so PlayerFragment.player != null
         if (null != playerFragment && null != recentVideosFragment) {
+            playerFragment.setCallback(this);
             playerFragment.setNextPreviousListeners(recentVideosFragment.getNextListener(),
                     recentVideosFragment.getPreviousListener());
         }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/VideoListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/VideoListActivity.java
@@ -79,6 +79,7 @@ public class VideoListActivity extends BaseVideosDownloadStateActivity
         super.onPostCreate(savedInstanceState);
         // Wait until PlayerFragment.onActivityCreated() is called, so that PlayerFragment.player != null
         // Wait until VideoListFragment.onActivityCreated() is called, so that VideoListFragment.adapter has been filled
+        playerFragment.setCallback(this);
         playerFragment.setNextPreviousListeners(listFragment.getNextListener(), listFragment.getPreviousListener());
     }
 
@@ -86,10 +87,6 @@ public class VideoListActivity extends BaseVideosDownloadStateActivity
     protected void onResume() {
         super.onResume();
         try{
-            if (playerFragment != null) {
-                playerFragment.setCallback(this);
-            }
-
             View container = findViewById(R.id.container_player);
             if (container == null || container.getVisibility() != View.VISIBLE) {
                 // this is to lock to portrait while player is invisible


### PR DESCRIPTION
#544 fixed the issue of the listeners for the next and previous buttons not being re-registered upon Activity restart in the videos module. However, the media player state change callback is still not being re-registered in the 'recent videos' module, causing database updates to not be performed after activity restarts. This commit fixes the oversight by registering it as well in the `onPostCreate()` callback for both tabs (it was previously being done in the `onResume()` callback of `VideoListActivity` i.e. the 'all videos' tab).

Fixes https://openedx.atlassian.net/browse/MA-1990