### PR TITLE
Fix wrong thread response count display

### DIFF
--- a/VideoLocker/res/layout/number_responses_or_comments_layout.xml
+++ b/VideoLocker/res/layout/number_responses_or_comments_layout.xml
@@ -1,28 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<TextView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    tools:showIn="@layout/discussion_responses_thread_row">
-
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:gravity="center">
-
-        <org.edx.mobile.view.custom.IconImageViewXml
-            android:id="@+id/number_responses_or_comments_icon_view"
-            android:layout_width="@dimen/edx_xxx_small"
-            android:layout_height="@dimen/edx_xxx_small"
-            android:layout_marginEnd="@dimen/discussion_responses_thread_text_view_spacing"
-            android:layout_marginRight="@dimen/discussion_responses_thread_text_view_spacing"
-            app:iconColor="@color/edx_grayscale_neutral_base"
-            app:iconName="fa-comment"/>
-
-        <TextView
-            android:id="@+id/number_responses_or_comments_label"
-            style="@style/discussion_responses_small_text" />
-
-    </LinearLayout>
-
-</merge>
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/number_responses_or_comments_label"
+    style="@style/discussion_responses_small_text"
+    tools:showIn="@layout/discussion_responses_thread_row" />

--- a/VideoLocker/res/values/text_styles.xml
+++ b/VideoLocker/res/values/text_styles.xml
@@ -293,6 +293,8 @@
         <item name="android:textSize">@dimen/edx_xxx_small</item>
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
+        <item name="android:gravity">center_vertical</item>
+        <item name="android:drawablePadding">@dimen/discussion_responses_thread_text_view_spacing</item>
     </style>
 
 </resources>

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionAPI.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionAPI.java
@@ -106,6 +106,10 @@ public class DiscussionAPI {
         return discussionService.searchThreadList(courseId, text, PAGE_SIZE, page);
     }
 
