### PR TITLE
Fixed missed login exception

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/LoginActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/LoginActivity.java
@@ -275,13 +275,13 @@ public class LoginActivity extends BaseFragmentActivity implements SocialLoginDe
                             }
                         } catch (LoginException ex) {
                             super.onException(ex);
+                            onUserLoginFailure(ex, null, null);
                         }
                     }
-
                     @Override
                     public void onException(Exception ex) {
                         super.onException(ex);
-                        onUserLoginFailure(ex, null, null);
+                        tryToSetUIInteraction(true);
                     }
 
                 };


### PR DESCRIPTION
After refactoring of task implementations, the login failure method was not being called.

Seems like after https://github.com/edx/edx-app-android/pull/627 was merged, the new loginexception was being caught at the correct place, where we were instead catching it on a LoginTask exception.

@1zaman @miankhalid @bguertin 

Fixes: https://openedx.atlassian.net/browse/MA-2227