### PR TITLE
Fix Task implementations

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
@@ -202,8 +202,8 @@ public abstract class FindCoursesBaseActivity extends BaseFragmentActivity imple
 
                                     @Override
                                     public void onException(Exception ex) {
+                                        super.onException(ex);
                                         isTaskInProgress = false;
-                                        logger.error(ex);
                                         Toast.makeText(getContext(), R.string.cannot_show_dashboard, Toast.LENGTH_SHORT).show();
                                     }
                                 };
@@ -216,8 +216,8 @@ public abstract class FindCoursesBaseActivity extends BaseFragmentActivity imple
 
             @Override
             public void onException(Exception ex) {
+                super.onException(ex);
                 isTaskInProgress = false;
-                logger.error(ex);
                 logger.debug("Error during enroll api call");
                 showEnrollErrorMessage(courseId, emailOptIn);
             }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/notification/ParseSyncTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/notification/ParseSyncTask.java
@@ -20,16 +20,7 @@ public abstract class ParseSyncTask extends Task<Void> {
 
     @Override
     public Void call( ) throws Exception{
-        try {
-            subscribedChannels = ParseInstallation.getCurrentInstallation().getList("channels");
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex);
-        }
+        subscribedChannels = ParseInstallation.getCurrentInstallation().getList("channels");
         return null;
-    }
-
-    public void onException(Exception ex){
-          //do nothing.?
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/services/EdxCookieManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/services/EdxCookieManager.java
@@ -78,7 +78,7 @@ public class EdxCookieManager {
 
                 @Override
                 public void onException(Exception ex) {
-                    logger.error(ex);
+                    super.onException(ex);
                     EventBus.getDefault().post(new SessionIdRefreshEvent(false));
                     task = null;
                 }

--- a/VideoLocker/src/main/java/org/edx/mobile/services/LastAccessManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/services/LastAccessManager.java
@@ -53,8 +53,8 @@ public class LastAccessManager {
                         }
                         @Override
                         public void onException(Exception ex) {
+                            super.onException(ex);
                             callback.setFetchingLastAccessed( false );
-                            logger.error(ex);
                         }
                     };
 
@@ -118,11 +118,6 @@ public class LastAccessManager {
                             +result.getLastVisitedModuleId());
                          callback.showLastAccessedView(result.getLastVisitedModuleId(), courseId, view);
                     }
-                }
-
-                @Override
-                public void onException(Exception ex) {
-                    logger.error(ex);
                 }
             };
             syncLastAccessTask.execute( );

--- a/VideoLocker/src/main/java/org/edx/mobile/services/VideoDownloadHelper.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/services/VideoDownloadHelper.java
@@ -159,6 +159,7 @@ public class VideoDownloadHelper {
 
             @Override
             public void onException(Exception ex) {
+                super.onException(ex);
                 callback.onDownloadFailedToStart();
             }
         };

--- a/VideoLocker/src/main/java/org/edx/mobile/social/google/GoogleProvider.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/social/google/GoogleProvider.java
@@ -62,11 +62,6 @@ public class GoogleProvider implements SocialProvider {
         }
 
         @Override
