### PR TITLE
Fix media player controls access in fullscreen

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/player/PlayerFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/PlayerFragment.java
@@ -844,8 +844,6 @@ public class PlayerFragment extends BaseFragment implements IPlayerListener, Ser
     @Override
     public void onFullScreen(boolean isFullScreen) {
         if (isPrepared) {
-            freezePlayer();
-
             isManualFullscreen = isFullScreen;
             if (isFullScreen) {
                 enterFullScreen();


### PR DESCRIPTION
For some reason, the media player was frozen by `PlayerFragment` upon starting fullscreen mode via the control button, even though there was no corresponding unfreezing upon entering it. This didn't cause any issue in the videos module where the Activity was restarted (and the `PlayerFragment` along with the media player state reinitialized) upon the orientation change, but it did cause the player to be paused upon entering fullscreen in `CourseUnitVideoFragment`, where the Activity is not restarted. The media player controls were also hidden and disassociated by the freezing of the player.

This was patched in #248, but for some reason, instead of removing the freezing completely, it just removed it for the specific condition in which the `PlayerFragment` was inside a `ViewPager`, which scenario was managed separately by the parent Fragment in that commit. However, this special mode was removed in #545, which sought to have the media player handling automatically managed by `PlayerFragment`'s lifecycle, reintroducing this issue. This is now fixed by just removing the inappropriate freezing of the media player upon entering fullscreen mode.

Fixes [MA-2120][].

[MA-2120]: https://openedx.atlassian.net/browse/MA-2120