### PR TITLE
Disable API Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ android:
     - extra-google-m2repository
     - extra-android-m2repository
 
-# Disable travis email notifications until builds work properly
 notifications:
   email: true
 

--- a/VideoLocker/src/test/java/org/edx/mobile/test/http/ApiTests.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/http/ApiTests.java
@@ -16,6 +16,7 @@ import org.edx.mobile.model.course.HasDownloadEntry;
 import org.edx.mobile.model.course.IBlock;
 import org.edx.mobile.model.course.VideoBlockModel;
 import org.edx.mobile.module.registration.model.RegistrationDescription;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -36,11 +37,16 @@ import static org.junit.Assume.assumeFalse;
 /**
  * This class contains unit tests for API calls to server.
  * <p/>
- * if we run it in the CI of github, we can not provide the credential to
- * make the service call.
- * unless we find a way to handle it,  we will disable all the testing agaist
- * real webservice right now
+ * We don't really want to have unit tests that talk to a live server and we can't run
+ * them on CI since we don't even know what server to talk to.
+ * As such, these are disabled until we figure out what we want to do about them.
+ * Probably we want to mock the HTTP responses so we can still exercise the rest of the
+ * API logic.
+ *
+ * If you want to run them locally, you can just temporarily remove the @Ignore annotation
  */
+
+@Ignore
 public class ApiTests extends HttpBaseTestCase {
 
 


### PR DESCRIPTION
We shouldn't have unit tests that talk to a live server. Also they make
developing locally more difficult. Just disable them for now.