### PR TITLE
Use offline interceptor everywhere

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/http/OfflineRequestInterceptor.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/OfflineRequestInterceptor.java
@@ -5,42 +5,50 @@ import android.content.Context;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.util.NetworkUtil;
 
-import retrofit.RequestInterceptor;
+import java.io.IOException;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
 
 /**
  * okhttp does not work with offline mode by default.
  * we force okhttp to look at the local cache when in offline mode
  */
-public class OfflineRequestInterceptor implements RequestInterceptor {
+public class OfflineRequestInterceptor implements Interceptor {
     protected final Logger logger = new Logger(getClass().getName());
     private final static int MAX_STALE = 60 * 60 * 24 * 28; // tolerate 4-weeks stale
     private Context context;
     private int maxStaleTime;
-    public OfflineRequestInterceptor(Context context){
+
+    public OfflineRequestInterceptor(Context context) {
         this(context, MAX_STALE);
     }
 
-    public OfflineRequestInterceptor(Context context, int maxStaleTime){
+    public OfflineRequestInterceptor(Context context, int maxStaleTime) {
 
         this.context = context;
         this.maxStaleTime = maxStaleTime;
     }
 
     @Override
-    public void intercept(RequestInterceptor.RequestFacade request) {
+    public Response intercept(Chain chain) throws IOException {
+        final Request.Builder builder = chain.request().newBuilder();
         if (isNetworkConnected()) {
             //TODO? should we specify caching here?
 //            int maxAge = 60; // read from cache for 1 minute
 //            request.addHeader("Cache-Control", "public, max-age=" + maxAge);
-            request.addHeader("Cache-Control", "public");
+            builder.header("Cache-Control", "public");
         } else {
-            request.addHeader("Cache-Control",
-                "public, only-if-cached, max-stale=" + maxStaleTime);
+            builder.header("Cache-Control",
+                    "public, only-if-cached, max-stale=" + maxStaleTime);
         }
+        return chain.proceed(builder.build());
     }
 
     //TODO - we dont need this method after DI is used
-    public boolean isNetworkConnected(){
+    public boolean isNetworkConnected() {
         return NetworkUtil.isConnected(context);
     }
+
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/http/OkHttpUtil.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/OkHttpUtil.java
@@ -57,6 +57,7 @@ public class OkHttpUtil {
                         context.getString(R.string.app_name) + "/" +
                         BuildConfig.APPLICATION_ID + "/" +
                         BuildConfig.VERSION_NAME));
+        interceptors.add(new OfflineRequestInterceptor(context));
         if (isOAuthBased) {
             interceptors.add(new OauthHeaderRequestInterceptor(context));
         }

--- a/VideoLocker/src/main/java/org/edx/mobile/http/RestApiManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/RestApiManager.java
@@ -94,7 +94,6 @@ public class RestApiManager implements IApi{
         RestAdapter restAdapter = new RestAdapter.Builder()
             .setClient(new Ok3Client(oauthBasedClient))
             .setEndpoint(getBaseUrl())
-            .setRequestInterceptor(new OfflineRequestInterceptor(context))
             .build();
         oauthRestApi = restAdapter.create(OauthRestApi.class);
 

--- a/VideoLocker/src/test/java/org/edx/mobile/test/http/RetrofitOkhttpTestCase.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/http/RetrofitOkhttpTestCase.java
@@ -72,6 +72,12 @@ public class RetrofitOkhttpTestCase extends BaseTestCase {
         HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor();
         loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
         interceptors.add(loggingInterceptor);
+        interceptors.add(new OfflineRequestInterceptor(context) {
+            @Override
+            public boolean isNetworkConnected() {
+                return isNetworkConnected;
+            }
+        });
         OkHttpClient oauthBasedClient = oauthBasedClientBuilder.build();
 
         Executor executor = Executors.newCachedThreadPool();
@@ -79,11 +85,6 @@ public class RetrofitOkhttpTestCase extends BaseTestCase {
             .setExecutors(executor, executor)
             .setClient(new Ok3Client(oauthBasedClient))
             .setEndpoint(server.url("/").toString())
-            .setRequestInterceptor(new OfflineRequestInterceptor(context) {
-                public boolean isNetworkConnected() {
-                    return isNetworkConnected;
-                }
-            })
             .build();
 
         DummyService service = restAdapter.create(DummyService.class);


### PR DESCRIPTION
I converted the offline interceptor to an OkHttp interceptor (rather than a Retrofit interceptor), so that we can apply it everywhere OkHttp is used. I don't think there is any instance where we do not want it applied.