### PR TITLE
Update the comments module to new paginated API

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionAPI.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionAPI.java
@@ -110,7 +110,6 @@ public class DiscussionAPI {
         return discussionService.getThread(threadId);
     }
 
-    // get the responses, and all comments for each of which, of a thread
     public Page<DiscussionComment> getResponsesList(String threadId, int page)
             throws RetroHttpException {
         return discussionService.getResponsesList(threadId, PAGE_SIZE, page);
@@ -120,6 +119,11 @@ public class DiscussionAPI {
                                                                boolean endorsed)
             throws RetroHttpException {
         return discussionService.getResponsesListForQuestion(threadId, PAGE_SIZE, page, endorsed);
+    }
+
+    public Page<DiscussionComment> getCommentsList(String responseId, int pageSize, int page)
+            throws RetroHttpException {
+        return discussionService.getCommentsList(responseId, pageSize, page);
     }
 
     public DiscussionThread setThreadFlagged(DiscussionThread thread, boolean flagged)

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionComment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionComment.java
@@ -41,7 +41,6 @@ public class DiscussionComment implements Serializable, IAuthorData {
     private boolean abuseFlagged = false;
     private List<String> editableFields;
     private int childCount = 0;
-    private List<DiscussionComment> children;
 
     public String getIdentifier() {
         return identifier;
@@ -117,10 +116,6 @@ public class DiscussionComment implements Serializable, IAuthorData {
 
     public void incrementChildCount() {
         childCount++;
-    }
-
-    public List<DiscussionComment> getChildren() {
-        return children;
     }
 
     public IAuthorData getEndorserData() {

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionService.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionService.java
@@ -127,6 +127,13 @@ public interface DiscussionService {
             throws RetroHttpException;
 
 
+    @GET("/api/discussion/v1/comments/{comment_id}/")
+    Page<DiscussionComment> getCommentsList(@Path("comment_id") String responseId,
+                                            @Query("page_size") int pageSize,
+                                            @Query("page") int page)
+            throws RetroHttpException;
+
+
     @PATCH("/api/discussion/v1/threads/{thread_id}/")
     DiscussionThread setThreadFlagged(@Path("thread_id") String threadId,
                                       @Body FlagBody flagBody)

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetCommentsListTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetCommentsListTask.java
@@ -1,0 +1,32 @@
+package org.edx.mobile.task;
+
+import android.content.Context;
+
+import org.edx.mobile.discussion.DiscussionComment;
+import org.edx.mobile.model.Page;
+
+public abstract class GetCommentsListTask extends Task<Page<DiscussionComment>> {
+
+    private static final int PAGE_SIZE = 20;
+
+    String responseId;
+    int page = 1;
+
+    public GetCommentsListTask(Context context, String responseId, int page) {
+        super(context);
+        this.responseId = responseId;
+        this.page = page;
+    }
+
+    public Page<DiscussionComment> call() throws Exception {
+        try {
+            if (responseId != null) {
+                return environment.getDiscussionAPI().getCommentsList(responseId, PAGE_SIZE, page);
+            }
+        } catch (Exception ex) {
+            handle(ex);
+            logger.error(ex, true);
+        }
+        return null;
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
@@ -5,7 +5,6 @@ import android.graphics.Rect;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -20,7 +19,9 @@ import org.edx.mobile.discussion.DiscussionComment;
 import org.edx.mobile.discussion.DiscussionCommentPostedEvent;
 import org.edx.mobile.discussion.DiscussionThread;
 import org.edx.mobile.discussion.DiscussionUtils;
+import org.edx.mobile.model.Page;
 import org.edx.mobile.module.analytics.ISegment;
+import org.edx.mobile.task.GetCommentsListTask;
 import org.edx.mobile.task.SetCommentFlaggedTask;
 import org.edx.mobile.view.adapters.DiscussionCommentsAdapter;
 
@@ -28,6 +29,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import de.greenrobot.event.EventBus;
+import org.edx.mobile.view.adapters.InfiniteScrollUtils;
+
 import roboguice.inject.InjectExtra;
 import roboguice.inject.InjectView;
 
@@ -60,6 +63,13 @@ public class CourseDiscussionCommentsFragment extends BaseFragment implements Di
     private DiscussionCommentsAdapter discussionCommentsAdapter;
 
     @Nullable
+    private GetCommentsListTask getCommentsListTask;
+
+    private int nextPage = 1;
+
+    private InfiniteScrollUtils.InfiniteListController controller;
+
+    @Nullable
     private SetCommentFlaggedTask setCommentFlaggedTask;
 
     @Nullable
@@ -73,8 +83,14 @@ public class CourseDiscussionCommentsFragment extends BaseFragment implements Di
         super.onViewCreated(view, savedInstanceState);
 
         discussionCommentsAdapter = new DiscussionCommentsAdapter(getActivity(), this, discussionResponse);
+        controller = InfiniteScrollUtils.configureRecyclerViewWithInfiniteList(discussionCommentsListView,
+                discussionCommentsAdapter, new InfiniteScrollUtils.PageLoader<DiscussionComment>() {
+            @Override
+            public void loadNextPage(@NonNull InfiniteScrollUtils.PageLoadCallback<DiscussionComment> callback) {
+                getCommentsList(callback);
+            }
+        });
 
-        discussionCommentsListView.setLayoutManager(new LinearLayoutManager(getActivity(), LinearLayoutManager.VERTICAL, false));
         final int overlap = getResources().getDimensionPixelSize(R.dimen.edx_hairline);
         discussionCommentsListView.addItemDecoration(new RecyclerView.ItemDecoration() {
             @Override
@@ -95,6 +111,30 @@ public class CourseDiscussionCommentsFragment extends BaseFragment implements Di
                 });
     }
 
+    protected void getCommentsList(@NonNull final InfiniteScrollUtils.PageLoadCallback<DiscussionComment> callback) {
+        if (getCommentsListTask != null) {
+            getCommentsListTask.cancel(true);
+        }
+        getCommentsListTask = new GetCommentsListTask(getActivity(),
+                discussionResponse.getIdentifier(),
+                nextPage) {
+            @Override
+            public void onSuccess(Page<DiscussionComment> threadCommentsPage) {
+                ++nextPage;
+                callback.onPageLoaded(threadCommentsPage);
+                discussionCommentsAdapter.notifyDataSetChanged();
+            }
+
+            @Override
+            public void onException(Exception ex) {
+                logger.error(ex);
+                discussionCommentsAdapter.setProgressVisible(false);
+            }
+        };
+        getCommentsListTask.setProgressCallback(null);
+        getCommentsListTask.execute();
+    }
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -111,6 +151,9 @@ public class CourseDiscussionCommentsFragment extends BaseFragment implements Di
     @Override
     public void onDestroy() {
         super.onDestroy();
+        if (getCommentsListTask != null) {
+            getCommentsListTask.cancel(true);
+        }
         EventBus.getDefault().unregister(this);
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
@@ -127,6 +127,7 @@ public class CourseDiscussionResponsesFragment extends BaseFragment implements C
     @Override
     public void onDestroy() {
         super.onDestroy();
+        responsesLoader.reset();
         EventBus.getDefault().unregister(this);
     }
 


### PR DESCRIPTION
Previously, the whole comment tree was sent at once in the responses API. The new API unbundles this into separate paginated queries at each level. #574 added support for it on showing the comments count in the responses module. This pull request now changes the comments module to use the new API as well, and removes the unsupported field from the previous API.

Fixes [MA-2056][].

[MA-2056]: https://openedx.atlassian.net/browse/MA-2056