### PR TITLE
Endorsed response support for discussion threads

### DIFF
--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -260,6 +260,8 @@
     <string name="post_attribution">{time} by {author} {author_label}</string>
     <!-- The date and author of an answer to a discussion question e.g. "Marked as answer 2 days ago by Khalid TA" -->
     <string name="answer_author_attribution">Marked as answer {time} by {author} {author_label}</string>
+    <!-- The date and author of an endorsed response to a discussion thread e.g. "Endorsed 2 days ago by Khalid TA" -->
+    <string name="endorser_attribution">Endorsed {time} by {author} {author_label}</string>
     <!-- Label for the visibility of a discussion post that is only visible to cohort -->
     <string name="discussion_post_visibility_cohort">This post is visible only to {cohort}.</string>
     <!-- Label for the visibility of a discussion post that is visible to everyone -->
@@ -286,8 +288,8 @@
     <string name="number_responses_or_comments_add_comment_label">@string/discussion_add_comment_title</string>
     <!--Label for indicating that a response is an answer-->
     <string name="discussion_responses_answer">Answer</string>
-    <!--Label for indicating who endorsed the comment as an answer-->
-    <string name="discussion_responses_endorsed_author">Marked as answer {endorsed_at} by {endorsed_by_author} {endorsed_by_label}</string>
+    <!--Label for indicating that a response is endorsed-->
+    <string name="discussion_responses_endorsed">Endorsed</string>
     <!-- Label for time span when its less than a second after posting a response/comment -->
     <string name="just_now">Just now</string>
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -2,6 +2,7 @@ package org.edx.mobile.view.adapters;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
 import android.support.v4.widget.TextViewCompat;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -292,8 +293,23 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
         holder.socialLayoutViewHolder.threadFollowContainer.setVisibility(View.INVISIBLE);
 
         if (comment.isEndorsed()) {
+            DiscussionThread.ThreadType threadType = discussionThread.getType();
+            @StringRes int attributionStringRes;
+            @StringRes int endorsementTypeStringRes;
+            switch (threadType) {
+                case QUESTION:
+                    attributionStringRes = R.string.answer_author_attribution;
+                    endorsementTypeStringRes = R.string.discussion_responses_answer;
+                    break;
+                case DISCUSSION:
+                default:
+                    endorsementTypeStringRes = R.string.discussion_responses_endorsed;
+                    attributionStringRes = R.string.endorser_attribution;
+                    break;
+            }
+            holder.responseAnswerTextView.setText(endorsementTypeStringRes);
             DiscussionTextUtils.setAuthorAttributionText(holder.responseAnswerAuthorTextView,
-                    R.string.answer_author_attribution, comment.getEndorserData(),
+                    attributionStringRes, comment.getEndorserData(),
                     new Runnable() {
                         @Override
                         public void run() {


### PR DESCRIPTION
Patches: https://openedx.atlassian.net/browse/MA-1186

Answered Question | Endorsed Discussion
------------ | -------------
![answered_question](https://cloud.githubusercontent.com/assets/1710804/12946835/1e2d9d3c-d019-11e5-986a-129b5562b8e9.png) | ![endorsed_discussion](https://cloud.githubusercontent.com/assets/1710804/12946841/21fec67a-d019-11e5-9b5f-5283e653c3cd.png)

@aleffert how does it look now ? the web doesn't show any indication as `Answer` or `Endorsed`, but, we had `Answer` label incase of question, so, it seemed logical to rename it `Endorsed` in case of discussion.

@1zaman @bguertin @BenjiLee plz review
