### PR TITLE
Fix courseware video autoplay

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitVideoFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitVideoFragment.java
@@ -192,20 +192,21 @@ public class CourseUnitVideoFragment extends CourseUnitFragment
     public void setUserVisibleHint(boolean isVisibleToUser) {
         super.setUserVisibleHint(isVisibleToUser);
 
-        BaseFragmentActivity activity = (BaseFragmentActivity) getActivity();
-        if (activity == null) {
+        if (playerFragment == null) {
             return;
         }
 
         if (isVisibleToUser) {
-            checkVideoStatus(unit);
+            if (playerFragment.getPlayingVideo() == null) {
+                checkVideoStatusAndPlay(unit);
+            } else {
+                checkVideoStatus(unit);
+            }
         } else {
-            activity.hideInfoMessage();
+            ((BaseFragmentActivity) getActivity()).hideInfoMessage();
         }
 
-        if (playerFragment != null) {
-            playerFragment.setUserVisibleHint(isVisibleToUser);
-        }
+        playerFragment.setUserVisibleHint(isVisibleToUser);
     }
 
     @Override


### PR DESCRIPTION
#545 refactored the media player automatic handling based on screen events into `PlayerFragment`. However, that caused a regression in `CourseUnitVideoFragment` causing the autoplay upon swiping the `ViewPager` to stop working. This is now fixed by ensuring that the `PlayerFragment` is initialized once by `CourseUnitVideoFragment` upon first receiving visibility to the user (whether it's opened directly or swiped to), after which the `PlayerFragment` will take care of handling the media player based on it's own lifecycle.

Fixes [MA-2107][].

[MA-2107]: https://openedx.atlassian.net/browse/MA-2107