### PR TITLE
Response endorsed state indication enabled

### DIFF
--- a/VideoLocker/res/layout/discussion_endorsed_text_view.xml
+++ b/VideoLocker/res/layout/discussion_endorsed_text_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/discussion_responses_answer_text_view"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingBottom="3dp"
+    android:drawablePadding="4dp"
+    android:text="@string/discussion_responses_answer"
+    android:textColor="@color/edx_utility_success"
+    android:textSize="@dimen/edx_x_small"
+    android:visibility="gone"
+    tools:visibility="visible"
+    tools:showIn="@layout/discussion_responses_response_row" />

--- a/VideoLocker/res/layout/discussion_responses_response_row.xml
+++ b/VideoLocker/res/layout/discussion_responses_response_row.xml
@@ -24,15 +24,7 @@
             android:paddingBottom="3dp"
             android:paddingTop="@dimen/discussion_responses_box_padding">
 
-            <TextView
-                android:id="@+id/discussion_responses_answer_text_view"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingBottom="3dp"
-                android:drawablePadding="4dp"
-                android:text="@string/discussion_responses_answer"
-                android:textColor="@color/edx_utility_success"
-                android:textSize="@dimen/edx_x_small" />
+            <include layout="@layout/discussion_endorsed_text_view" />
 
             <TextView
                 android:id="@+id/discussion_responses_comment_body_text_view"

--- a/VideoLocker/res/layout/fragment_add_comment.xml
+++ b/VideoLocker/res/layout/fragment_add_comment.xml
@@ -19,13 +19,14 @@
             android:paddingBottom="@dimen/widget_margin"
             android:paddingLeft="@dimen/edx_margin"
             android:paddingRight="@dimen/edx_margin"
-            android:paddingTop="@dimen/widget_margin">
+            android:paddingTop="@dimen/widget_double_margin">
+
+            <include layout="@layout/discussion_endorsed_text_view" />
 
             <TextView
                 android:id="@+id/tvResponse"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/widget_margin"
                 android:textColor="@color/edx_grayscale_neutral_dark"
                 android:textSize="@dimen/edx_small"
                 tools:text="Response body" />

--- a/VideoLocker/res/layout/row_discussion_comment.xml
+++ b/VideoLocker/res/layout/row_discussion_comment.xml
@@ -4,7 +4,15 @@
     android:id="@+id/row_discussion_comment_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:paddingTop="@dimen/discussion_responses_box_padding">
+
+    <include
+        layout="@layout/discussion_endorsed_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/discussion_responses_box_padding"
+        android:layout_marginStart="@dimen/discussion_responses_box_padding" />
 
     <TextView
         android:id="@+id/discussion_comment_body"
@@ -12,7 +20,6 @@
         android:layout_height="wrap_content"
         android:layout_marginLeft="@dimen/discussion_responses_box_padding"
         android:layout_marginRight="@dimen/discussion_responses_box_padding"
-        android:layout_marginTop="@dimen/discussion_responses_box_padding"
         android:textColor="@color/edx_grayscale_neutral_dark"
         android:textSize="@dimen/edx_x_small"
         tools:text="This is the text of a comment. This is the text of a comment. This is the text of a comment. This is the text of a comment. This is the text of a comment." />

--- a/VideoLocker/res/values/dimens.xml
+++ b/VideoLocker/res/values/dimens.xml
@@ -121,6 +121,7 @@
     <dimen name="edx_double_margin">30dp</dimen>
     <dimen name="edx_quadruple_margin">60dp</dimen>
     <dimen name="widget_margin">10dp</dimen>
+    <dimen name="widget_double_margin">20dp</dimen>
     <dimen name="horizontal_input_padding">@dimen/widget_margin</dimen>
     <dimen name="vertical_input_padding">8dp</dimen>
     <dimen name="edx_button_height">40dp</dimen>

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Typeface;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
+import android.support.v4.widget.TextViewCompat;
 import android.text.Html;
 import android.text.SpannableString;
 import android.text.Spanned;
@@ -16,6 +17,8 @@ import android.view.View;
 import android.widget.TextView;
 
 import com.google.inject.Inject;
+import com.joanzapata.iconify.IconDrawable;
+import com.joanzapata.iconify.fonts.FontAwesomeIcons;
 
 import org.edx.mobile.R;
 import org.edx.mobile.util.Config;
@@ -119,5 +122,30 @@ public abstract class DiscussionTextUtils {
         }
 
         return s.subSequence(start, end);
