### PR TITLE
Allow state loss in CourseOutlineFragment addition

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineActivity.java
@@ -67,7 +67,7 @@ public class CourseOutlineActivity extends CourseVideoListActivity {
             FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
             fragmentTransaction.add(R.id.fragment_container, fragment, CourseOutlineFragment.TAG);
             fragmentTransaction.disallowAddToBackStack();
-            fragmentTransaction.commit();
+            fragmentTransaction.commitAllowingStateLoss();
         }
 
         if (isOnCourseOutline()) {


### PR DESCRIPTION
`CourseOutlineActivity` adds `CourseOutlineFragment` to it's layout after loading the course components. Since this is done asynchronously, the exact state is not certain at that time (since the callback method invocation only guarantees that the Activity has not yet been destroyed). This can cause the Fragment state to be lost if the state has already been saved at this time (which can be done at any point), at which point the `FragmentManager` will throw an `IllegalStateException` to complain about this issue. This commit changes the transaction to allow state loss to avoid the exception.

Fixes [MA-2003][].

[MA-2003]: https://openedx.atlassian.net/browse/MA-2003