### PR TITLE
Remove limit from endorsed responses on threads

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionAPI.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionAPI.java
@@ -106,12 +106,19 @@ public class DiscussionAPI {
         return discussionService.searchThreadList(courseId, text, PAGE_SIZE, page);
     }
 
-    // get the responses, and all comments for each of which, of a thread
+    // get the paginated responses of a discussion thread
     public Page<DiscussionComment> getResponsesList(String threadId, int page)
             throws RetroHttpException {
         return discussionService.getResponsesList(threadId, PAGE_SIZE, page);
     }
 
+    // get all the endorsed or non-endorsed responses of a question thread
+    public Page<DiscussionComment> getResponsesListForQuestion(String threadId, boolean endorsed)
+            throws RetroHttpException {
+        return discussionService.getResponsesListForQuestion(threadId, endorsed);
+    }
+
+    // get the endorsed or non-endorsed paginated responses of a question thread
     public Page<DiscussionComment> getResponsesListForQuestion(String threadId, int page,
                                                                boolean endorsed)
             throws RetroHttpException {

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionService.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionService.java
@@ -116,6 +116,12 @@ public interface DiscussionService {
 
     @GET("/api/discussion/v1/comments/")
     Page<DiscussionComment> getResponsesListForQuestion(@Query("thread_id") String threadId,
+                                                        @Query("endorsed") boolean endorsed)
+            throws RetroHttpException;
+
+
+    @GET("/api/discussion/v1/comments/")
+    Page<DiscussionComment> getResponsesListForQuestion(@Query("thread_id") String threadId,
                                                         @Query("page_size") int pageSize,
                                                         @Query("page") int page,
                                                         @Query("endorsed") boolean endorsed)

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetResponsesListTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetResponsesListTask.java
@@ -24,7 +24,14 @@ public abstract class GetResponsesListTask extends Task<Page<DiscussionComment>>
     public Page<DiscussionComment> call() throws Exception {
         try {
             if (threadId != null) {
+                // Question threads require the 'endorsed' parameter.
                 if (isQuestionType) {
+                    if (shouldGetEndorsed) {
+                        // Get all the endorsed responses in one go without pagination,
+                        // as we don't expect to have a large number of them.
+                        return environment.getDiscussionAPI().getResponsesListForQuestion(threadId,
+                                true);
+                    }
                     return environment.getDiscussionAPI().getResponsesListForQuestion(threadId,
                             page, shouldGetEndorsed);
                 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
@@ -166,8 +166,8 @@ public class CourseDiscussionResponsesFragment extends BaseFragment implements C
         }
 
         /**
-         * Gets the list of endorsed answers for a {@link DiscussionThread.ThreadType#QUESTION}
-         * type discussion thread
+         * Gets the complete list of endorsed answers for a
+         * {@link DiscussionThread.ThreadType#QUESTION} type discussion thread
          */
         protected void getEndorsedList() {
             if (getEndorsedListTask != null) {


### PR DESCRIPTION
#475 added support for displaying endorsed responses, which are loaded concurrently with the non-endorsed ones (but shown before or at the same time as them), but since it used the same Retrofit method definition for both of them, it established a page limit to the endorsed responses as well, even though it was not paginated or meant to be so (as we don't expect a large number of endorsed responses).

This issue is now fixed by creating a separate method definition for querying endorsed responses that doesn't include the pagination parameters, and thus returns all the endorsed responses without pagination. Comments have been added before each of these methods to match the discussion responses query method, and that one has also been updated to reflect the new API format (in which the nested comments are not included recursively).

Fixes [MA-2099][].

[MA-2099]: https://openedx.atlassian.net/browse/MA-2099