### PR TITLE
Non-updating creation time for discussion responses/comments

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
@@ -34,11 +34,21 @@ public abstract class DiscussionTextUtils {
                                                 @StringRes final int stringRes,
                                                 @NonNull final IAuthorData authorData,
                                                 @NonNull final Runnable onAuthorClickListener) {
+        setAuthorAttributionText(textView, stringRes, authorData,
+                System.currentTimeMillis(), onAuthorClickListener);
+    }
+
+
+    public static void setAuthorAttributionText(@NonNull TextView textView,
+                                                @StringRes final int stringRes,
+                                                @NonNull final IAuthorData authorData,
+                                                long initialTimeStampMs,
+                                                @NonNull final Runnable onAuthorClickListener) {
         final CharSequence text;
         {
             final Context context = textView.getContext();
             final CharSequence formattedTime = getRelativeTimeSpanString(context,
-                    authorData.getCreatedAt().getTime());
+                    initialTimeStampMs, authorData.getCreatedAt().getTime());
             final String authorLabel = authorData.getAuthorLabel();
 
             final SpannableString authorSpan = new SpannableString(authorData.getAuthor());
@@ -73,13 +83,14 @@ public abstract class DiscussionTextUtils {
         textView.setMovementMethod(new LinkMovementMethod());
     }
 
-    private static CharSequence getRelativeTimeSpanString(@NonNull Context context, long timeMs) {
-        if (System.currentTimeMillis() - timeMs < DateUtils.SECOND_IN_MILLIS) {
+    private static CharSequence getRelativeTimeSpanString(@NonNull Context context, long nowMs,
+                                                          long timeMs) {
+        if (nowMs - timeMs < DateUtils.SECOND_IN_MILLIS) {
             return context.getString(R.string.just_now);
         } else {
             return DateUtils.getRelativeTimeSpanString(
                     timeMs,
-                    System.currentTimeMillis(),
+                    nowMs,
                     DateUtils.SECOND_IN_MILLIS,
                     DateUtils.FORMAT_NUMERIC_DATE | DateUtils.FORMAT_SHOW_YEAR);
         }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -60,6 +60,8 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
     private final List<DiscussionComment> discussionResponses = new ArrayList<>();
 
     private boolean progressVisible = false;
+    // Record the current time at initialization to keep the display of the elapsed time durations stable.
+    private long initialTimeStampMs = System.currentTimeMillis();
 
     static class RowType {
         static final int THREAD = 0;
@@ -152,8 +154,8 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
         bindSocialView(holder.socialLayoutViewHolder, discussionThread);
         DiscussionTextUtils.setAuthorAttributionText(
                 holder.authorLayoutViewHolder.discussionAuthorTextView,
-                R.string.post_attribution,
-                discussionThread, new Runnable() {
+                R.string.post_attribution, discussionThread, initialTimeStampMs,
+                new Runnable() {
                     @Override
                     public void run() {
                         listener.onClickAuthor(discussionThread.getAuthor());
@@ -273,7 +275,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
         DiscussionTextUtils.setAuthorAttributionText(
                 holder.authorLayoutViewHolder.discussionAuthorTextView,
                 R.string.post_attribution,
-                comment, new Runnable() {
+                comment, initialTimeStampMs, new Runnable() {
                     @Override
                     public void run() {
                         listener.onClickAuthor(comment.getAuthor());
@@ -323,7 +325,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
             }
             holder.responseAnswerTextView.setText(endorsementTypeStringRes);
             DiscussionTextUtils.setAuthorAttributionText(holder.responseAnswerAuthorTextView,
-                    attributionStringRes, comment.getEndorserData(),
+                    attributionStringRes, comment.getEndorserData(), initialTimeStampMs,
                     new Runnable() {
                         @Override
                         public void run() {
@@ -434,6 +436,8 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
     }
 
     public void addNewResponse(@NonNull DiscussionComment response) {
+        // Since, we have a added a new response we need to update timestamps of all responses
+        initialTimeStampMs = System.currentTimeMillis();
         int offset = 1 + discussionResponses.size();
         discussionResponses.add(response);
         discussionThread.incrementResponseCount();
@@ -442,6 +446,8 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
     }
 
     public void addNewComment(@NonNull DiscussionComment parent) {
+        // Since, we have a added a new comment we need to update timestamps of all responses as well
+        initialTimeStampMs = System.currentTimeMillis();
         discussionThread.incrementCommentCount();
         String parentId = parent.getIdentifier();
         for (ListIterator<DiscussionComment> responseIterator = discussionResponses.listIterator();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DiscussionCommentsAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DiscussionCommentsAdapter.java
@@ -30,6 +30,8 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
 
     @NonNull
     private DiscussionComment response;
+    // Record the current time at initialization to keep the display of the elapsed time durations stable.
+    private long initialTimeStampMs = System.currentTimeMillis();
 
     private final List<DiscussionComment> discussionComments = new ArrayList<>();
 
@@ -133,8 +135,8 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
         holder.discussionCommentBody.setText(commentBody);
 
         DiscussionTextUtils.setAuthorAttributionText(holder.discussionCommentAuthorTextView,
-                R.string.post_attribution,
-                discussionComment, new Runnable() {
+                R.string.post_attribution, discussionComment, initialTimeStampMs,
+                new Runnable() {
                     @Override
                     public void run() {
                         listener.onClickAuthor(discussionComment.getAuthor());
@@ -190,12 +192,11 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
     }
 
     public void insertCommentAtEnd(DiscussionComment comment) {
+        // Since, we have a added a new comment we need to update timestamps of all comments
+        initialTimeStampMs = System.currentTimeMillis();
         response.incrementChildCount();
-        int lastCommentIndex = discussionComments.size();
         discussionComments.add(comment);
-        notifyItemInserted(lastCommentIndex + 1);
-        notifyItemChanged(lastCommentIndex); // Last item's background is different, so must be refreshed as well
-        notifyItemChanged(0); // Comments count is shown in the response header, so it also needs to be refreshed.
+        notifyDataSetChanged();
     }
 
     public void updateComment(DiscussionComment comment) {


### PR DESCRIPTION
Fixes [MA-1740](https://openedx.atlassian.net/browse/MA-1740).

Previously whenever notifyDatasetChanged was called on the responses/comments adapter, the time spanned since the creation time of a response or a comment updated with respect to the latest time.

This is now solved by initialising a time stamp at the time of adapter creation which is then used as the elapsed time since the creation time of a response/comment.

@1zaman @bguertin @BenjiLee plz review