### PR TITLE
Endorser's label fix on endorsed response screen

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionComment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionComment.java
@@ -114,4 +114,26 @@ public class DiscussionComment implements Serializable, IAuthorData {
         return children;
     }
 
+    public IAuthorData getEndorserData() {
+        if (!endorsed) {
+            return null;
+        } else {
+            return new IAuthorData() {
+                @Override
+                public String getAuthor() {
+                    return endorsedBy;
+                }
+
+                @Override
+                public String getAuthorLabel() {
+                    return endorsedByLabel;
+                }
+
+                @Override
+                public Date getCreatedAt() {
+                    return endorsedAt;
+                }
+            };
+        }
+    }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -293,7 +293,8 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
 
         if (comment.isEndorsed()) {
             DiscussionTextUtils.setAuthorAttributionText(holder.responseAnswerAuthorTextView,
-                    R.string.answer_author_attribution, comment, new Runnable() {
+                    R.string.answer_author_attribution, comment.getEndorserData(),
+                    new Runnable() {
                         @Override
                         public void run() {
                             listener.onClickAuthor(comment.getAuthor());

--- a/VideoLocker/src/main/java/org/edx/mobile/view/view_holders/AuthorLayoutViewHolder.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/view_holders/AuthorLayoutViewHolder.java
@@ -4,8 +4,6 @@ import android.view.View;
 import android.widget.TextView;
 
 import org.edx.mobile.R;
-import org.edx.mobile.discussion.DiscussionTextUtils;
-import org.edx.mobile.discussion.IAuthorData;
 
 public class AuthorLayoutViewHolder {
 


### PR DESCRIPTION
Previously we were showing the response's author details for the endorsed response as well instead of endorser's, which was wrong.

This PR fixes that issue.

Fixes: https://openedx.atlassian.net/browse/MA-1186

Wrong | Correct
------------ | -------------
<img src="https://openedx.atlassian.net/secure/attachment/29802/Screenshot_2016-02-08-15-02-29.png" width="250" /> | <img src="https://cloud.githubusercontent.com/assets/1710804/12886431/e69d50e6-ce8e-11e5-9278-3ccd5bd693d7.png" width="250" />


quick review @1zaman @bguertin @BenjiLee 