### PR TITLE
Add SettingsExtension and RuntimeApplication

### DIFF
--- a/VideoLocker/AndroidManifest.xml
+++ b/VideoLocker/AndroidManifest.xml
@@ -42,7 +42,7 @@
         android:icon="@drawable/app_icon"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
-        android:name="org.edx.mobile.base.MainApplication" >
+        android:name=".base.RuntimeApplication" >
 
         <activity
             android:name="org.edx.mobile.view.SplashActivity"

--- a/VideoLocker/res/layout/fragment_settings.xml
+++ b/VideoLocker/res/layout/fragment_settings.xml
@@ -1,59 +1,62 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white"
-    android:orientation="vertical"
     tools:context="org.edx.mobile.view.SettingsFragment">
-
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/grey_3" />
 
     <LinearLayout
         android:id="@+id/settings_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/white"
-        android:orientation="horizontal"
-        android:padding="15dp">
+        android:divider="@drawable/edx_divider"
+        android:orientation="vertical"
+        android:showDividers="middle|end">
 
         <LinearLayout
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:orientation="vertical">
+            android:background="@color/white"
+            android:orientation="horizontal"
+            android:padding="@dimen/edx_margin">
 
-            <TextView
-                android:id="@+id/settingsText"
-                style="@style/regular_text"
-                android:layout_width="match_parent"
+            <LinearLayout
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                android:text="@string/settings_wifi_top"
-                android:textColor="@color/grey_6"
-                android:textSize="13sp"
-                tools:targetApi="17" />
+                android:layout_weight="1"
+                android:orientation="vertical">
 
-            <TextView
-                android:id="@+id/download_only_tv"
-                style="@style/regular_text"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                android:text="@string/settings_wifi_bottom"
-                android:textColor="@color/grey_4"
-                android:textSize="11sp"
-                tools:targetApi="17" />
+                <TextView
+                    android:id="@+id/settingsText"
+                    style="@style/regular_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:text="@string/settings_wifi_top"
+                    android:textColor="@color/grey_6"
+                    android:textSize="13sp"
+                    tools:targetApi="17" />
+
+                <TextView
+                    android:id="@+id/download_only_tv"
+                    style="@style/regular_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:text="@string/settings_wifi_bottom"
+                    android:textColor="@color/grey_4"
+                    android:textSize="11sp"
+                    tools:targetApi="17" />
+            </LinearLayout>
+
+            <Switch
+                android:id="@+id/wifi_setting"
+                style="@style/edX.Widget.Switch"
+                android:checked="true" />
         </LinearLayout>
 
-        <Switch
-            android:id="@+id/wifi_setting"
-            style="@style/edX.Widget.Switch"
-            android:checked="true" />
     </LinearLayout>
-
-</LinearLayout>
+</ScrollView>

--- a/VideoLocker/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -31,6 +31,8 @@ import org.edx.mobile.view.Router;
 
 import java.util.Locale;
 
+import javax.inject.Inject;
+
 import de.greenrobot.event.EventBus;
 import io.fabric.sdk.android.Fabric;
 import roboguice.RoboGuice;
@@ -39,7 +41,7 @@ import uk.co.chrisjenx.calligraphy.CalligraphyConfig;
 /**
  * This class initializes the modules of the app based on the configuration.
  */
