### PR TITLE
MA-2916 Halt pagination on receiving errors

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
@@ -130,7 +130,9 @@ public class CourseDiscussionCommentsFragment extends BaseFragment implements Di
             @Override
             public void onException(Exception ex) {
                 super.onException(ex);
-                discussionCommentsAdapter.setProgressVisible(false);
+                callback.onError();
+                nextPage = 1;
+                hasMorePages = false;
             }
         };
         getCommentsListTask.setProgressCallback(null);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsSearchFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsSearchFragment.java
@@ -94,6 +94,13 @@ public class CourseDiscussionPostsSearchFragment extends CourseDiscussionPostsBa
                     }
                 }
             }
+
+            @Override
+            protected void onException(Exception ex) {
+                super.onException(ex);
+                callback.onError();
+                nextPage = 1;
+            }
         };
         searchThreadListTask.setProgressCallback(null);
         searchThreadListTask.execute();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
@@ -269,6 +269,13 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
                     checkNoResultView(EmptyQueryResultsFor.CATEGORY);
                 }
             }
+
+            @Override
+            protected void onException(Exception ex) {
+                super.onException(ex);
+                callback.onError();
+                nextPage = 1;
+            }
         };
         getThreadListTask.setProgressCallback(null);
         getThreadListTask.execute();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
@@ -241,6 +241,14 @@ public class CourseDiscussionResponsesFragment extends BaseFragment implements C
                         }
                     }
                 }
+
+                @Override
+                protected void onException(Exception ex) {
+                    super.onException(ex);
+                    callback.onError();
+                    nextPage = 1;
+                    hasMorePages = false;
+                }
             };
             getResponsesListTask.setProgressCallback(null);
             getResponsesListTask.execute();

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/InfiniteScrollUtils.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/InfiniteScrollUtils.java
@@ -96,6 +96,11 @@ public class InfiniteScrollUtils {
          * @param hasMore Whether there are more pages to load.
          */
         public abstract void onPageLoaded(List<T> newItems, boolean hasMore);
+
+        /**
+         * Callback for receiving an error during the page load.
+         */
+        public abstract void onError();
     }
 
     public interface InfiniteListController {
@@ -157,6 +162,16 @@ public class InfiniteScrollUtils {
                     if (!hasMoreItems) {
                         adapter.setProgressVisible(false);
                     }
+                    loading = false;
+                }
+
+                @Override
+                public void onError() {
+                    if (isAbandoned()) {
+                        return;
+                    }
+                    adapter.setProgressVisible(false);
+                    hasMoreItems = false;
                     loading = false;
                 }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/dialog/NativeFindCoursesFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/dialog/NativeFindCoursesFragment.java
@@ -73,6 +73,8 @@ public class NativeFindCoursesFragment extends BaseFragment {
                     @Override
                     protected void onException(Exception e) throws RuntimeException {
                         super.onException(e);
+                        callback.onError();
+                        nextPage = 1;
                         if (null != viewHolder) {
                             viewHolder.loadingIndicator.setVisibility(View.GONE);
                         }


### PR DESCRIPTION
The `PageLoadCallback` interface (more recently converted to an abstract class) of `InfiniteScrollUtils` only defined a callback for a successful page load, and none to handle the case where it encounters an error doing so. Therefore, lacking support in the callback, the client implementations mostly didn't handle the case as well (except for the comments module, which invoked the method to hide the progress bar on the adapter directly). This issue is now addressed by adding an error callback that stops the controller, and invoking it in all error cases.

Fixes [MA-2196][].

[MA-2196]: https://openedx.atlassian.net/browse/MA-2196