### PR TITLE
Fix crash upon Threads screen re-instantiation

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsSearchFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsSearchFragment.java
@@ -120,8 +120,16 @@ public class CourseDiscussionPostsSearchFragment extends CourseDiscussionPostsBa
 
     @Override
     public void onRestart() {
-        nextPage = 1;
-        controller.resetSilently();
+        /*
+        If the activity/fragment needs to be reinstantiated upon restoration,
+        then in some cases the onRestart() callback maybe invoked before view
+        initialization, and thus the controller might not be initialized, and
+        therefore we need to guard this with a null check.
+         */
+        if (controller != null) {
+            nextPage = 1;
+            controller.resetSilently();
+        }
     }
 
     @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
@@ -180,8 +180,16 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
             mSelectedItem = -1;
         }
 
-        nextPage = 1;
-        controller.resetSilently();
+        /*
+        If the activity/fragment needs to be reinstantiated upon restoration,
+        then in some cases the onRestart() callback maybe invoked before view
+        initialization, and thus the controller might not be initialized, and
+        therefore we need to guard this with a null check.
+         */
+        if (controller != null) {
+            nextPage = 1;
+            controller.resetSilently();
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes [MA-2202](https://openedx.atlassian.net/browse/MA-2202)

This is a really hard crash to reproduce, I was able to unintentionally reproduce it following the given steps:

1. Let the Responses screen be open on the simulator.
2. Allow the machine (macbook/pc) to sleep for a while.
3. Upon resuming the machine, tap the back button on the simulator.
4. App crashes while trying to re-instantiate the Threads screen.

@1zaman @BenjiLee @bguertin plz review