### PR TITLE
Fix incrementing of response/comment counts

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
@@ -168,6 +168,9 @@ public class CourseDiscussionCommentsFragment extends BaseFragment implements Di
             if (!hasMorePages) {
                 discussionCommentsAdapter.insertCommentAtEnd(event.getComment());
                 discussionCommentsListView.smoothScrollToPosition(discussionCommentsAdapter.getItemCount() - 1);
+            } else {
+                // We still need to update the comment count locally
+                discussionCommentsAdapter.incrementCommentCount();
             }
         }
     }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
@@ -142,6 +142,9 @@ public class CourseDiscussionResponsesFragment extends BaseFragment implements C
                     courseDiscussionResponsesAdapter.addNewResponse(event.getComment());
                     discussionResponsesRecyclerView.smoothScrollToPosition(
                             courseDiscussionResponsesAdapter.getItemCount() - 1);
+                } else {
+                    // We still need to update the response count locally
+                    courseDiscussionResponsesAdapter.incrementResponseCount();
                 }
             } else {
                 // We got a comment to a response

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -405,9 +405,13 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
         initialTimeStampMs = System.currentTimeMillis();
         int offset = 1 + discussionResponses.size();
         discussionResponses.add(response);
-        discussionThread.incrementResponseCount();
+        incrementResponseCount();
         notifyItemInserted(offset);
-        notifyItemChanged(0); // Comments count is shown in the thread details header, so it also needs to be refreshed.
+    }
+
+    public void incrementResponseCount() {
+        discussionThread.incrementResponseCount();
+        notifyItemChanged(0); // Response count is shown in the thread details header, so it also needs to be refreshed.
     }
 
     public void addNewComment(@NonNull DiscussionComment parent) {
@@ -424,7 +428,6 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
                 break;
             }
         }
-        notifyItemChanged(0); // Comments count is shown in the thread details header, so it also needs to be refreshed.
     }
 
     public static class ShowMoreViewHolder extends RecyclerView.ViewHolder {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DiscussionCommentsAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DiscussionCommentsAdapter.java
@@ -194,9 +194,14 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
     public void insertCommentAtEnd(DiscussionComment comment) {
         // Since, we have a added a new comment we need to update timestamps of all comments
         initialTimeStampMs = System.currentTimeMillis();
-        response.incrementChildCount();
         discussionComments.add(comment);
+        incrementCommentCount();
         notifyDataSetChanged();
+    }
+
+    public void incrementCommentCount() {
+        response.incrementChildCount();
+        notifyItemChanged(0);
     }
 
     public void updateComment(DiscussionComment comment) {


### PR DESCRIPTION
Fixes [MA-2197](https://openedx.atlassian.net/browse/MA-2197).

PR #625 added a check on locally adding responses and comments to the adapters on their specific screens, which introduced inconsistency of response & comment counts that we maintain locally.

This PR fixes the issue by pulling out the count incrementing logic to a class level function and calling it separately.

@1zaman quick review
