### PR TITLE
MA-2231 User profile loading image crash

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CropImageActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CropImageActivity.java
@@ -57,12 +57,14 @@ public class CropImageActivity extends BaseAppActivity {
                 findViewById(R.id.save).setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        setResult(Activity.RESULT_OK, new Intent()
-                                        .putExtra(EXTRA_CROP_RECT, imageView.getCropRect())
-                                        .putExtra(EXTRA_IMAGE_URI, imageUri)
-                                        .putExtra(EXTRA_FROM_CAMERA, getIntent().getBooleanExtra(EXTRA_FROM_CAMERA, false))
-                        );
-                        finish();
+                        if (imageView.isReady()) {
+                            setResult(Activity.RESULT_OK, new Intent()
+                                    .putExtra(EXTRA_CROP_RECT, imageView.getCropRect())
+                                    .putExtra(EXTRA_IMAGE_URI, imageUri)
+                                    .putExtra(EXTRA_FROM_CAMERA, getIntent().getBooleanExtra(EXTRA_FROM_CAMERA, false))
+                            );
+                            finish();
+                        }
                     }
                 });
             }


### PR DESCRIPTION
When choosing an image for user profiles, if saved before that image is loaded for cropping, the app crashes. This fix makes it so that if the image has not loaded, saving does nothing.

Addresses: https://openedx.atlassian.net/browse/MA-2231