+    }
+
+    public static void setEndorsedState(@NonNull TextView target,
+                                        @NonNull DiscussionThread thread,
+                                        @NonNull DiscussionComment response) {
+        if (response.isEndorsed()) {
+            Context context = target.getContext();
+            TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(
+                    target,
+                    new IconDrawable(context, FontAwesomeIcons.fa_check_square_o)
+                            .sizeRes(context, R.dimen.edx_xxx_small)
+                            .colorRes(context, R.color.edx_utility_success),
+                    null, null, null);
+            switch (thread.getType()) {
+                case QUESTION:
+                    target.setText(R.string.discussion_responses_answer);
+                    break;
+                case DISCUSSION:
+                default:
+                    target.setText(R.string.discussion_responses_endorsed);
+                    break;
+            }
+            target.setVisibility(View.VISIBLE);
+        }
+
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
@@ -83,7 +83,8 @@ public class CourseDiscussionCommentsFragment extends BaseFragment implements Di
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        discussionCommentsAdapter = new DiscussionCommentsAdapter(getActivity(), this, discussionResponse);
+        discussionCommentsAdapter = new DiscussionCommentsAdapter(getActivity(), this,
+                discussionThread, discussionResponse);
         controller = InfiniteScrollUtils.configureRecyclerViewWithInfiniteList(discussionCommentsListView,
                 discussionCommentsAdapter, new InfiniteScrollUtils.PageLoader<DiscussionComment>() {
             @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
@@ -59,6 +59,9 @@ public class DiscussionAddCommentFragment extends BaseFragment {
     @InjectView(R.id.tvTimeAuthor)
     private TextView textViewTimeAuthor;
 
+    @InjectView(R.id.discussion_responses_answer_text_view)
+    private TextView responseAnswerTextView;
+
     @Inject
     private Router router;
 
@@ -87,7 +90,9 @@ public class DiscussionAddCommentFragment extends BaseFragment {
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
         textViewResponse.setText(Html.fromHtml(discussionResponse.getRenderedBody()));
+        DiscussionTextUtils.setEndorsedState(responseAnswerTextView, discussionThread, discussionResponse);
         DiscussionTextUtils.setAuthorAttributionText(textViewTimeAuthor,
                 R.string.post_attribution, discussionResponse, new Runnable() {
                     @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DiscussionCommentsAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DiscussionCommentsAdapter.java
@@ -16,6 +16,7 @@ import com.joanzapata.iconify.fonts.FontAwesomeIcons;
 import org.edx.mobile.R;
 import org.edx.mobile.discussion.DiscussionComment;
 import org.edx.mobile.discussion.DiscussionTextUtils;
+import org.edx.mobile.discussion.DiscussionThread;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +31,9 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
 
     @NonNull
     private DiscussionComment response;
+
+    @NonNull
+    private DiscussionThread thread;
     // Record the current time at initialization to keep the display of the elapsed time durations stable.
     private long initialTimeStampMs = System.currentTimeMillis();
 
@@ -48,9 +52,12 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
         void onClickAuthor(@NonNull String username);
     }
 
-    public DiscussionCommentsAdapter(@NonNull Context context, @NonNull Listener listener, @NonNull DiscussionComment response) {
+    public DiscussionCommentsAdapter(@NonNull Context context, @NonNull Listener listener,
+                                     @NonNull DiscussionThread thread,
+                                     @NonNull DiscussionComment response) {
         this.context = context;
         this.listener = listener;
+        this.thread = thread;
         this.response = response;
     }
 
@@ -90,8 +97,11 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
         @DrawableRes
         final int backgroundRes;
         final IconDrawable iconDrawable;
+        final int standardMargin = context.getResources().getDimensionPixelOffset(R.dimen.discussion_responses_standard_margin);
         if (position == 0) {
+            holder.discussionCommentRow.setPadding(0, standardMargin, 0, 0);
             discussionComment = response;
+            DiscussionTextUtils.setEndorsedState(holder.responseAnswerTextView, thread, response);
             backgroundRes = R.drawable.row_discussion_first_comment_background;
             layoutParams.topMargin = context.getResources().getDimensionPixelOffset(R.dimen.discussion_responses_standard_margin);
             final int childCount = discussionComment.getChildCount();
@@ -104,13 +114,13 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
             holder.discussionCommentCountReportTextView.setClickable(false);
 
         } else {
-            final int extraSidePadding = context.getResources().getDimensionPixelOffset(R.dimen.discussion_responses_standard_margin);
-            holder.discussionCommentRow.setPadding(extraSidePadding, 0, extraSidePadding, 0);
+            holder.responseAnswerTextView.setVisibility(View.GONE);
+            holder.discussionCommentRow.setPadding(standardMargin, standardMargin, standardMargin, 0);
 
             discussionComment = discussionComments.get(position - 1);
             if (!progressVisible && position == getItemCount() - 1) {
                 backgroundRes = R.drawable.row_discussion_last_comment_background;
-                layoutParams.bottomMargin = context.getResources().getDimensionPixelOffset(R.dimen.discussion_responses_standard_margin);
+                layoutParams.bottomMargin = standardMargin;
             } else {
                 backgroundRes = R.drawable.row_discussion_comment_background;
             }
@@ -181,6 +191,7 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
         TextView discussionCommentBody;
         TextView discussionCommentAuthorTextView;
         TextView discussionCommentCountReportTextView;
+        TextView responseAnswerTextView;
 
         public ViewHolder(View itemView) {
             super(itemView);
@@ -188,6 +199,7 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
             discussionCommentBody = (TextView) itemView.findViewById(R.id.discussion_comment_body);
             discussionCommentAuthorTextView = (TextView) itemView.findViewById(R.id.discussion_comment_author_text_view);
             discussionCommentCountReportTextView = (TextView) itemView.findViewById(R.id.discussion_comment_count_report_text_view);
+            responseAnswerTextView = (TextView) itemView.findViewById(R.id.discussion_responses_answer_text_view);
         }
     }
 


### PR DESCRIPTION
Fixes [MA-2088](https://openedx.atlassian.net/browse/MA-2088)

Indication enabled on the following screens:
- Responses Screen.
- Add Comments Screen.
- View Comments Screen.

Responses | Add Comment | View Comments
---- | ---- | -----
<img src="https://cloud.githubusercontent.com/assets/1710804/14174887/d4574b26-f760-11e5-8334-8835cb1c2fad.png" width="250" /> | <img src="https://cloud.githubusercontent.com/assets/1710804/14174862/a45fb462-f760-11e5-86b6-6b5267e29724.png" width="250" /> | <img src="https://cloud.githubusercontent.com/assets/1710804/14174865/a6e77698-f760-11e5-81bd-15d93332ecd1.png" width="250" />

@1zaman @BenjiLee plz review