### PR TITLE
Don't hold implicit reference to activity from loader

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/loader/CoursesAsyncLoader.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/loader/CoursesAsyncLoader.java
@@ -26,7 +26,6 @@ public class CoursesAsyncLoader extends AsyncTaskLoader<AsyncTaskResult<List<Enr
     ServiceManager api;
 
     public CoursesAsyncLoader(Context context, Bundle args, IEdxEnvironment environment,  ServiceManager api){
-
         super(context);
         this.environment = environment;
         this.api = api;
@@ -39,7 +38,6 @@ public class CoursesAsyncLoader extends AsyncTaskLoader<AsyncTaskResult<List<Enr
     @Override
     public AsyncTaskResult<List<EnrolledCoursesResponse>> loadInBackground() {
 
-
         // FIXME: (PR#120) Should this Loader class really be called when social feature is disabled?
         if (environment.getConfig().getSocialSharingConfig().isEnabled() && this.oauthToken == null) {
             return null;
@@ -47,22 +45,15 @@ public class CoursesAsyncLoader extends AsyncTaskLoader<AsyncTaskResult<List<Enr
 
         AsyncTaskResult<List<EnrolledCoursesResponse>> result = new AsyncTaskResult<List<EnrolledCoursesResponse>>();
         try {
-
-            List<EnrolledCoursesResponse> list = getCourses(api);
-            result.setResult(list);
+            List<EnrolledCoursesResponse> response = api.getEnrolledCourses();
+            environment.getNotificationDelegate().syncWithServerForFailure();
+            environment.getNotificationDelegate().checkCourseEnrollment(response);
+            result.setResult(response);
 
         } catch (Exception e) {
-
             result.setEx(e);
-
         }
         return result;
-
-    }
-
-    protected List<EnrolledCoursesResponse> getCourses(ServiceManager api) throws Exception {
-       // return api.getFriendsCourses(false, this.oauthToken); ?
-        return api.getEnrolledCourses(false);
     }
 
     @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyCourseListTabFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyCourseListTabFragment.java
@@ -77,15 +77,7 @@ public class MyCourseListTabFragment extends CourseListTabFragment {
 
     @Override
     public Loader<AsyncTaskResult<List<EnrolledCoursesResponse>>> onCreateLoader(int i, Bundle bundle) {
-        return new CoursesAsyncLoader(getActivity(), bundle, environment, environment.getServiceManager()) {
-            @Override
-            protected List<EnrolledCoursesResponse> getCourses(ServiceManager api) throws Exception {
-                List<EnrolledCoursesResponse> response = api.getEnrolledCourses();
-                environment.getNotificationDelegate().syncWithServerForFailure();
-                environment.getNotificationDelegate().checkCourseEnrollment(response);
-                return response;
-            }
-        };
+        return new CoursesAsyncLoader(getActivity(), bundle, environment, environment.getServiceManager());
     }
 
     @Override


### PR DESCRIPTION
MyCourseListTabFragment creates an anonymous implementation of CoursesAsyncLoader, which will reference the fragment, which in turn references the ListView and adapter, and so both will survive, as well as the activity instance itself, even after the activity destroyed.

Fixed by inlining overridden method in the loader, since it is only used in this one place, thus we no longer need an anonymous implementation.