### PR TITLE
MA-2165 redirect to youtube

### DIFF
--- a/VideoLocker/res/layout/fragment_course_unit_only_on_youtube.xml
+++ b/VideoLocker/res/layout/fragment_course_unit_only_on_youtube.xml
@@ -1,0 +1,45 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/edx_grayscale_neutral_white_t"
+    android:gravity="center"
+    android:orientation="vertical">
+
+    <org.edx.mobile.view.custom.IconImageViewXml
+        android:layout_width="@dimen/large_indicator_icon_width"
+        android:layout_height="@dimen/large_indicator_icon_height"
+        android:layout_margin="@dimen/edx_margin"
+        app:iconColor="@color/edx_grayscale_neutral_light"
+        app:iconName="fa-film" />
+
+    <TextView
+        android:id="@+id/only_youtube_available_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/edx_margin"
+        android:layout_marginLeft="@dimen/edx_quadruple_margin"
+        android:layout_marginRight="@dimen/edx_quadruple_margin"
+        android:gravity="center"
+        android:singleLine="false"
+        tools:text="@string/assessment_only_on_youtube"
+        android:textAlignment="center"
+        android:textColor="@color/edx_grayscale_neutral_dark"
+        android:textSize="@dimen/edx_base"
+        tools:targetApi="17" />
+
+    <Button
+        android:id="@+id/view_on_youtube_button"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/edx_button_height"
+        android:layout_marginBottom="@dimen/edx_margin"
+        android:background="@drawable/gray_bordered_button_background"
+        android:paddingLeft="@dimen/button_horizontal_padding"
+        android:paddingRight="@dimen/button_horizontal_padding"
+        android:text="@string/assessment_open_on_youtube"
+        android:textColor="@color/edx_grayscale_neutral_x_dark"
+        android:textSize="@dimen/edx_base" />
+
+</LinearLayout>
+

--- a/VideoLocker/res/values/dimens.xml
+++ b/VideoLocker/res/values/dimens.xml
@@ -119,6 +119,7 @@
     <dimen name="edx_box_radius">5dp</dimen>
     <dimen name="edx_margin">15dp</dimen>
     <dimen name="edx_double_margin">30dp</dimen>
+    <dimen name="edx_quadruple_margin">60dp</dimen>
     <dimen name="widget_margin">10dp</dimen>
     <dimen name="horizontal_input_padding">@dimen/widget_margin</dimen>
     <dimen name="vertical_input_padding">8dp</dimen>

--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -376,7 +376,7 @@
     <string name="assessment_full_course">Full Course</string>
     <!-- Label for empty video in video only mode-->
     <string name="assessment_empty_video_info">There are no videos in this section. To view other section content, select {mode_switcher} above and switch to full course mode.</string>
-   <!-- Label showing assessment only available on website-->
+    <!-- Label showing assessment only available on website-->
     <string name="assessment_not_available">This interactive component isn’t yet available on mobile.</string>
     <!-- Label showing assessment only available on website-->
     <string name="assessment_explore_on_web">Explore other parts of this course or view this on web.</string>
@@ -390,6 +390,10 @@
     <string name="assessment_soon">Soon</string>
     <!-- Label to notify user to rotate device for viewing a video in full screen -->
     <string name="assessment_rotate_for_fullscreen">Rotate your device to view this video in full screen.</string>
+    <!-- Label showing only youtube is available -->
+    <string name="assessment_only_on_youtube">This video can only be played on YouTube.</string>
+    <!-- Label for button to open on youtube -->
+    <string name="assessment_open_on_youtube">View video on YouTube</string>
 
     <!-- Video List -->
     <!-- Label shown to indicate video currently downloading -->

--- a/VideoLocker/src/main/java/org/edx/mobile/model/course/EncodedVideos.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/model/course/EncodedVideos.java
@@ -30,4 +30,11 @@ public class EncodedVideos implements Serializable {
             return fallback;
         return null;
     }
+
+    @Nullable
+    public VideoInfo getYoutubeVideoInfo() {
+        if (youtube != null && URLUtil.isNetworkUrl(youtube.url))
+            return youtube;
+        return null;
+    }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -289,8 +289,12 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements 
             CourseComponent unit = getUnit(pos);
             CourseUnitFragment unitFragment;
             //FIXME - for the video, let's ignore studentViewMultiDevice for now
-            if (unit instanceof VideoBlockModel && ((VideoBlockModel)unit).getData().encodedVideos.getPreferredVideoInfo() != null) {
-                unitFragment = CourseUnitVideoFragment.newInstance((VideoBlockModel) unit);
+            if (unit instanceof VideoBlockModel &&
+                    ((VideoBlockModel) unit).getData().encodedVideos.getPreferredVideoInfo() != null) {
+                    unitFragment = CourseUnitVideoFragment.newInstance((VideoBlockModel) unit);
+            } else if (unit instanceof VideoBlockModel &&
+                    ((VideoBlockModel) unit).getData().encodedVideos.getYoutubeVideoInfo() != null) {
+                    unitFragment = CourseUnitOnlyOnYoutubeFragment.newInstance(unit);
             } else if (!unit.isMultiDevice()) {
                 unitFragment = CourseUnitMobileNotSupportedFragment.newInstance(unit);
             } else if (unit.getType() != BlockType.VIDEO &&

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitOnlyOnYoutubeFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitOnlyOnYoutubeFragment.java
@@ -1,0 +1,59 @@
+package org.edx.mobile.view;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import org.edx.mobile.R;
+import org.edx.mobile.model.course.CourseComponent;
+import org.edx.mobile.model.course.VideoBlockModel;
+import org.edx.mobile.services.ViewPagerDownloadManager;
+
+public class CourseUnitOnlyOnYoutubeFragment extends CourseUnitFragment {
+
+    static CourseUnitOnlyOnYoutubeFragment newInstance(CourseComponent unit) {
+        CourseUnitOnlyOnYoutubeFragment fragment = new CourseUnitOnlyOnYoutubeFragment();
+        Bundle args = new Bundle();
+        args.putSerializable(Router.EXTRA_COURSE_UNIT, unit);
+        fragment.setArguments(args);
+
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View v = inflater.inflate(R.layout.fragment_course_unit_only_on_youtube, container, false);
+        ((TextView) v.findViewById(R.id.only_youtube_available_message)).setText(R.string.assessment_only_on_youtube);
+        v.findViewById(R.id.view_on_youtube_button).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent i = new Intent(Intent.ACTION_VIEW);
+                i.setData(Uri.parse(((VideoBlockModel) unit).getData().encodedVideos.youtube.url));
+                startActivity(i);
+            }
+        });
+        return v;
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        if (ViewPagerDownloadManager.instance.inInitialPhase(unit))
+            ViewPagerDownloadManager.instance.addTask(this);
+    }
+
+    @Override
+    public void run() {
+        ViewPagerDownloadManager.instance.done(this, true);
+    }
+}


### PR DESCRIPTION
@bguertin @miankhalid @1zaman 

When there is no encoded video urls returned from the courses outline api,
and the youtube url is present, start an implicit intent with the youtube url.

Note: Seems like we could/should combine the screens like fragment_course_unit_grade, fragment_course_unit_empty, fragment_dashboard_disabled etc.

Addresses https://openedx.atlassian.net/browse/MA-2165