### PR TITLE
Response pages duplication fix

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
@@ -109,7 +109,6 @@ public class CourseDiscussionResponsesFragment extends BaseFragment implements C
                 // We got a comment to a response
                 courseDiscussionResponsesAdapter.addNewComment(event.getParent());
             }
-            responsesLoader.reset();
         }
     }
 


### PR DESCRIPTION
In 51bd52b I forgot to remove the call to reset the pages loading logic, which caused loading of pages from page-1 upon addition of new response/comment.

Fixes: https://openedx.atlassian.net/browse/MA-2091

@1zaman @bguertin @BenjiLee plz review this one line nuke :wink: 