-        public void onException(Exception ex) {
-            logger.error(ex);
-        }
-
-        @Override
         public String call() throws Exception {
             //try to wait a while .
             try {
@@ -80,25 +75,20 @@ public class GoogleProvider implements SocialProvider {
             //the code refactoring.
             Bundle p = new Bundle();
             String url = "https://www.googleapis.com/oauth2/v1/userinfo?access_token=" + accessToken;
-            try {
-                String json = new HttpManager().get(url, p).body;
-                logger.debug(json);
-                Gson gson = new GsonBuilder().create();
-                GoogleUserProfile userProfile = gson.fromJson(json, GoogleUserProfile.class);
-                String name = userProfile.name;
-                if (TextUtils.isEmpty(name)) {
-                    if (!TextUtils.isEmpty(userProfile.given_name)) {
-                        name = userProfile.given_name + " ";
-                    }
-                    if (!TextUtils.isEmpty(userProfile.family_name)) {
-                        name += userProfile.given_name;
-                    }
+            String json = new HttpManager().get(url, p).body;
+            logger.debug(json);
+            Gson gson = new GsonBuilder().create();
+            GoogleUserProfile userProfile = gson.fromJson(json, GoogleUserProfile.class);
+            String name = userProfile.name;
+            if (TextUtils.isEmpty(name)) {
+                if (!TextUtils.isEmpty(userProfile.given_name)) {
+                    name = userProfile.given_name + " ";
                 }
-                return name;
-            } catch (Exception ex) {
-                //  logger.error(ex);
+                if (!TextUtils.isEmpty(userProfile.family_name)) {
+                    name += userProfile.given_name;
+                }
             }
-            return null;
+            return name;
         }
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/task/CreateCommentTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/CreateCommentTask.java
@@ -1,6 +1,7 @@
 package org.edx.mobile.task;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import org.edx.mobile.discussion.CommentBody;
 import org.edx.mobile.discussion.DiscussionComment;
@@ -8,9 +9,10 @@ import org.edx.mobile.discussion.DiscussionComment;
 public abstract class CreateCommentTask extends
 Task<DiscussionComment> {
 
+    @NonNull
     CommentBody thread;
 
-    public CreateCommentTask(Context context, CommentBody thread) {
+    public CreateCommentTask(@NonNull Context context, @NonNull CommentBody thread) {
         super(context);
         this.thread = thread;
     }
@@ -18,16 +20,6 @@ Task<DiscussionComment> {
 
 
     public DiscussionComment call( ) throws Exception{
-        try {
-
-            if(thread!=null){
-
-                return environment.getDiscussionAPI().createComment(thread);
-            }
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
-        }
-        return null;
+        return environment.getDiscussionAPI().createComment(thread);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/CreateResponseTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/CreateResponseTask.java
@@ -1,6 +1,7 @@
 package org.edx.mobile.task;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import org.edx.mobile.discussion.DiscussionComment;
 import org.edx.mobile.discussion.ResponseBody;
@@ -8,9 +9,10 @@ import org.edx.mobile.discussion.ResponseBody;
 public abstract class CreateResponseTask extends
 Task<DiscussionComment> {
 
+    @NonNull
     ResponseBody thread;
 
-    public CreateResponseTask(Context context, ResponseBody thread) {
+    public CreateResponseTask(@NonNull Context context, @NonNull ResponseBody thread) {
         super(context);
         this.thread = thread;
     }
@@ -18,16 +20,6 @@ Task<DiscussionComment> {
 
 
     public DiscussionComment call( ) throws Exception{
-        try {
-
-            if(thread!=null){
-
-                return environment.getDiscussionAPI().createResponse(thread);
-            }
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
-        }
-        return null;
+        return environment.getDiscussionAPI().createResponse(thread);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/CreateThreadTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/CreateThreadTask.java
@@ -1,6 +1,7 @@
 package org.edx.mobile.task;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import org.edx.mobile.discussion.DiscussionThread;
 import org.edx.mobile.discussion.ThreadBody;
@@ -8,9 +9,10 @@ import org.edx.mobile.discussion.ThreadBody;
 public abstract class CreateThreadTask extends
 Task<DiscussionThread> {
 
+    @NonNull
     ThreadBody thread;
 
-    public CreateThreadTask(Context context, ThreadBody thread) {
+    public CreateThreadTask(@NonNull Context context, @NonNull ThreadBody thread) {
         super(context);
         this.thread = thread;
     }
@@ -18,16 +20,6 @@ Task<DiscussionThread> {
 
 
     public DiscussionThread call( ) throws Exception{
-        try {
-
-            if(thread!=null){
-
-                return environment.getDiscussionAPI().createThread(thread);
-            }
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
-        }
-        return null;
+        return environment.getDiscussionAPI().createThread(thread);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/EnqueueDownloadTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/EnqueueDownloadTask.java
@@ -1,6 +1,7 @@
 package org.edx.mobile.task;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import com.google.inject.Inject;
 
@@ -13,35 +14,24 @@ public abstract class EnqueueDownloadTask extends Task<Long> {
 
 
     @Inject
+    @NonNull
     TranscriptManager transcriptManager;
+    @NonNull
     List<DownloadEntry> downloadList;
-    public EnqueueDownloadTask(Context context, List<DownloadEntry> downloadList) {
+    public EnqueueDownloadTask(@NonNull Context context, @NonNull List<DownloadEntry> downloadList) {
         super(context);
         this.downloadList = downloadList;
     }
 
     @Override
     public Long call( ) throws Exception{
-        try {
-
-            if(downloadList!=null){
-                int count = 0;
-                for (DownloadEntry de : downloadList) {
-                    try{
-                        if(environment.getStorage().addDownload(de)!=-1){
-                            count++;
-                        }
-                        transcriptManager.downloadTranscriptsForVideo(de.transcript);
-                    }catch(Exception e){
-                        logger.error(e);
-                    }
-                }
-                return (long)count;
+        int count = 0;
+        for (DownloadEntry de : downloadList) {
+            if(environment.getStorage().addDownload(de)!=-1){
+                count++;
             }
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex);
+            transcriptManager.downloadTranscriptsForVideo(de.transcript);
         }
-        return 0L;
+        return (long)count;
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetAnnouncementTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetAnnouncementTask.java
@@ -17,35 +17,16 @@ public abstract class GetAnnouncementTask extends
     }
 
     public List<AnnouncementsModel> call() throws Exception{
-        try {
-            ServiceManager api = environment.getServiceManager();
-            
-            try {
-                // return instant data from cache
-                final List<AnnouncementsModel> list = api
-                        .getAnnouncement(enrollment.getCourse().getCourse_updates(), true);
-                if (list != null) {
-                    handler.post(new Runnable() {
-                        public void run() {
-                            try {
-                                onSuccess(list);
-                            }catch (Exception ex){
-                                logger.error(ex);
-                            }
-                            stopProgress();
-                        }
-                    });
-                }
-            } catch(Exception ex) {
-                logger.error(ex);
-            }
-            
-            return api.getAnnouncement(enrollment.getCourse().getCourse_updates(), false);
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
+        ServiceManager api = environment.getServiceManager();
+
+        // return instant data from cache if available
+        List<AnnouncementsModel> list = api
+                .getAnnouncement(enrollment.getCourse().getCourse_updates(), true);
+        if (list == null) {
+            list = api.getAnnouncement(enrollment.getCourse().getCourse_updates(), false);
         }
-        return null;
+
+        return list;
     }
 
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetCommentsListTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetCommentsListTask.java
@@ -1,6 +1,7 @@
 package org.edx.mobile.task;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import org.edx.mobile.discussion.DiscussionComment;
 import org.edx.mobile.model.Page;
@@ -9,24 +10,17 @@ public abstract class GetCommentsListTask extends Task<Page<DiscussionComment>> 
 
     private static final int PAGE_SIZE = 20;
 
+    @NonNull
     String responseId;
     int page = 1;
 
-    public GetCommentsListTask(Context context, String responseId, int page) {
+    public GetCommentsListTask(@NonNull Context context, @NonNull String responseId, int page) {
         super(context);
         this.responseId = responseId;
         this.page = page;
     }
 
     public Page<DiscussionComment> call() throws Exception {
-        try {
-            if (responseId != null) {
-                return environment.getDiscussionAPI().getCommentsList(responseId, PAGE_SIZE, page);
-            }
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
-        }
-        return null;
+        return environment.getDiscussionAPI().getCommentsList(responseId, PAGE_SIZE, page);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetCourseStructureTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetCourseStructureTask.java
@@ -1,6 +1,7 @@
 package org.edx.mobile.task;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import org.edx.mobile.base.MainApplication;
 import org.edx.mobile.http.OkHttpUtil;
@@ -12,45 +13,24 @@ import java.util.Date;
 public abstract class GetCourseStructureTask extends
 Task<CourseComponent> {
 
+    @NonNull
     String courseId;
 
-    public GetCourseStructureTask(Context context, String courseId) {
+    public GetCourseStructureTask(@NonNull Context context, @NonNull String courseId) {
         super(context);
         this.courseId = courseId;
     }
 
     public CourseComponent call( ) throws Exception{
-        try {
-
-            if(courseId!=null){
-                PrefManager.UserPrefManager prefManager = new PrefManager.UserPrefManager(MainApplication.instance());
-                long lastFetchTime = prefManager.getLastCourseStructureFetch(courseId);
-                long curTime = new Date().getTime();
-                OkHttpUtil.REQUEST_CACHE_TYPE useCacheType = OkHttpUtil.REQUEST_CACHE_TYPE.PREFER_CACHE;
-                //if last fetch happened over one hour ago, re-fetch data
-                if ( lastFetchTime + 3600 * 1000 < curTime ){
-                    useCacheType =  OkHttpUtil.REQUEST_CACHE_TYPE.IGNORE_CACHE;;
-                    prefManager.setLastCourseStructureFetch(courseId, curTime);
-                }
-                final CourseComponent model = environment.getServiceManager().getCourseStructure(courseId, useCacheType);
-                if (model != null) {
-                    handler.post(new Runnable() {
-                        public void run() {
-                            try {
-                                onSuccess(model);
-                            } catch (Exception e) {
-                                handle(e);
-                                logger.error(e);
-                            }
-                            stopProgress();
-                        }
-                    });
-                }
-            }
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
+        PrefManager.UserPrefManager prefManager = new PrefManager.UserPrefManager(MainApplication.instance());
+        long lastFetchTime = prefManager.getLastCourseStructureFetch(courseId);
+        long curTime = new Date().getTime();
+        OkHttpUtil.REQUEST_CACHE_TYPE useCacheType = OkHttpUtil.REQUEST_CACHE_TYPE.PREFER_CACHE;
+        //if last fetch happened over one hour ago, re-fetch data
+        if ( lastFetchTime + 3600 * 1000 < curTime ){
+            useCacheType =  OkHttpUtil.REQUEST_CACHE_TYPE.IGNORE_CACHE;;
+            prefManager.setLastCourseStructureFetch(courseId, curTime);
         }
-        return null;
+        return environment.getServiceManager().getCourseStructure(courseId, useCacheType);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetHandoutTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetHandoutTask.java
@@ -1,53 +1,33 @@
 package org.edx.mobile.task;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.model.api.HandoutModel;
 import org.edx.mobile.services.ServiceManager;
 
 public abstract class GetHandoutTask extends Task<HandoutModel> {
+    @NonNull
     EnrolledCoursesResponse enrollment;
-    public GetHandoutTask(Context context,EnrolledCoursesResponse enrollment ) {
+    public GetHandoutTask(@NonNull Context context, @NonNull EnrolledCoursesResponse enrollment) {
         super(context);
         this.enrollment = enrollment;
     }
 
     @Override
     public HandoutModel call() throws Exception{
-        try {
+        ServiceManager api = environment.getServiceManager();
 
-            if(enrollment!=null){
-                ServiceManager api = environment.getServiceManager();
-
-                try {
-                    // return instant data from cache
-                    final HandoutModel model = api.getHandout
-                            (enrollment.getCourse().getCourse_handouts(), true);
-                    if (model != null) {
-                        handler.post(new Runnable() {
-                            public void run() {
-                                try {
-                                    onSuccess(model);
-                                } catch (Exception e) {
-                                    logger.error(e);
-                                }
-                                stopProgress();
-                            }
-                        });
-                    }
-                } catch(Exception ex) {
-                    logger.error(ex);
-                }
-
-                return api.getHandout(enrollment.getCourse()
-                        .getCourse_handouts(), false);
-            }
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
+        // return instant data from cache if available
+        HandoutModel model = api.getHandout
+                (enrollment.getCourse().getCourse_handouts(), true);
+        if (model == null) {
+            model = api.getHandout(enrollment.getCourse()
+                    .getCourse_handouts(), false);;
         }
-        return null;
+
+        return model;
     }
 
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetLastAccessedTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetLastAccessedTask.java
@@ -1,31 +1,24 @@
 package org.edx.mobile.task;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import org.edx.mobile.model.api.SyncLastAccessedSubsectionResponse;
 import org.edx.mobile.services.ServiceManager;
 
 public abstract class GetLastAccessedTask extends Task<SyncLastAccessedSubsectionResponse> {
 
+    @NonNull
     String courseId;
-    public GetLastAccessedTask(Context context,  String courseId) {
+    public GetLastAccessedTask(@NonNull Context context, @NonNull String courseId) {
         super(context);
         this.courseId = courseId;
     }
 
     @Override
     public SyncLastAccessedSubsectionResponse call() throws Exception{
-        try {
-
-            if(courseId!=null){
-                ServiceManager api = environment.getServiceManager();
-                SyncLastAccessedSubsectionResponse res = api.getLastAccessedSubsection(courseId);
-                return res;
-            }
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
-        }
-        return null;
+        ServiceManager api = environment.getServiceManager();
+        SyncLastAccessedSubsectionResponse res = api.getLastAccessedSubsection(courseId);
+        return res;
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetResponsesListTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetResponsesListTask.java
@@ -1,19 +1,21 @@
 package org.edx.mobile.task;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import org.edx.mobile.discussion.DiscussionComment;
 import org.edx.mobile.model.Page;
 
 public abstract class GetResponsesListTask extends Task<Page<DiscussionComment>> {
 
+    @NonNull
     String threadId;
     int page = 1;
     boolean isQuestionType;
     boolean shouldGetEndorsed;
 
-    public GetResponsesListTask(Context context, String threadId, int page, boolean isQuestionType,
-                                boolean shouldGetEndorsed) {
+    public GetResponsesListTask(@NonNull Context context, @NonNull String threadId, int page,
+                                boolean isQuestionType, boolean shouldGetEndorsed) {
         super(context);
         this.threadId = threadId;
         this.page = page;
@@ -22,18 +24,10 @@ public abstract class GetResponsesListTask extends Task<Page<DiscussionComment>>
     }
 
     public Page<DiscussionComment> call() throws Exception {
-        try {
-            if (threadId != null) {
-                if (isQuestionType) {
-                    return environment.getDiscussionAPI().getResponsesListForQuestion(threadId,
-                            page, shouldGetEndorsed);
-                }
-                return environment.getDiscussionAPI().getResponsesList(threadId, page);
-            }
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
+        if (isQuestionType) {
+            return environment.getDiscussionAPI().getResponsesListForQuestion(threadId,
+                    page, shouldGetEndorsed);
         }
-        return null;
+        return environment.getDiscussionAPI().getResponsesList(threadId, page);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetSessesionExchangeCookieTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetSessesionExchangeCookieTask.java
@@ -15,14 +15,8 @@ public abstract class GetSessesionExchangeCookieTask extends Task<List<HttpCooki
 
     @Override
     public List<HttpCookie> call( ) throws Exception{
-        try {
-                ServiceManager api = environment.getServiceManager();
-                return api.getSessionExchangeCookie();
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
-        }
-        return null;
+        ServiceManager api = environment.getServiceManager();
+        return api.getSessionExchangeCookie();
     }
 
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetThreadListTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetThreadListTask.java
@@ -17,16 +17,20 @@ import java.util.List;
 
 public abstract class GetThreadListTask extends Task<Page<DiscussionThread>> {
 
+    @NonNull
     final String courseId;
+    @NonNull
     final DiscussionTopic topic;
+    @NonNull
     final DiscussionPostsFilter filter;
+    @NonNull
     final DiscussionPostsSort orderBy;
     final int page;
 
-    public GetThreadListTask(Context context, String courseId,
-                             DiscussionTopic topic,
-                             DiscussionPostsFilter filter,
-                             DiscussionPostsSort orderBy,
+    public GetThreadListTask(@NonNull Context context, @NonNull String courseId,
+                             @NonNull DiscussionTopic topic,
+                             @NonNull DiscussionPostsFilter filter,
+                             @NonNull DiscussionPostsSort orderBy,
                              int page) {
         super(context);
         this.courseId = courseId;
@@ -37,22 +41,14 @@ public abstract class GetThreadListTask extends Task<Page<DiscussionThread>> {
     }
 
     public Page<DiscussionThread> call() throws Exception {
-        try {
-            if (courseId != null) {
-                if (!topic.isFollowingType()) {
-                    return environment.getDiscussionAPI().getThreadList(courseId,
-                            getAllTopicIds(), filter.getQueryParamValue(),
-                            orderBy.getQueryParamValue(), page);
-                } else {
-                    return environment.getDiscussionAPI().getFollowingThreadList(courseId,
-                            filter.getQueryParamValue(), orderBy.getQueryParamValue(), page);
-                }
-            }
-        } catch (RetroHttpException ex) {
-            handle(ex);
-            logger.error(ex, true);
+        if (!topic.isFollowingType()) {
+            return environment.getDiscussionAPI().getThreadList(courseId,
+                    getAllTopicIds(), filter.getQueryParamValue(),
+                    orderBy.getQueryParamValue(), page);
+        } else {
+            return environment.getDiscussionAPI().getFollowingThreadList(courseId,
+                    filter.getQueryParamValue(), orderBy.getQueryParamValue(), page);
         }
-        return null;
     }
 
     @NonNull

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetThreadTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetThreadTask.java
@@ -1,28 +1,22 @@
 package org.edx.mobile.task;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import org.edx.mobile.discussion.DiscussionThread;
 import org.edx.mobile.http.RetroHttpException;
 
 public abstract class GetThreadTask extends Task<DiscussionThread> {
 
+    @NonNull
     final String threadId;
 
-    public GetThreadTask(Context context, String threadId) {
+    public GetThreadTask(@NonNull Context context, @NonNull String threadId) {
         super(context);
         this.threadId = threadId;
     }
 
     public DiscussionThread call() throws Exception {
-        try {
-            if (threadId != null) {
-                return environment.getDiscussionAPI().getThread(threadId);
-            }
-        } catch (RetroHttpException ex) {
-            handle(ex);
-            logger.error(ex, true);
-        }
-        return null;
+        return environment.getDiscussionAPI().getThread(threadId);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetTopicListTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetTopicListTask.java
@@ -1,15 +1,17 @@
 package org.edx.mobile.task;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import org.edx.mobile.discussion.CourseTopics;
 
 public abstract class GetTopicListTask extends
 Task<CourseTopics> {
 
+    @NonNull
     String courseId;
 
-    public GetTopicListTask(Context context, String courseId) {
+    public GetTopicListTask(@NonNull Context context, @NonNull String courseId) {
         super(context);
         this.courseId = courseId;
     }
@@ -17,16 +19,6 @@ Task<CourseTopics> {
 
 
     public CourseTopics call( ) throws Exception{
-        try {
-
-            if(courseId!=null){
-
-                return environment.getDiscussionAPI().getTopicList(courseId);
-            }
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
-        }
-        return null;
+        return environment.getDiscussionAPI().getTopicList(courseId);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/LoginTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/LoginTask.java
@@ -1,6 +1,7 @@
 package org.edx.mobile.task;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import org.edx.mobile.model.api.AuthResponse;
 import org.edx.mobile.services.ServiceManager;
@@ -11,10 +12,12 @@ import org.edx.mobile.services.ServiceManager;
  *
  */
 public abstract class LoginTask extends Task<AuthResponse> {
+    @NonNull
     String username;
+    @NonNull
     String password;
 
-    public LoginTask(Context context, String username, String password) {
+    public LoginTask(@NonNull Context context, @NonNull String username, @NonNull String password) {
         super(context);
         this.username = username;
         this.password = password;
@@ -22,15 +25,7 @@ public abstract class LoginTask extends Task<AuthResponse> {
 
     @Override
     public AuthResponse call() throws Exception{
-        try {
-            if(username!=null) {
-                return getAuthResponse(context, username, password);
-            }
-        } catch(Exception ex) {
-            handle(ex);
-            logger.error(ex);
-        }
-        return null;
+        return getAuthResponse(context, username, password);
     }
 
     public  AuthResponse getAuthResponse(Context context, String username, String password) throws Exception {

--- a/VideoLocker/src/main/java/org/edx/mobile/task/RegisterTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/RegisterTask.java
@@ -26,43 +26,37 @@ public abstract class RegisterTask extends Task<RegisterResponse> {
 
     @Override
     public RegisterResponse call( ) throws Exception{
-        try {
-            ServiceManager api = environment.getServiceManager();
-            RegisterResponse res = api.register(parameters);
+        ServiceManager api = environment.getServiceManager();
+        RegisterResponse res = api.register(parameters);
 
-            if (res.isSuccess()) {
-                switch ( backstoreType ){
-                    case  TYPE_GOOGLE :
-                    case  TYPE_FACEBOOK :
-                         // do SOCIAL LOGIN first
-                        if ( backstoreType == SocialFactory.SOCIAL_SOURCE_TYPE.TYPE_FACEBOOK ) {
-                            auth = api.loginByFacebook(accessToken);
-                        } else if ( backstoreType == SocialFactory.SOCIAL_SOURCE_TYPE.TYPE_GOOGLE ) {
-                            auth = api.loginByGoogle(accessToken);
-                        }
-                        if (auth != null && auth.isSuccess()) {
-                            // we got a valid accessToken so profile can be fetched
-                            ProfileModel profile =  api.getProfile();
+        if (res.isSuccess()) {
+            switch ( backstoreType ){
+                case  TYPE_GOOGLE :
+                case  TYPE_FACEBOOK :
+                    // do SOCIAL LOGIN first
+                    if ( backstoreType == SocialFactory.SOCIAL_SOURCE_TYPE.TYPE_FACEBOOK ) {
+                        auth = api.loginByFacebook(accessToken);
+                    } else if ( backstoreType == SocialFactory.SOCIAL_SOURCE_TYPE.TYPE_GOOGLE ) {
+                        auth = api.loginByGoogle(accessToken);
+                    }
+                    if (auth != null && auth.isSuccess()) {
+                        // we got a valid accessToken so profile can be fetched
+                        ProfileModel profile =  api.getProfile();
 
-                        }
-                        break;
-                    default: //normal email addrss login
-                        String username = parameters.getString("username");
-                        String password = parameters.getString("password");
+                    }
+                    break;
+                default: //normal email addrss login
+                    String username = parameters.getString("username");
+                    String password = parameters.getString("password");
 
-                        auth =  getAuthResponse(context, username, password);
-                        if (auth.isSuccess()) {
-                            logger.debug("login succeeded after email registration");
-                        }
-                }
+                    auth =  getAuthResponse(context, username, password);
+                    if (auth.isSuccess()) {
+                        logger.debug("login succeeded after email registration");
+                    }
             }
-
-            return res;
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
         }
-        return null;
+
+        return res;
     }
 
     public  AuthResponse getAuthResponse(Context context, String username, String password) throws Exception {

--- a/VideoLocker/src/main/java/org/edx/mobile/task/ResetPasswordTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/ResetPasswordTask.java
@@ -1,31 +1,24 @@
 package org.edx.mobile.task;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import org.edx.mobile.model.api.ResetPasswordResponse;
 import org.edx.mobile.services.ServiceManager;
 
 public abstract class ResetPasswordTask extends Task<ResetPasswordResponse> {
 
+    @NonNull
     String emailId;
-    public ResetPasswordTask(Context context,String emailId) {
+    public ResetPasswordTask(@NonNull Context context, @NonNull String emailId) {
         super(context);
         this.emailId = emailId;
     }
 
     @Override
     public ResetPasswordResponse call() throws Exception{
-        try {
-
-            if(emailId!=null){
-                ServiceManager api = environment.getServiceManager();
-                ResetPasswordResponse res = api.resetPassword(emailId);
-                return res;
-            }
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
-        }
-        return null;
+        ServiceManager api = environment.getServiceManager();
+        ResetPasswordResponse res = api.resetPassword(emailId);
+        return res;
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/SearchThreadListTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/SearchThreadListTask.java
@@ -1,6 +1,7 @@
 package org.edx.mobile.task;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import org.edx.mobile.discussion.DiscussionThread;
 import org.edx.mobile.model.Page;
@@ -8,11 +9,14 @@ import org.edx.mobile.model.Page;
 public abstract class SearchThreadListTask extends
         Task<Page<DiscussionThread>> {
 
+    @NonNull
     final String courseId;
+    @NonNull
     final String text;
     final int page;
 
-    public SearchThreadListTask(Context context, String courseId, String text, int page) {
+    public SearchThreadListTask(@NonNull Context context, @NonNull String courseId,
+                                @NonNull String text, int page) {
         super(context);
         this.courseId = courseId;
         this.text = text;
@@ -20,14 +24,6 @@ public abstract class SearchThreadListTask extends
     }
 
     public Page<DiscussionThread> call() throws Exception {
-        try {
-            if (courseId != null) {
-                return environment.getDiscussionAPI().searchThreadList(courseId, text, page);
-            }
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
-        }
-        return null;
+        return environment.getDiscussionAPI().searchThreadList(courseId, text, page);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/SetCommentFlaggedTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/SetCommentFlaggedTask.java
@@ -16,13 +16,7 @@ public abstract class SetCommentFlaggedTask extends Task<DiscussionComment> {
         this.flagged = flagged;
     }
 
-    public DiscussionComment call() {
-        try {
-            return environment.getDiscussionAPI().setCommentFlagged(comment, flagged);
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
-            return null;
-        }
+    public DiscussionComment call() throws Exception {
+        return environment.getDiscussionAPI().setCommentFlagged(comment, flagged);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/SetCommentVotedTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/SetCommentVotedTask.java
@@ -16,13 +16,7 @@ public abstract class SetCommentVotedTask extends Task<DiscussionComment> {
         this.voted = voted;
     }
 
-    public DiscussionComment call() {
-        try {
-            return environment.getDiscussionAPI().setCommentVoted(comment, voted);
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
-            return null;
-        }
+    public DiscussionComment call() throws Exception {
+        return environment.getDiscussionAPI().setCommentVoted(comment, voted);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/SetThreadFlaggedTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/SetThreadFlaggedTask.java
@@ -16,13 +16,7 @@ public abstract class SetThreadFlaggedTask extends Task<DiscussionThread> {
         this.flagged = flagged;
     }
 
-    public DiscussionThread call() {
-        try {
-            return environment.getDiscussionAPI().setThreadFlagged(thread, flagged);
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
-            return null;
-        }
+    public DiscussionThread call() throws Exception {
+        return environment.getDiscussionAPI().setThreadFlagged(thread, flagged);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/SetThreadFollowedTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/SetThreadFollowedTask.java
@@ -16,13 +16,7 @@ public abstract class SetThreadFollowedTask extends Task<DiscussionThread> {
         this.followed = followed;
     }
 
-    public DiscussionThread call() {
-        try {
-            return environment.getDiscussionAPI().setThreadFollowed(thread, followed);
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
-            return null;
-        }
+    public DiscussionThread call() throws Exception {
+        return environment.getDiscussionAPI().setThreadFollowed(thread, followed);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/SetThreadReadTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/SetThreadReadTask.java
@@ -29,9 +29,4 @@ public class SetThreadReadTask extends Task<DiscussionThread> {
     protected void onSuccess(DiscussionThread discussionThread) {
         EventBus.getDefault().post(new DiscussionThreadUpdatedEvent(discussionThread));
     }
-
-    @Override
-    protected void onException(Exception e) throws RuntimeException {
-        handle(e);
-    }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/SetThreadVotedTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/SetThreadVotedTask.java
@@ -16,13 +16,7 @@ public abstract class SetThreadVotedTask extends Task<DiscussionThread> {
         this.voted = voted;
     }
 
-    public DiscussionThread call() {
-        try {
-            return environment.getDiscussionAPI().setThreadVoted(thread, voted);
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
-            return null;
-        }
+    public DiscussionThread call() throws Exception {
+        return environment.getDiscussionAPI().setThreadVoted(thread, voted);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/SyncLastAccessedTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/SyncLastAccessedTask.java
@@ -1,15 +1,19 @@
 package org.edx.mobile.task;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import org.edx.mobile.model.api.SyncLastAccessedSubsectionResponse;
 import org.edx.mobile.services.ServiceManager;
 
 public abstract class SyncLastAccessedTask extends Task<SyncLastAccessedSubsectionResponse> {
 
+    @NonNull
     String courseId ;
+    @NonNull
     String lastVisitedModuleId ;
-    public SyncLastAccessedTask(Context context, String courseId, String lastVisitedModuleId) {
+    public SyncLastAccessedTask(@NonNull Context context, @NonNull String courseId,
+                                @NonNull String lastVisitedModuleId) {
         super(context);
         this.courseId = courseId;
         this.lastVisitedModuleId = lastVisitedModuleId;
@@ -17,18 +21,9 @@ public abstract class SyncLastAccessedTask extends Task<SyncLastAccessedSubsecti
 
     @Override
     public SyncLastAccessedSubsectionResponse call( ) throws Exception{
-        try {
-
-            if(courseId!=null && lastVisitedModuleId !=null){
-                ServiceManager api = environment.getServiceManager();
-                SyncLastAccessedSubsectionResponse res = api.syncLastAccessedSubsection(
-                        courseId, lastVisitedModuleId);
-                return res;
-            }
-        } catch (Exception ex) {
-            handle(ex);
-            logger.error(ex, true);
-        }
-        return null;
+        ServiceManager api = environment.getServiceManager();
+        SyncLastAccessedSubsectionResponse res = api.syncLastAccessedSubsection(
+                courseId, lastVisitedModuleId);
+        return res;
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/Task.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/Task.java
@@ -99,17 +99,8 @@ public abstract class Task<T> extends RoboAsyncTask<T> {
         }
     }
 
-    protected void handle(final Exception ex) {
-        handler.post(new Runnable() {
-            public void run() {
-                showErrorMessage(ex);
-                onException(ex);
-            }
-        });
-    }
-
-    // TODO: Make this the default behaviour?
-    protected void showErrorMessage(final Exception ex) {
+    @Override
+    protected void onException(Exception ex) {
         final TaskMessageCallback callback = getMessageCallback();
         if (callback == null) {
             return;

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseCombinedInfoFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseCombinedInfoFragment.java
@@ -167,6 +167,7 @@ public class CourseCombinedInfoFragment extends CourseDetailBaseFragment {
 
             @Override
             public void onException(Exception ex) {
+                super.onException(ex);
                 showEmptyAnnouncementMessage();
             }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDetailFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDetailFragment.java
@@ -217,12 +217,6 @@ public class CourseDetailFragment extends BaseFragment {
                     courseAbout.setVisibility(View.GONE);
                 }
             }
-
-            @Override
-            protected void onException(Exception e) throws RuntimeException {
-                super.onException(e);
-                showErrorMessage(e);
-            }
         };
         getCourseDetailTask.execute();
     }
@@ -337,11 +331,6 @@ public class CourseDetailFragment extends BaseFragment {
                                         environment.getRouter().showMyCourses(getActivity());
                                         environment.getRouter().showCourseDashboardTabs(getActivity(), environment.getConfig(), course, false);
                                     }
-
-                                    @Override
-                                    public void onException(Exception ex) {
-                                        logger.error(ex);
-                                    }
                                 };
                         getEnrolledCourseTask.execute();
                     }
@@ -349,7 +338,7 @@ public class CourseDetailFragment extends BaseFragment {
             }
             @Override
             public void onException(Exception ex) {
-                logger.error(ex);
+                super.onException(ex);
                 Toast.makeText(getContext(), R.string.enrollment_failure, Toast.LENGTH_SHORT).show();
             }
         };

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
@@ -127,7 +127,7 @@ public class CourseDiscussionCommentsFragment extends BaseFragment implements Di
 
             @Override
             public void onException(Exception ex) {
-                logger.error(ex);
+                super.onException(ex);
                 discussionCommentsAdapter.setProgressVisible(false);
             }
         };
@@ -173,11 +173,6 @@ public class CourseDiscussionCommentsFragment extends BaseFragment implements Di
             @Override
             public void onSuccess(DiscussionComment comment) {
                 discussionCommentsAdapter.updateComment(comment);
-            }
-
-            @Override
-            public void onException(Exception ex) {
-                logger.error(ex);
             }
         };
         setCommentFlaggedTask.execute();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsSearchFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsSearchFragment.java
@@ -93,13 +93,6 @@ public class CourseDiscussionPostsSearchFragment extends CourseDiscussionPostsBa
                     }
                 }
             }
-
-            @Override
-            public void onException(Exception ex) {
-                logger.error(ex);
-                //  hideProgress();
-
-            }
         };
         searchThreadListTask.setProgressCallback(null);
         searchThreadListTask.execute();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
@@ -242,12 +242,6 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
                     checkNoResultView(EmptyQueryResultsFor.CATEGORY);
                 }
             }
-
-            @Override
-            public void onException(Exception ex) {
-                logger.error(ex);
-                //  hideProgress();
-            }
         };
         getThreadListTask.setProgressCallback(null);
         getThreadListTask.execute();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
@@ -229,11 +229,6 @@ public class CourseDiscussionResponsesFragment extends BaseFragment implements C
                         }
                     }
                 }
-
-                @Override
-                public void onException(Exception ex) {
-                    logger.error(ex);
-                }
             };
             getResponsesListTask.setProgressCallback(null);
             getResponsesListTask.execute();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionTopicsFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionTopicsFragment.java
@@ -128,21 +128,14 @@ public class CourseDiscussionTopicsFragment extends BaseFragment {
         getTopicListTask = new GetTopicListTask(getActivity(), courseData.getCourse().getId()) {
             @Override
             public void onSuccess(CourseTopics courseTopics) {
-                if (courseTopics != null) {
-                    logger.debug("GetTopicListTask success=" + courseTopics);
-                    ArrayList<DiscussionTopic> allTopics = new ArrayList<>();
-                    allTopics.addAll(courseTopics.getNonCoursewareTopics());
-                    allTopics.addAll(courseTopics.getCoursewareTopics());
+                logger.debug("GetTopicListTask success=" + courseTopics);
+                ArrayList<DiscussionTopic> allTopics = new ArrayList<>();
+                allTopics.addAll(courseTopics.getNonCoursewareTopics());
+                allTopics.addAll(courseTopics.getCoursewareTopics());
 
-                    List<DiscussionTopicDepth> allTopicsWithDepth = DiscussionTopicDepth.createFromDiscussionTopics(allTopics);
-                    discussionTopicsAdapter.setItems(allTopicsWithDepth);
-                    discussionTopicsAdapter.notifyDataSetChanged();
-                }
-            }
-
-            @Override
-            public void onException(Exception ex) {
-                logger.error(ex);
+                List<DiscussionTopicDepth> allTopicsWithDepth = DiscussionTopicDepth.createFromDiscussionTopics(allTopics);
+                discussionTopicsAdapter.setItems(allTopicsWithDepth);
+                discussionTopicsAdapter.notifyDataSetChanged();
             }
         };
         getTopicListTask.execute();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseHandoutFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseHandoutFragment.java
@@ -106,12 +106,13 @@ public class CourseHandoutFragment extends BaseFragment {
 
             @Override
             public void onException(Exception ex) {
+                super.onException(ex);
+
                 if (getActivity() == null) {
                     return;
                 }
 
                 isHandoutFetched = false;
-                logger.error(ex);
                 CourseHandoutFragment.this.showErrorMessage(R.string.no_handouts_to_display,
                         FontAwesomeIcons.fa_exclamation_circle);
             }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseLectureListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseLectureListActivity.java
@@ -328,6 +328,7 @@ public class CourseLectureListActivity extends BaseFragmentActivity {
 
             @Override
             public void onException(Exception ex) {
+                super.onException(ex);
                 hideProgressDialog();
                 showInfoMessage(getString(R.string.msg_video_not_downloaded));
             }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
@@ -139,7 +139,7 @@ public class DiscussionAddCommentFragment extends BaseFragment {
 
             @Override
             public void onException(Exception ex) {
-                logger.error(ex);
+                super.onException(ex);
                 buttonAddComment.setEnabled(true);
             }
         };

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddPostFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddPostFragment.java
@@ -211,7 +211,7 @@ public class DiscussionAddPostFragment extends BaseFragment {
 
             @Override
             public void onException(Exception ex) {
-                logger.error(ex);
+                super.onException(ex);
                 addPostButton.setEnabled(true);
             }
         };
@@ -258,11 +258,6 @@ public class DiscussionAddPostFragment extends BaseFragment {
                 values.put(ISegment.Keys.TOPIC_ID, selectedTopic.getIdentifier());
                 segIO.trackScreenView(ISegment.Screens.FORUM_CREATE_TOPIC_THREAD,
                         courseData.getCourse().getId(), selectedTopic.getName(), values);
-            }
-
-            @Override
-            public void onException(Exception ex) {
-                logger.error(ex);
             }
         };
         getTopicListTask.setMessageCallback(null);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
@@ -139,7 +139,7 @@ public class DiscussionAddResponseFragment extends BaseFragment {
 
             @Override
             public void onException(Exception ex) {
-                logger.error(ex);
+                super.onException(ex);
                 buttonAddComment.setEnabled(true);
             }
         };

--- a/VideoLocker/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
@@ -174,12 +174,6 @@ public class EditUserProfileFragment extends BaseFragment {
                                         hideLoading();
                                     }
 
-                                    @Override
-                                    protected void onException(Exception e) throws RuntimeException {
-                                        super.onException(e);
-                                        showErrorMessage(e);
-                                    }
-
                                     private void hideLoading() {
                                         if (null != viewHolder) {
                                             viewHolder.profileImageProgress.setVisibility(View.GONE);
@@ -424,7 +418,6 @@ public class EditUserProfileFragment extends BaseFragment {
                         @Override
                         protected void onException(Exception e) throws RuntimeException {
                             super.onException(e);
-                            showErrorMessage(e);
                             hideLoading();
                         }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/LoginActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/LoginActivity.java
@@ -274,13 +274,13 @@ public class LoginActivity extends BaseFragmentActivity implements SocialLoginDe
                                 throw new LoginException(errorMsg);
                             }
                         } catch (LoginException ex) {
-                            logger.error(ex);
-                            handle(ex);
+                            super.onException(ex);
                         }
                     }
 
                     @Override
                     public void onException(Exception ex) {
+                        super.onException(ex);
                         onUserLoginFailure(ex, null, null);
                     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -331,7 +331,7 @@ public class RegisterActivity extends BaseFragmentActivity
 
                 @Override
                 public void onException(Exception ex) {
-                    logger.error(ex);
+                    super.onException(ex);
                     hideProgress();
                 }
             };

--- a/VideoLocker/src/main/java/org/edx/mobile/view/UserProfileFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/UserProfileFragment.java
@@ -130,8 +130,6 @@ public class UserProfileFragment extends BaseFragment {
                 @Override
                 protected void onException(Exception e) throws RuntimeException {
                     viewHolder.loadingIndicator.setVisibility(View.GONE);
-                    logger.error(e);
-                    showErrorMessage(e);
                 }
             };
             getAccountTask.setProgressCallback(null); // Disable built-in loading indicator

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -168,15 +168,8 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
                 SetThreadFlaggedTask task = new SetThreadFlaggedTask(context, discussionThread, !discussionThread.isAbuseFlagged()) {
                     @Override
                     public void onSuccess(DiscussionThread topicThread) {
-                        if (topicThread != null) {
-                            CourseDiscussionResponsesAdapter.this.discussionThread = topicThread;
-                            notifyItemChanged(0);
-                        }
-                    }
-
-                    @Override
-                    public void onException(Exception ex) {
-                        logger.error(ex);
+                        CourseDiscussionResponsesAdapter.this.discussionThread = topicThread;
+                        notifyItemChanged(0);
                     }
                 };
                 task.execute();
@@ -195,16 +188,9 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
                 SetThreadVotedTask task = new SetThreadVotedTask(context, discussionThread, !discussionThread.isVoted()) {
                     @Override
                     public void onSuccess(DiscussionThread updatedDiscussionThread) {
-                        if (updatedDiscussionThread != null) {
-                            CourseDiscussionResponsesAdapter.this.discussionThread = updatedDiscussionThread;
-                            EventBus.getDefault().post(new DiscussionThreadUpdatedEvent(updatedDiscussionThread));
-                            notifyItemChanged(0);
-                        }
-                    }
-
-                    @Override
-                    public void onException(Exception ex) {
-                        logger.error(ex);
+                        CourseDiscussionResponsesAdapter.this.discussionThread = updatedDiscussionThread;
+                        EventBus.getDefault().post(new DiscussionThreadUpdatedEvent(updatedDiscussionThread));
+                        notifyItemChanged(0);
                     }
                 };
                 task.execute();
@@ -218,16 +204,9 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
                 SetThreadFollowedTask task = new SetThreadFollowedTask(context, discussionThread, !discussionThread.isFollowing()) {
                     @Override
                     public void onSuccess(DiscussionThread updatedDiscussionThread) {
-                        if (updatedDiscussionThread != null) {
-                            CourseDiscussionResponsesAdapter.this.discussionThread = updatedDiscussionThread;
-                            EventBus.getDefault().post(new DiscussionThreadUpdatedEvent(updatedDiscussionThread));
-                            notifyItemChanged(0);
-                        }
-                    }
-
-                    @Override
-                    public void onException(Exception ex) {
-                        logger.error(ex);
+                        CourseDiscussionResponsesAdapter.this.discussionThread = updatedDiscussionThread;
+                        EventBus.getDefault().post(new DiscussionThreadUpdatedEvent(updatedDiscussionThread));
+                        notifyItemChanged(0);
                     }
                 };
                 task.execute();
@@ -289,15 +268,8 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
                 SetCommentFlaggedTask task = new SetCommentFlaggedTask(context, comment, !comment.isAbuseFlagged()) {
                     @Override
                     public void onSuccess(DiscussionComment comment) {
-                        if (comment != null) {
-                            discussionResponses.set(position - 1, comment);
-                            notifyItemChanged(position);
-                        }
-                    }
-
-                    @Override
-                    public void onException(Exception ex) {
-                        logger.error(ex);
+                        discussionResponses.set(position - 1, comment);
+                        notifyItemChanged(position);
                     }
                 };
                 task.execute();
@@ -350,15 +322,8 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
                 SetCommentVotedTask task = new SetCommentVotedTask(context, response, !response.isVoted()) {
                     @Override
                     public void onSuccess(DiscussionComment comment) {
-                        if (comment != null) {
-                            discussionResponses.set(position - 1, comment);
-                            notifyItemChanged(position);
-                        }
-                    }
-
-                    @Override
-                    public void onException(Exception ex) {
-                        logger.error(ex);
+                        discussionResponses.set(position - 1, comment);
+                        notifyItemChanged(position);
                     }
                 };
                 task.execute();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/dialog/NativeFindCoursesFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/dialog/NativeFindCoursesFragment.java
@@ -73,7 +73,6 @@ public class NativeFindCoursesFragment extends BaseFragment {
                     @Override
                     protected void onException(Exception e) throws RuntimeException {
                         super.onException(e);
-                        showErrorMessage(e);
                         if (null != viewHolder) {
                             viewHolder.loadingIndicator.setVisibility(View.GONE);
                         }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/dialog/ResetPasswordDialog.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/dialog/ResetPasswordDialog.java
@@ -122,7 +122,7 @@ public class ResetPasswordDialog extends DialogFragment {
 
             @Override
             public void onException(Exception ex) {
-                logger.error(ex);
+                super.onException(ex);
                 email_et.setEnabled(true);
                 resetLayout.setVisibility(View.GONE);
                 isResetSuccessful = false;


### PR DESCRIPTION
Previously, the `Task` implementations were catching and handling all exceptions in the call() method implementation itself, and returning `null` in those cases, in spite of the fact that the base `RoboAsyncTask` implementation already has a framework for catching the exceptions and passing it to the `onException()` callback. The generic exception handling method that was being called in those cases was presumably not implemented in this callback to avoid requiring subclasses to call through to the super implementation. However, since all exceptions were captured, this guaranteed that the callback was never invoked in the first place. The callback implementations were also not usually prepared
to handle `null` results. This inconsistent design led to a lot of issues and crashes in the case of failures.

This pull request fixes these issues by removing all this exception catching from the `call()` implementations, and moving the generic error handling logic to the `onException()` callback, and ensuring the all the subclasses call through to the super implementation (and removing the
redundancies in the subclass implementations). In cases where the callback override is completely redundant, it has been removed. All the `null` checking in the `call()` implementations have been replaced by `@NonNull` annotations in the constructor parameters and the local variables. Since Retrofit API method calls should never return null, the `null` checking on the results of tasks that use those methods have been removed as well. The custom `HttpManager` using the Apache client that is used in the courseware module has no such guarantees though, so the null checks on their results have been left alone.

Fixes [MA-2060][].

[MA-2060]: https://openedx.atlassian.net/browse/MA-2060