### PR TITLE
Redraw navigation drawer on resume of MyCourseList

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyCoursesListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyCoursesListActivity.java
@@ -44,6 +44,8 @@ public class MyCoursesListActivity extends BaseSingleFragmentActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        configureDrawer();
+
         notificationDelegate.checkAppUpgrade();
     }
 


### PR DESCRIPTION
@1zaman @aleffert Quick and dirty fix for the interim.

MyCourse is the main activity so it always remains in the stack. When returning to the MyCourse from anyway, it uses the original drawer. 

This is just a hack and FYI for now. Currently brainstorming a better solution.

Addresses: https://openedx.atlassian.net/browse/MA-2201

Update:

I think this is a sufficient interim solution for now. Another way we could do this is to create a profile singleton but I think that is more work than is worth right now. 