### PR TITLE
MA-2128 Removed webview cache deletion

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -113,11 +113,6 @@ public class MainApplication extends MultiDexApplication {
         if (needVersionUpgrade) {
             // try repair of download data if app version is updated
             injector.getInstance(IStorage.class).repairDownloadCompletionData();
-
-            //try to clear browser cache.
-            //there is an potential issue related to the 301 redirection.
-            //https://openedx.atlassian.net/browse/MA-794
-            EdxCookieManager.getSharedInstance().clearWebViewCache(this);
         }
 
         // Register Font Awesome module in android-iconify library

--- a/VideoLocker/src/main/java/org/edx/mobile/services/EdxCookieManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/services/EdxCookieManager.java
@@ -53,31 +53,6 @@ public class EdxCookieManager {
             }
         }
         authSessionCookieExpiration = -1;
-
-    }
-
-    public void clearWebViewCache(Context context){
-        try {
-            clearWebWiewCookie(context);
-
-            boolean success = context.deleteDatabase("webview.db");
-            logger.debug("delete webview.db result = " + success);
-            success =  context.deleteDatabase("webviewCache.db");
-            logger.debug("delete webviewCache.db result = " + success);
-        } catch (Exception e) {
-            logger.error(e);
-        }
-
-
-        File webviewCacheDir = new File(context.getCacheDir().getAbsolutePath()+"/webviewCache");
-        if(webviewCacheDir.exists()){
-            context.deleteFile(webviewCacheDir.getAbsolutePath());
-        }
-
-        File appCacheDir = new File(context.getFilesDir().getAbsolutePath()+ "/webcache");
-        if(appCacheDir.exists()){
-            context.deleteFile(appCacheDir.getAbsolutePath());
-        }
     }
 
     public synchronized  void tryToRefreshSessionCookie( ){


### PR DESCRIPTION
Removed cache deletion from the main thread where Android versions
4.X up to 4.3 were crashing due to a database error.

@bguertin @miankhalid @1zaman 

Addresses: https://fabric.io/edx-inc/android/apps/org.edx.mobile/issues/56aa911ff5d3a7f76b69c380
https://openedx.atlassian.net/browse/MA-2128