### PR TITLE
Fix issue with google play info not coming in

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/http/HttpManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/HttpManager.java
@@ -53,12 +53,11 @@ import java.util.List;
 public class HttpManager {
     protected final Logger logger = new Logger(getClass().getName());
 
-    @Inject
     Context context;
 
     /**
      * Executes a GET request to given URL with given parameters.
-     * 
+     *
      * @param urlWithAppendedParams
      * @param headers
      * @return
@@ -66,6 +65,12 @@ public class HttpManager {
      * @throws ClientProtocolException
      * @throws IOException
      */
+
+    @Inject
+    public HttpManager(Context context) {
+        this.context = context;
+    }
+
     public HttpResult get(String urlWithAppendedParams, Bundle headers)
             throws ParseException, ClientProtocolException, IOException {
         final DefaultHttpClient client = newClient();

--- a/VideoLocker/src/main/java/org/edx/mobile/social/google/GoogleProvider.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/social/google/GoogleProvider.java
@@ -75,7 +75,7 @@ public class GoogleProvider implements SocialProvider {
             //the code refactoring.
             Bundle p = new Bundle();
             String url = "https://www.googleapis.com/oauth2/v1/userinfo?access_token=" + accessToken;
-            String json = new HttpManager().get(url, p).body;
+            String json = new HttpManager(getContext()).get(url, p).body;
             logger.debug(json);
             Gson gson = new GsonBuilder().create();
             GoogleUserProfile userProfile = gson.fromJson(json, GoogleUserProfile.class);


### PR DESCRIPTION
If we instantiate an ``HTTPManager`` directly as we do here, then it
doesn't get injected. Hence, the injected ``context`` member was null.
This change makes the context explicit as a constructor argument, so if
someone constructs an ``HTTPManager`` directly rather than through
roboguice, the compiler will force them do the right thing and pass a
context.

The underlying code is pretty bad - google provides APIs for this, so we
shouldn't have make these queries directly, but fixing that seemed out of
scope.

JIRA: https://openedx.atlassian.net/browse/MA-2200