### PR TITLE
Fix default text of topic dropdown while thread creation

### DIFF
--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -340,8 +340,6 @@
 
     <!-- Title placeholder in adding a new post -->
     <string name="discussion_post_title">Title</string>
-    <!-- Topic selection placeholder -->
-    <string name="discussion_add_post_choose_a_topic">Choose a topic…</string>
     <!-- Label for selected topic when creating a post -->
     <string name="discussion_add_post_topic_selection">Topic: {topic}</string>
     <!-- Add post button title in adding a new discussion -->

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddPostFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddPostFragment.java
@@ -234,18 +234,28 @@ public class DiscussionAddPostFragment extends BaseFragment {
             @Override
             public void onSuccess(CourseTopics courseTopics) {
                 final ArrayList<DiscussionTopic> allTopics = new ArrayList<>();
-                allTopics.addAll(courseTopics.getCoursewareTopics());
                 allTopics.addAll(courseTopics.getNonCoursewareTopics());
+                allTopics.addAll(courseTopics.getCoursewareTopics());
 
                 final TopicSpinnerAdapter adapter = new TopicSpinnerAdapter(container.getContext(), DiscussionTopicDepth.createFromDiscussionTopics(allTopics));
                 topicsSpinner.setAdapter(adapter);
 
                 {
                     // Attempt to select the topic that we navigated from
-                    // Otherwise, leave the default option, which is "Choose a topic..."
-                    int selectedTopicIndex = adapter.getPosition(discussionTopic);
-                    if (selectedTopicIndex >= 0) {
-                        topicsSpinner.setSelection(selectedTopicIndex);
+                    // Otherwise, leave the default option, which is the first non-courseware topic
+                    if (!discussionTopic.isAllType() && !discussionTopic.isFollowingType()) {
+                        int selectedTopicIndex = -1;
+                        if (discussionTopic.getIdentifier() == null) {
+                            // In case of a parent topic, we need to select the first child topic
+                            if (!discussionTopic.getChildren().isEmpty()) {
+                                selectedTopicIndex = adapter.getPosition(discussionTopic.getChildren().get(0));
+                            }
+                        } else {
+                            selectedTopicIndex = adapter.getPosition(discussionTopic);
+                        }
+                        if (selectedTopicIndex >= 0) {
+                            topicsSpinner.setSelection(selectedTopicIndex);
+                        }
                     }
                 }
             }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/TopicSpinnerAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/TopicSpinnerAdapter.java
@@ -25,7 +25,6 @@ public class TopicSpinnerAdapter extends ArrayAdapter<DiscussionTopicDepth> {
 
     public TopicSpinnerAdapter(@NonNull Context context, @NonNull List<DiscussionTopicDepth> objects) {
         super(context, 0, new ArrayList<DiscussionTopicDepth>());
-        add(null); // Represents "Choose a topic..." placeholder
         addAll(objects);
     }
 
@@ -38,13 +37,9 @@ public class TopicSpinnerAdapter extends ArrayAdapter<DiscussionTopicDepth> {
             view = (TextView) convertView;
         }
         final DiscussionTopicDepth topic = getItem(position);
-        final CharSequence text;
-        if (null == topic) {
-            text = getContext().getString(R.string.discussion_add_post_choose_a_topic);
-        } else {
-            text = ResourceUtil.getFormattedString(getContext().getResources(), R.string.discussion_add_post_topic_selection, "topic", topic.getDiscussionTopic().getName());
-        }
-        view.setText(text);
+        view.setText(ResourceUtil.getFormattedString(getContext().getResources(),
+                R.string.discussion_add_post_topic_selection, "topic",
+                topic.getDiscussionTopic().getName()));
         return view;
     }
 
@@ -57,17 +52,10 @@ public class TopicSpinnerAdapter extends ArrayAdapter<DiscussionTopicDepth> {
             view = (TextView) convertView;
         }
         final DiscussionTopicDepth topic = getItem(position);
-        final int extraLeftPadding;
-        final String text;
-        if (null == topic) {
-            extraLeftPadding = 0;
-            text = getContext().getString(R.string.discussion_add_post_choose_a_topic);
-        } else {
-            extraLeftPadding = topic.getDepth() * extraPaddingPerLevel;
-            text = topic.getDiscussionTopic().getName();
-        }
-        ViewCompat.setPaddingRelative(view, basePadding + extraLeftPadding, view.getPaddingTop(), basePadding, view.getPaddingBottom());
-        view.setText(text);
+        final int extraLeftPadding = topic.getDepth() * extraPaddingPerLevel;
+        ViewCompat.setPaddingRelative(view, basePadding + extraLeftPadding, view.getPaddingTop(),
+                basePadding, view.getPaddingBottom());
+        view.setText(topic.getDiscussionTopic().getName());
         view.setEnabled(isEnabled(position));
         return view;
     }
@@ -87,12 +75,12 @@ public class TopicSpinnerAdapter extends ArrayAdapter<DiscussionTopicDepth> {
      * @return The position of the specified topic, or -1 if not found
      */
     public int getPosition(@NonNull DiscussionTopic discussionTopic) {
-            for (int i = 0; i < getCount(); ++i) {
-                final DiscussionTopicDepth item = getItem(i);
-                if (null != item && item.isPostable() && discussionTopic.hasSameId(item.getDiscussionTopic())) {
-                    return i;
-                }
+        for (int i = 0; i < getCount(); ++i) {
+            final DiscussionTopicDepth item = getItem(i);
+            if (item.isPostable() && discussionTopic.hasSameId(item.getDiscussionTopic())) {
+                return i;
             }
+        }
         return -1;
     }
 }


### PR DESCRIPTION
Fixes [MA-1430](https://openedx.atlassian.net/browse/MA-1430).

`Choose a topic...` option has been removed and Non-courseware topics now appear first in the topics spinner.

Following are the cases for default item selection of the topics spinner on the `Create a new post` screen:
- in case of All and Following posts, the first non-courseware topic is selected.
- in case of a parent topic, its first child topic is selected.

The dropdown looks like this now:

<img src="https://cloud.githubusercontent.com/assets/1710804/13431531/a836ed44-dfeb-11e5-9bac-adbb528c2b19.png" width="250" />

@1zaman @bguertin @BenjiLee plz review