+    public DiscussionThread getThread(String threadId) throws RetroHttpException {
+        return discussionService.getThread(threadId);
+    }
+
     // get the responses, and all comments for each of which, of a thread
     public Page<DiscussionComment> getResponsesList(String threadId, int page)
             throws RetroHttpException {

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionService.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionService.java
@@ -107,6 +107,11 @@ public interface DiscussionService {
             throws RetroHttpException;
 
 
+    @GET("/api/discussion/v1/threads/{thread_id}/")
+    DiscussionThread getThread(@Path("thread_id") String threadId)
+            throws RetroHttpException;
+
+
     @GET("/api/discussion/v1/comments/")
     Page<DiscussionComment> getResponsesList(@Query("thread_id") String threadId,
                                              @Query("page_size") int pageSize,

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionThread.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionThread.java
@@ -58,6 +58,9 @@ public class DiscussionThread implements Serializable, IAuthorData {
     private String authorLabel;
     private int commentCount = 0;
     private int unreadCommentCount = 0;
+    // Since the response count field is not provided in the thread list
+    // query, it is defaulted to -1 to indicate that it's not available.
+    private int responseCount = -1;
     private String commentListUrl;
     private boolean hasEndorsed = false;
     private boolean pinned = false;
@@ -128,6 +131,21 @@ public class DiscussionThread implements Serializable, IAuthorData {
 
     public int getUnreadCommentCount() {
         return unreadCommentCount;
+    }
+
+    /**
+     * @return The response count, or -1 if it's not available.
+     */
+    public int getResponseCount() {
+        return responseCount;
+    }
+
+    /**
+     * Increment the response count.
+     */
+    public void incrementResponseCount() {
+        responseCount++;
+        incrementCommentCount();
     }
 
     public boolean isHasEndorsed() {

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetThreadTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetThreadTask.java
@@ -1,0 +1,28 @@
+package org.edx.mobile.task;
+
+import android.content.Context;
+
+import org.edx.mobile.discussion.DiscussionThread;
+import org.edx.mobile.http.RetroHttpException;
+
+public abstract class GetThreadTask extends Task<DiscussionThread> {
+
+    final String threadId;
+
+    public GetThreadTask(Context context, String threadId) {
+        super(context);
+        this.threadId = threadId;
+    }
+
+    public DiscussionThread call() throws Exception {
+        try {
+            if (threadId != null) {
+                return environment.getDiscussionAPI().getThread(threadId);
+            }
+        } catch (RetroHttpException ex) {
+            handle(ex);
+            logger.error(ex, true);
+        }
+        return null;
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
@@ -135,11 +135,9 @@ public class CourseDiscussionResponsesFragment extends BaseFragment implements C
         if (discussionThread.containsComment(event.getComment())) {
             if (event.getParent() == null) {
                 // We got a response
-                discussionThread.incrementResponseCount();
                 courseDiscussionResponsesAdapter.addNewResponse(event.getComment());
             } else {
                 // We got a comment to a response
-                discussionThread.incrementCommentCount();
                 courseDiscussionResponsesAdapter.addNewComment(event.getParent());
             }
         }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -11,6 +11,7 @@ import android.view.ViewGroup;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import com.joanzapata.iconify.Icon;
 import com.joanzapata.iconify.IconDrawable;
 import com.joanzapata.iconify.fonts.FontAwesomeIcons;
 import com.joanzapata.iconify.widget.IconImageView;
@@ -225,8 +226,15 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
     }
 
     private void bindNumberResponsesView(NumberResponsesViewHolder holder) {
-        holder.numberResponsesOrCommentsLabel.setText(holder.numberResponsesOrCommentsLabel.getResources().getQuantityString(
-                R.plurals.number_responses_or_comments_responses_label, discussionThread.getCommentCount(), discussionThread.getCommentCount()));
+        int responsesCount = discussionThread.getResponseCount();
+        if (responsesCount < 0) {
+            // The responses count is not available yet, so hide the view.
+            holder.numberResponsesOrCommentsLabel.setVisibility(View.GONE);
+        } else {
+            holder.numberResponsesOrCommentsLabel.setVisibility(View.VISIBLE);
+            holder.numberResponsesOrCommentsLabel.setText(holder.numberResponsesOrCommentsLabel.getResources().getQuantityString(
+                    R.plurals.number_responses_or_comments_responses_label, responsesCount, responsesCount));
+        }
     }
 
     private void bindViewHolderToShowMoreRow(ShowMoreViewHolder holder) {
@@ -352,23 +360,32 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
     }
 
     private void bindNumberCommentsView(NumberResponsesViewHolder holder, DiscussionComment response) {
+        String text;
+        Icon icon;
+
         int numChildren = response == null ? 0 : response.getChildCount();
 
-        if (numChildren == 0) {
+        if (response.getChildCount() == 0) {
             if (discussionThread.isClosed()) {
-                holder.numberResponsesOrCommentsLabel.setText(context.getString(
-                        R.string.discussion_add_comment_disabled_title));
-                holder.numberResponsesIconImageView.setIcon(FontAwesomeIcons.fa_lock);
+                text = context.getString(R.string.discussion_add_comment_disabled_title);
+                icon = FontAwesomeIcons.fa_lock;
             } else {
-                holder.numberResponsesOrCommentsLabel.setText(context.getString(
-                        R.string.number_responses_or_comments_add_comment_label));
-                holder.numberResponsesIconImageView.setIcon(FontAwesomeIcons.fa_comment);
+                text = context.getString(R.string.number_responses_or_comments_add_comment_label);
+                icon = FontAwesomeIcons.fa_comment;
             }
         } else {
-            holder.numberResponsesOrCommentsLabel.setText(holder.numberResponsesOrCommentsLabel.getResources().
-                    getQuantityString(R.plurals.number_responses_or_comments_comments_label, numChildren, numChildren));
-            holder.numberResponsesIconImageView.setIcon(FontAwesomeIcons.fa_comment);
+            text = context.getResources().getQuantityString(
+                    R.plurals.number_responses_or_comments_comments_label, numChildren, numChildren);
+            icon = FontAwesomeIcons.fa_comment;
         }
+
+        holder.numberResponsesOrCommentsLabel.setText(text);
+        TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(
+                holder.numberResponsesOrCommentsLabel,
+                new IconDrawable(context, icon)
+                        .colorRes(context, R.color.edx_grayscale_neutral_base)
+                        .sizeRes(context, R.dimen.edx_xxx_small),
+                null, null, null);
     }
 
     @Override
@@ -392,6 +409,11 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
         }
 
         return RowType.RESPONSE;
+    }
+
+    public void updateDiscussionThread(@NonNull DiscussionThread discussionThread) {
+        this.discussionThread = discussionThread;
+        notifyDataSetChanged();
     }
 
     @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -430,10 +430,12 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
 
     public void addNewResponse(@NonNull DiscussionComment response) {
         discussionResponses.add(response);
+        discussionThread.incrementResponseCount();
         notifyDataSetChanged();
     }
 
     public void addNewComment(@NonNull DiscussionComment parent) {
+        discussionThread.incrementCommentCount();
         String parentId = parent.getIdentifier();
         for (DiscussionComment response : discussionResponses) {
             if (parentId.equals(response.getIdentifier())) {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/view_holders/NumberResponsesViewHolder.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/view_holders/NumberResponsesViewHolder.java
@@ -1,23 +1,30 @@
 package org.edx.mobile.view.view_holders;
 
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.support.v4.widget.TextViewCompat;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.TextView;
 
-import com.joanzapata.iconify.widget.IconImageView;
+import com.joanzapata.iconify.IconDrawable;
+import com.joanzapata.iconify.fonts.FontAwesomeIcons;
 
 import org.edx.mobile.R;
 
 public class NumberResponsesViewHolder extends RecyclerView.ViewHolder {
     public TextView numberResponsesOrCommentsLabel;
-    public IconImageView numberResponsesIconImageView;
 
     public NumberResponsesViewHolder(View itemView) {
         super(itemView);
         numberResponsesOrCommentsLabel = (TextView) itemView.
                 findViewById(R.id.number_responses_or_comments_label);
-        numberResponsesIconImageView = (IconImageView) itemView.
-                findViewById(R.id.number_responses_or_comments_icon_view);
+        Context context = numberResponsesOrCommentsLabel.getContext();
+        Drawable iconDrawable = new IconDrawable(context, FontAwesomeIcons.fa_comment)
+                .colorRes(context, R.color.edx_grayscale_neutral_base)
+                .sizeRes(context, R.dimen.edx_xxx_small);
+        TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(
+                numberResponsesOrCommentsLabel, iconDrawable, null, null, null);
     }
 
 }


### PR DESCRIPTION
The responses count display in `CourseDiscussionResponsesFragment` has been fixed to show only the top-level responses count instead of the total comments count. This field is not available from querying the thread list, so it's the thread details are queried explicitly to get access to this field. The paginated query for the responses is intialized concurrently, but their delivery to the adapter is deferred until the thread details have also been loaded and delivered.

The response count field has been added to the thread model, with a default unset state, and the adapter has been set up to hide it's display in the unset state. The response count layout has also been flattened into a single `TextView` to enable easily changing it's visibility directly, which requires the `IconDrawable` to be set as a compound drawable dynamically. This is done by it's view holder upon inflation to set the default icon, and upon binding the responses row to choose between the locked and unlocked items.

Fixes [MA-2014].

[MA-2014]: https://openedx.atlassian.net/browse/MA-2014