### PR TITLE
Prevent keyboard from appearing until SearchView has focus

### DIFF
--- a/VideoLocker/res/layout/fragment_discussion_topics.xml
+++ b/VideoLocker/res/layout/fragment_discussion_topics.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:tools="http://schemas.android.com/tools"
     android:background="@color/white"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
     android:orientation="vertical">
 
     <SearchView
@@ -14,17 +16,13 @@
         android:background="@color/white"
         android:iconifiedByDefault="false" />
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/edx_hairline"
-        android:background="@color/edx_grayscale_neutral_light" />
+    <View style="@style/gray_separator" />
 
     <ListView
         android:id="@+id/discussion_topics_listview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/white"
-        tools:listheader="@layout/header_discussion_topics_list"
-        tools:listitem="@layout/row_discussion_topic"/>
+        tools:listitem="@layout/row_discussion_topic" />
 
 </LinearLayout>

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionTopicsFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionTopicsFragment.java
@@ -1,5 +1,6 @@
 package org.edx.mobile.view;
 
+import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -17,18 +18,19 @@ import com.joanzapata.iconify.IconDrawable;
 import com.joanzapata.iconify.fonts.FontAwesomeIcons;
 
 import org.edx.mobile.R;
+import org.edx.mobile.base.BaseFragment;
 import org.edx.mobile.discussion.CourseTopics;
 import org.edx.mobile.discussion.DiscussionTopic;
 import org.edx.mobile.discussion.DiscussionTopicDepth;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.task.GetTopicListTask;
+import org.edx.mobile.util.SoftKeyboardUtil;
 import org.edx.mobile.view.adapters.DiscussionTopicsAdapter;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.edx.mobile.base.BaseFragment;
 import roboguice.inject.InjectExtra;
 import roboguice.inject.InjectView;
 
@@ -102,8 +104,12 @@ public class CourseDiscussionTopicsFragment extends BaseFragment {
             public boolean onQueryTextSubmit(String query) {
                 if (query == null || query.trim().length() == 0)
                     return false;
-
-                router.showCourseDiscussionPostsForSearchQuery(getActivity(), query, courseData);
+                Activity activity = getActivity();
+                if (activity != null) {
+                    SoftKeyboardUtil.hide(activity);
+                    discussionTopicsSearchView.clearFocus();
+                    router.showCourseDiscussionPostsForSearchQuery(getActivity(), query, courseData);
+                }
                 return true;
             }
 
@@ -123,12 +129,7 @@ public class CourseDiscussionTopicsFragment extends BaseFragment {
             }
         });
 
-        // TODO: Find a better way to hide the keyboard AND take the focus away from the SearchView
-        discussionTopicsSearchView.requestFocus();
-        discussionTopicsSearchView.clearFocus();
-
         getTopicList();
-
     }
 
     private void getTopicList() {


### PR DESCRIPTION
Fixes: https://openedx.atlassian.net/browse/MA-2018

The container layout has been made focusable, so that keyboard doesn't appear when we open the activity.

@1zaman @BenjiLee @bguertin plz review