### PR TITLE
Fixes crash on navigation of parent topic

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTopic.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTopic.java
@@ -17,6 +17,7 @@
 package org.edx.mobile.discussion;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.google.gson.annotations.SerializedName;
@@ -34,6 +35,14 @@ public class DiscussionTopic implements Serializable {
     String threadListUrl = "";
     List<DiscussionTopic> children = new ArrayList<>();
 
+    /**
+     * Returns the identifier for a discussion topic.
+     * <br>
+     * NOTE: The identifier for a parent topic is always null.
+     *
+     * @return The identifier for a discussion topic.
+     */
+    @Nullable
     public String getIdentifier() {
         return identifier;
     }
@@ -67,7 +76,7 @@ public class DiscussionTopic implements Serializable {
     }
 
     public boolean hasSameId(@NonNull DiscussionTopic discussionTopic) {
-        return discussionTopic.getIdentifier().equals(identifier);
+        return identifier != null && identifier.equals(discussionTopic.getIdentifier());
     }
 
     public boolean containsThread(@NonNull DiscussionThread discussionThread) {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsActivity.java
@@ -68,7 +68,7 @@ public class CourseDiscussionPostsActivity extends BaseSingleFragmentActivity  {
         }
 
         if (discussionTopic != null && discussionTopic.getName() != null) {
-            if (discussionTopic.getIdentifier().equals(DiscussionTopic.FOLLOWING_TOPICS_ID)) {
+            if (DiscussionTopic.FOLLOWING_TOPICS_ID.equals(discussionTopic.getIdentifier())) {
                 SpannableString title = new SpannableString("   " + discussionTopic.getName());
                 IconDrawable starIcon = new IconDrawable(this, FontAwesomeIcons.fa_star)
                         .colorRes(this, R.color.edx_grayscale_neutral_white_t)


### PR DESCRIPTION
Crash was introduced in [here](https://github.com/edx/edx-app-android/commit/bd6ae85604930a35dead0efa43127404a0d8bcfc#diff-ad2c66471884d7415a8775d55d50c04eR71), where we check equality based on
identifier of a topic. This identifier is null incase of parent topics,
causing the crash.

@1zaman @bguertin @BenjiLee plz review