### PR TITLE
Non courseware topics moved above courseware topics

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionTopicsFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionTopicsFragment.java
@@ -134,10 +134,9 @@ public class CourseDiscussionTopicsFragment extends BaseFragment {
             public void onSuccess(CourseTopics courseTopics) {
                 if (courseTopics != null) {
                     logger.debug("GetTopicListTask success=" + courseTopics);
-                    //  hideProgress();
                     ArrayList<DiscussionTopic> allTopics = new ArrayList<>();
-                    allTopics.addAll(courseTopics.getCoursewareTopics());
                     allTopics.addAll(courseTopics.getNonCoursewareTopics());
+                    allTopics.addAll(courseTopics.getCoursewareTopics());
 
                     List<DiscussionTopicDepth> allTopicsWithDepth = DiscussionTopicDepth.createFromDiscussionTopics(allTopics);
                     discussionTopicsAdapter.setItems(allTopicsWithDepth);
@@ -148,7 +147,6 @@ public class CourseDiscussionTopicsFragment extends BaseFragment {
             @Override
             public void onException(Exception ex) {
                 logger.error(ex);
-                //  hideProgress();
             }
         };
         getTopicListTask.execute();


### PR DESCRIPTION
Fixes [MA-2120](https://openedx.atlassian.net/browse/MA-2127)

Topics screen looks like this now:

<img src="https://cloud.githubusercontent.com/assets/1710804/13429096/543c8bbe-dfe0-11e5-9fb5-6111ec5bb827.png" width="250" />

We can see that non-courseware topic/s now appear on top of courseware topics.
(**General** is the only non-courseware topic in this case).

quick review @1zaman @bguertin @BenjiLee 