### PR TITLE
Fix endorsing author link directing to post author

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -301,7 +301,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
                     new Runnable() {
                         @Override
                         public void run() {
-                            listener.onClickAuthor(comment.getAuthor());
+                            listener.onClickAuthor(comment.getEndorsedBy());
                         }
                     });
             holder.responseAnswerTextView.setVisibility(View.VISIBLE);


### PR DESCRIPTION
#570 fixed the endorsing author section actually showing the post author in the discussions responses adapter, but it didn't fix the linking, so it still linked to the post author. This issue is now also fixed.

Fixes [MA-2194][].

[MA-2194]: https://openedx.atlassian.net/browse/MA-2194