### PR TITLE
Update screen immediately on a new response or comment

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionComment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionComment.java
@@ -111,13 +111,12 @@ public class DiscussionComment implements Serializable, IAuthorData {
         return editableFields;
     }
 
-
     public int getChildCount() {
         return childCount;
     }
 
-    public void setChildCount(int childCount) {
-        this.childCount = childCount;
+    public void incrementChildCount() {
+        childCount++;
     }
 
     public List<DiscussionComment> getChildren() {

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionComment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionComment.java
@@ -40,6 +40,7 @@ public class DiscussionComment implements Serializable, IAuthorData {
     private Date endorsedAt;
     private boolean abuseFlagged = false;
     private List<String> editableFields;
+    private int childCount = 0;
     private List<DiscussionComment> children;
 
     public String getIdentifier() {
@@ -108,6 +109,15 @@ public class DiscussionComment implements Serializable, IAuthorData {
 
     public List<String> getEditableFields() {
         return editableFields;
+    }
+
+
+    public int getChildCount() {
+        return childCount;
+    }
+
+    public void setChildCount(int childCount) {
+        this.childCount = childCount;
     }
 
     public List<DiscussionComment> getChildren() {

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionCommentPostedEvent.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionCommentPostedEvent.java
@@ -10,16 +10,27 @@ public class DiscussionCommentPostedEvent {
     @Nullable
     private final DiscussionComment parent;
 
-    public DiscussionCommentPostedEvent(@NonNull DiscussionComment comment, DiscussionComment parent) {
+    public DiscussionCommentPostedEvent(@NonNull DiscussionComment comment, @Nullable DiscussionComment parent) {
         this.comment = comment;
         this.parent = parent;
     }
 
+    /**
+     * Provides the response or the comment that was posted.
+     *
+     * @return The response or comment.
+     */
     @NonNull
     public DiscussionComment getComment() {
         return comment;
     }
 
+    /**
+     * Provides the parent of the comment that was posted.
+     * Note: The parent is always null in case of a response being posted.
+     *
+     * @return The parent of the comment if available i.e. response.
+     */
     @Nullable
     public DiscussionComment getParent() {
         return parent;

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionThread.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionThread.java
@@ -182,7 +182,9 @@ public class DiscussionThread implements Serializable, IAuthorData {
     }
 
     public void incrementCommentCount() {
-        ++this.commentCount;
+        ++commentCount;
+        ++unreadCommentCount;
+        read = false;
     }
 
     public boolean hasSameId(@NonNull DiscussionThread discussionThread) {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
@@ -13,6 +13,7 @@ import android.widget.TextView;
 import com.google.inject.Inject;
 
 import org.edx.mobile.R;
+import org.edx.mobile.base.BaseFragment;
 import org.edx.mobile.discussion.DiscussionComment;
 import org.edx.mobile.discussion.DiscussionCommentPostedEvent;
 import org.edx.mobile.discussion.DiscussionThread;
@@ -24,7 +25,6 @@ import org.edx.mobile.view.adapters.CourseDiscussionResponsesAdapter;
 import org.edx.mobile.view.adapters.InfiniteScrollUtils;
 
 import de.greenrobot.event.EventBus;
-import org.edx.mobile.base.BaseFragment;
 import roboguice.inject.InjectExtra;
 import roboguice.inject.InjectView;
 
@@ -102,9 +102,14 @@ public class CourseDiscussionResponsesFragment extends BaseFragment implements C
     public void onEventMainThread(DiscussionCommentPostedEvent event) {
         if (discussionThread.containsComment(event.getComment())) {
             discussionThread.incrementCommentCount();
-            courseDiscussionResponsesAdapter.setDiscussionThread(discussionThread);
+            if (event.getParent() == null) {
+                // We got a response
+                courseDiscussionResponsesAdapter.addNewResponse(event.getComment());
+            } else {
+                // We got a comment to a response
+                courseDiscussionResponsesAdapter.addNewComment(event.getParent());
+            }
             responsesLoader.reset();
-            controller.reset();
         }
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.support.v4.widget.TextViewCompat;
 import android.support.v7.widget.RecyclerView;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -238,17 +239,17 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
 
         holder.responseCommentBodyTextView.setText(DiscussionTextUtils.parseHtml(comment.getRenderedBody()));
 
-        if (discussionThread.isClosed() && comment.getChildren().isEmpty()) {
+        if (discussionThread.isClosed() && comment.getChildCount() == 0) {
             holder.addCommentLayout.setEnabled(false);
         } else {
             holder.addCommentLayout.setEnabled(true);
             holder.addCommentLayout.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    if (comment.getChildren().isEmpty()) {
-                        listener.onClickAddComment(comment);
-                    } else {
+                    if (comment.getChildCount() > 0) {
                         listener.onClickViewComments(comment);
+                    } else {
+                        listener.onClickAddComment(comment);
                     }
                 }
             });
@@ -352,7 +353,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
     }
 
     private void bindNumberCommentsView(NumberResponsesViewHolder holder, DiscussionComment response) {
-        int numChildren = response == null ? 0 : response.getChildren().size();
+        int numChildren = response == null ? 0 : response.getChildCount();
 
         if (numChildren == 0) {
             if (discussionThread.isClosed()) {
@@ -406,10 +407,22 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
         notifyDataSetChanged();
     }
 
-    public void setDiscussionThread(@NonNull DiscussionThread discussionThread) {
-        this.discussionThread = discussionThread;
-        this.discussionResponses.clear();
+    public void addNewResponse(@NonNull DiscussionComment response) {
+        discussionResponses.add(response);
         notifyDataSetChanged();
+    }
+
+    public void addNewComment(@NonNull DiscussionComment parent) {
+        String parentId = parent.getIdentifier();
+        if (!TextUtils.isEmpty(parentId)) {
+            for (DiscussionComment response : discussionResponses) {
+                if (parentId.equals(response.getIdentifier())) {
+                    response.setChildCount(response.getChildCount() + 1);
+                    notifyDataSetChanged();
+                    break;
+                }
+            }
+        }
     }
 
     public static class ShowMoreViewHolder extends RecyclerView.ViewHolder {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -5,7 +5,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.support.v4.widget.TextViewCompat;
 import android.support.v7.widget.RecyclerView;
-import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -414,13 +413,11 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
 
     public void addNewComment(@NonNull DiscussionComment parent) {
         String parentId = parent.getIdentifier();
-        if (!TextUtils.isEmpty(parentId)) {
-            for (DiscussionComment response : discussionResponses) {
-                if (parentId.equals(response.getIdentifier())) {
-                    response.setChildCount(response.getChildCount() + 1);
-                    notifyDataSetChanged();
-                    break;
-                }
+        for (DiscussionComment response : discussionResponses) {
+            if (parentId.equals(response.getIdentifier())) {
+                response.incrementChildCount();
+                notifyDataSetChanged();
+                break;
             }
         }
     }


### PR DESCRIPTION
- Previously responses disappeared upon adding a new one, because of the
incorrect calls to InfiniteScrollUtils functions, which is fixed in this
commit.

- Also, due to new changes to responses API, we don't get the comments
inside the children array of a response. We instead get a child_count,
depicting the number of comments on a response, which is being used now.

Ultimately fixing the responses screen to update itself properly upon
addition of a new comment as well.

fixes: https://openedx.atlassian.net/browse/MA-1729 & https://openedx.atlassian.net/browse/MA-2035

@1zaman @bguertin @BenjiLee plz review

**NOTE** : To test the addition of comments to a response, you'll need to point your build to this test server: https://wjia-dapi-cached.sandbox.edx.org
because, it includes the commit for sending `child_count` in the json of Responses API (which isn't yet merged inside the other sandboxes).