### PR TITLE
Prevent keyboard from appearing until SearchView has focus

### DIFF
--- a/VideoLocker/res/layout/fragment_discussion_topics.xml
+++ b/VideoLocker/res/layout/fragment_discussion_topics.xml
@@ -4,8 +4,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white"
-    android:focusable="true"
-    android:focusableInTouchMode="true"
     android:orientation="vertical">
 
     <SearchView

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionTopicsFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionTopicsFragment.java
@@ -1,6 +1,5 @@
 package org.edx.mobile.view;
 
-import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -25,7 +24,6 @@ import org.edx.mobile.discussion.DiscussionTopicDepth;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.task.GetTopicListTask;
-import org.edx.mobile.util.SoftKeyboardUtil;
 import org.edx.mobile.view.adapters.DiscussionTopicsAdapter;
 
 import java.util.ArrayList;
@@ -104,12 +102,7 @@ public class CourseDiscussionTopicsFragment extends BaseFragment {
             public boolean onQueryTextSubmit(String query) {
                 if (query == null || query.trim().length() == 0)
                     return false;
-                Activity activity = getActivity();
-                if (activity != null) {
-                    SoftKeyboardUtil.hide(activity);
-                    discussionTopicsSearchView.clearFocus();
-                    router.showCourseDiscussionPostsForSearchQuery(getActivity(), query, courseData);
-                }
+                router.showCourseDiscussionPostsForSearchQuery(getActivity(), query, courseData);
                 return true;
             }
 
@@ -159,5 +152,16 @@ public class CourseDiscussionTopicsFragment extends BaseFragment {
             }
         };
         getTopicListTask.execute();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        discussionTopicsSearchView.post(new Runnable() {
+            @Override
+            public void run() {
+                discussionTopicsSearchView.clearFocus();
+            }
+        });
     }
 }


### PR DESCRIPTION
A better approach has now been used to clear focus from the search view as compared to the one used in cb2e085.

Quick review @1zaman 