-public class MainApplication extends MultiDexApplication {
+public abstract class MainApplication extends MultiDexApplication {
 
     //FIXME - temporary solution
     public static final boolean RETROFIT_ENABLED = false;
@@ -52,7 +54,10 @@ public class MainApplication extends MultiDexApplication {
         return application;
     }
 
-    Injector injector;
+    private Injector injector;
+
+    @Inject
+    protected Config config;
 
     @Override
     public void onCreate() {
@@ -71,7 +76,7 @@ public class MainApplication extends MultiDexApplication {
         injector = RoboGuice.getOrCreateBaseApplicationInjector((Application) this, RoboGuice.DEFAULT_STAGE,
                 (Module) RoboGuice.newDefaultRoboModule(this), (Module) new EdxDefaultModule(this));
 
-        final Config config = injector.getInstance(Config.class);
+        injector.injectMembers(this);
 
         // initialize Fabric
         if (config.getFabricConfig().isEnabled() && !BuildConfig.DEBUG) {

--- a/VideoLocker/src/main/java/org/edx/mobile/base/RuntimeApplication.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/RuntimeApplication.java
@@ -1,0 +1,23 @@
+package org.edx.mobile.base;
+
+import org.edx.mobile.view.ExtensionRegistry;
+
+import javax.inject.Inject;
+
+/**
+ * Put any custom application configuration here.
+ * This file will not be edited by edX unless absolutely necessary.
+ */
+public class RuntimeApplication extends MainApplication {
+
+    @SuppressWarnings("unused")
+    @Inject
+    ExtensionRegistry extensionRegistry;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        // If you have any custom extensions, add them here. For example:
+        // extensionRegistry.forType(SettingsExtension.class).add(new MyCustomSettingsExtension());
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/view/ExtensionRegistry.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/ExtensionRegistry.java
@@ -1,0 +1,49 @@
+package org.edx.mobile.view;
+
+import android.support.annotation.NonNull;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Singleton;
+
+/**
+ * Keeps track of configured extensions that customize parts of the app.
+ * Add your extensions in {@link org.edx.mobile.base.RuntimeApplication#onCreate()}.
+ */
+@Singleton
+public class ExtensionRegistry {
+    private final Map<Class<? extends Extension>, Registry<? extends Extension>> registries = new HashMap<>();
+
+    public <T extends Extension> Registry<T> forType(Class<T> extensionType) {
+        @SuppressWarnings("unchecked")
+        Registry<T> registry = (Registry<T>) registries.get(extensionType);
+        if (null == registry) {
+            registry = new Registry<>();
+            registries.put(extensionType, registry);
+        }
+        return registry;
+    }
+
+    public static class Registry<T> implements Iterable<T> {
+        @NonNull
+        private final Set<T> items = new LinkedHashSet<>();
+
+        public void add(@NonNull T item) {
+            items.add(item);
+        }
+
+        @Override
+        @NonNull
+        public Iterator<T> iterator() {
+            return Collections.unmodifiableSet(items).iterator();
+        }
+    }
+
+    public interface Extension {
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/view/SettingsExtension.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/SettingsExtension.java
@@ -1,0 +1,19 @@
+package org.edx.mobile.view;
+
+import android.support.annotation.NonNull;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+/**
+ * Allows adding new items to the settings screen.
+ * Add your implementations to the {@link ExtensionRegistry}.
+ */
+public interface SettingsExtension extends ExtensionRegistry.Extension {
+    /**
+     * Inflate your custom settings views into the parent view. Horizontal dividers will be added automatically.
+     * You should use {@link org.edx.mobile.R.dimen.edx_margin} as padding around each item.
+     * Use LayoutInflater.from(parent.getContext()) if you need a layout inflater.
+     * Use parent.getContext().startActivity() if you need to navigate somewhere or show a dialog.
+     */
+    void onCreateSettingsView(@NonNull ViewGroup parent);
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/view/SettingsFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/SettingsFragment.java
@@ -5,6 +5,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CompoundButton;
+import android.widget.LinearLayout;
 import android.widget.Switch;
 
 import com.google.inject.Inject;
@@ -27,6 +28,9 @@ public class SettingsFragment extends BaseFragment {
     @Inject
     protected IEdxEnvironment environment;
 
+    @Inject
+    ExtensionRegistry extensionRegistry;
+
     private Switch wifiSwitch;
 
     @Override
@@ -42,8 +46,11 @@ public class SettingsFragment extends BaseFragment {
         final View layout = inflater.inflate(R.layout.fragment_settings, container, false);
         wifiSwitch = (Switch) layout.findViewById(R.id.wifi_setting);
         updateWifiSwitch();
+        final LinearLayout settingsLayout = (LinearLayout) layout.findViewById(R.id.settings_layout);
+        for (SettingsExtension extension : extensionRegistry.forType(SettingsExtension.class)) {
+            extension.onCreateSettingsView(settingsLayout);
+        }
         return layout;
-
     }
 
     private void updateWifiSwitch() {

--- a/VideoLocker/src/test/java/org/edx/mobile/test/http/ExtensionRegistryTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/http/ExtensionRegistryTest.java
@@ -1,0 +1,39 @@
+package org.edx.mobile.test.http;
+
+import org.edx.mobile.view.ExtensionRegistry;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+
+public class ExtensionRegistryTest {
+
+    @Test
+    public void forType_withNoExtensions_returnsEmptyRegistry() {
+        final ExtensionRegistry extensionRegistry = new ExtensionRegistry();
+        assertThat(extensionRegistry.forType(TestExtension.class).iterator().hasNext(), is(false));
+    }
+
+    @Test
+    public void forType_withAddedExtension_returnsRegistryWithAddedExtension() {
+        final ExtensionRegistry extensionRegistry = new ExtensionRegistry();
+        final TestExtension extension = mock(TestExtension.class);
+        extensionRegistry.forType(TestExtension.class).add(extension);
+        assertThat(extensionRegistry.forType(TestExtension.class).iterator().hasNext(), is(true));
+        assertThat(extensionRegistry.forType(TestExtension.class).iterator().next(), is(extension));
+    }
+
+    @Test
+    public void forType_withExtensionOfAlternateType_returnsEmptyRegistry() {
+        final ExtensionRegistry extensionRegistry = new ExtensionRegistry();
+        extensionRegistry.forType(AlternateTestExtension.class).add(mock(AlternateTestExtension.class));
+        assertThat(extensionRegistry.forType(TestExtension.class).iterator().hasNext(), is(false));
+    }
+
+    public interface TestExtension extends ExtensionRegistry.Extension {
+    }
+
+    public interface AlternateTestExtension extends ExtensionRegistry.Extension {
+    }
+}


### PR DESCRIPTION
The goal of this change is to make it easy to:
1) Add custom code to application's onCreate
2) Add custom settings to the settings screen

All without worrying about conflicting with unrelated code changes.

To solve this, I've done two things:
1) I've created `RuntimeApplication`, which is a place where devs should feel free to add custom code, without worrying about us causing conflicts.
2) Created "ExtensionRegistry". You can add a custom implementation of `SettingsExtension` to this, and we will use it when showing the settings screen.

Here's a complete example of how one might customize their application and add a custom setting:
```java
public class RuntimeApplication extends MainApplication {

    @Inject
    ExtensionRegistry extensionRegistry;

    @Override
    public void onCreate() {
        super.onCreate();

        MyCustomThing.setUp();

        extensionRegistry.forType(SettingsExtension.class).add(new SettingsExtension() {
            @Override
            public void onCreateSettingsView(@NonNull ViewGroup parent, @NonNull LayoutInflater inflater, @NonNull FragmentManager fragmentManager) {
                inflater.inflate(R.layout.my_custom_settings, parent, true);
            }
        });
    }
}
```


