### PR TITLE
Don't show error message on silent threads refresh

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsSearchFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsSearchFragment.java
@@ -97,7 +97,11 @@ public class CourseDiscussionPostsSearchFragment extends CourseDiscussionPostsBa
 
             @Override
             protected void onException(Exception ex) {
-                super.onException(ex);
+                // Don't display any error message if we're doing a silent
+                // refresh, as that would be confusing to the user.
+                if (!callback.isRefreshingSilently()) {
+                    super.onException(ex);
+                }
                 callback.onError();
                 nextPage = 1;
             }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
@@ -280,7 +280,11 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
 
             @Override
             protected void onException(Exception ex) {
-                super.onException(ex);
+                // Don't display any error message if we're doing a silent
+                // refresh, as that would be confusing to the user.
+                if (!callback.isRefreshingSilently()) {
+                    super.onException(ex);
+                }
                 callback.onError();
                 nextPage = 1;
             }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/InfiniteScrollUtils.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/InfiniteScrollUtils.java
@@ -101,6 +101,14 @@ public class InfiniteScrollUtils {
          * Callback for receiving an error during the page load.
          */
         public abstract void onError();
+
+        /**
+         * Returns the user visibility status of the page load.
+         *
+         * @return <code>true</code> If a silent refresh is being performed,
+         *         <code>false</code> if pagination is being done as usual.
+         */
+        public abstract boolean isRefreshingSilently();
     }
 
     public interface InfiniteListController {
@@ -173,6 +181,11 @@ public class InfiniteScrollUtils {
                     adapter.setProgressVisible(false);
                     hasMoreItems = false;
                     loading = false;
+                }
+
+                @Override
+                public boolean isRefreshingSilently() {
+                    return isRefreshingSilently;
                 }
 
                 /**


### PR DESCRIPTION
#625 introduced silent reloading of the discussion threads list upon Activity restart. However, in spite of it being hidden from the user, the reloading logic displayed an error message on failure, which is quite confusing for the user. This pull request patches the module to ensure that no error message would be displayed to the user upon performing silent refreshes.

Fixes [MA-2210][].

[MA-2210]: https://openedx.atlassian.net/browse/MA-2210