### PR TITLE
Clean up WebView usage in CourseUnitWebviewFragment

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
@@ -56,9 +56,27 @@ public abstract class FindCoursesBaseActivity extends BaseFragmentActivity imple
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        webview.onResume();
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        webview.onPause();
+    }
+
+    @Override
     protected void onDestroy() {
         super.onDestroy();
         disableEnrollCallback();
+    }
+
+    @Override
+    public void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        webview.destroy();
     }
 
     protected boolean isWebViewLoaded() {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CertificateFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CertificateFragment.java
@@ -123,4 +123,22 @@ public class CertificateFragment extends BaseFragment {
 
         webview.loadUrl(courseData.getCertificateURL());
     }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        webview.onResume();
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        webview.onPause();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        webview.destroy();
+    }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitFragment.java
@@ -11,12 +11,8 @@ import org.edx.mobile.view.common.RunnableCourseComponent;
 
 import org.edx.mobile.base.BaseFragment;
 
-/**
- * Created by hanning on 6/9/15.
- */
-public class CourseUnitFragment  extends BaseFragment implements PageViewStateCallback, RunnableCourseComponent {
-
-    public static interface HasComponent {
+public abstract class CourseUnitFragment extends BaseFragment implements PageViewStateCallback, RunnableCourseComponent {
+    public interface HasComponent {
         CourseComponent getComponent();
     }
 
@@ -30,7 +26,7 @@ public class CourseUnitFragment  extends BaseFragment implements PageViewStateCa
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         unit = getArguments() == null ? null :
-            (CourseComponent) getArguments().getSerializable(Router.EXTRA_COURSE_UNIT);
+                (CourseComponent) getArguments().getSerializable(Router.EXTRA_COURSE_UNIT);
     }
 
     @Override
@@ -49,11 +45,9 @@ public class CourseUnitFragment  extends BaseFragment implements PageViewStateCa
     }
 
     @Override
-    public void run() {
+    public abstract void run();
 
-    }
-
-    public void setHasComponentCallback(HasComponent callback){
+    public void setHasComponentCallback(HasComponent callback) {
         hasComponentCallback = callback;
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -25,7 +25,6 @@ import org.edx.mobile.model.course.VideoBlockModel;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.services.ViewPagerDownloadManager;
-import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.view.common.PageViewStateCallback;
 import org.edx.mobile.view.custom.DisableableViewPager;
 
@@ -302,7 +301,7 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements 
                     unit.getType() != BlockType.PROBLEM) {
                 unitFragment = CourseUnitEmptyFragment.newInstance(unit);
             } else if (unit instanceof HtmlBlockModel) {
-                unitFragment = CourseUnitWebviewFragment.newInstance((HtmlBlockModel) unit);
+                unitFragment = CourseUnitWebViewFragment.newInstance((HtmlBlockModel) unit);
             }
             //fallback
             else {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/dialog/WebViewDialogFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/dialog/WebViewDialogFragment.java
@@ -22,6 +22,8 @@ public class WebViewDialogFragment extends AppCompatDialogFragment {
     private static final String ARG_URL = "url";
     private static final String ARG_TITLE = "title";
 
+    WebView webView;
+
     public static WebViewDialogFragment newInstance(@NonNull String url, @Nullable String title) {
         final Bundle args = new Bundle();
         args.putString(ARG_URL, url);
@@ -48,7 +50,7 @@ public class WebViewDialogFragment extends AppCompatDialogFragment {
         final ProgressBar progress = (ProgressBar) view.findViewById(R.id.loading_indicator);
         progress.setVisibility(View.GONE);
 
-        final WebView webView = (WebView) view.findViewById(R.id.eula_webView);
+        webView = (WebView) view.findViewById(R.id.eula_webView);
         final URLInterceptorWebViewClient client =
                 new URLInterceptorWebViewClient(getActivity(), webView);
         client.setPageStatusListener(new URLInterceptorWebViewClient.IPageStatusListener() {
@@ -99,5 +101,24 @@ public class WebViewDialogFragment extends AppCompatDialogFragment {
         });
 
         return view;
+    }
+
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        webView.onResume();
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        webView.onPause();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        webView.destroy();
     }
 }

--- a/VideoLocker/src/test/java/org/edx/mobile/view/CourseUnitNavigationActivityTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/CourseUnitNavigationActivityTest.java
@@ -248,7 +248,7 @@ public class CourseUnitNavigationActivityTest extends CourseBaseActivityTest {
                 currentUnit.getType() != BlockType.PROBLEM ) {
             fragmentClass = CourseUnitEmptyFragment.class;
         } else if (currentUnit instanceof HtmlBlockModel) {
-            fragmentClass = CourseUnitWebviewFragment.class;
+            fragmentClass = CourseUnitWebViewFragment.class;
         } else {
             fragmentClass = CourseUnitMobileNotSupportedFragment.class;
         }

--- a/VideoLocker/src/test/java/org/edx/mobile/view/CourseUnitWebViewFragmentTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/CourseUnitWebViewFragmentTest.java
@@ -19,7 +19,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 
-public class CourseUnitWebviewFragmentTest extends UiTest {
+public class CourseUnitWebViewFragmentTest extends UiTest {
     /**
      * Method for iterating through the mock course response data, and
      * returning the first video block leaf.
@@ -48,7 +48,7 @@ public class CourseUnitWebviewFragmentTest extends UiTest {
      */
     @Test
     public void initializeTest() {
-        CourseUnitWebviewFragment fragment = CourseUnitWebviewFragment.newInstance(getHtmlUnit());
+        CourseUnitWebViewFragment fragment = CourseUnitWebViewFragment.newInstance(getHtmlUnit());
         SupportFragmentTestUtil.startVisibleFragment(fragment);
         View view = fragment.getView();
         assertNotNull(view);


### PR DESCRIPTION
We're now calling WebView's onPause, onResume, and destroy() methods just as `WebViewFragment` would.

Hoping this will also fix: https://fabric.io/edx-inc/android/apps/org.edx.mobile/issues/56ab5d5bf5d3a7f76b6d68e7

Fixes: https://openedx.atlassian.net/browse/MA-1924