### PR TITLE
Use better URL resolution logic for course images.

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/course/CourseDetail.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/course/CourseDetail.java
@@ -2,8 +2,10 @@ package org.edx.mobile.course;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.Nullable;
 
 import org.edx.mobile.model.api.StartType;
+import org.edx.mobile.util.UrlUtil;
 
 public class CourseDetail implements Parcelable {
     public String course_id;
@@ -57,7 +59,7 @@ public class CourseDetail implements Parcelable {
     }
 
     public static class Image implements Parcelable {
-        public String uri;
+        private String uri;
 
         protected Image(Parcel in) {
             uri = in.readString();
@@ -85,6 +87,11 @@ public class CourseDetail implements Parcelable {
                 return new Image[size];
             }
         };
+
+        @Nullable
+        public String getUri(String baseURL) {
+            return UrlUtil.makeAbsolute(uri, baseURL);
+        }
     }
 
     public static class Video implements Parcelable {

--- a/VideoLocker/src/main/java/org/edx/mobile/model/api/CourseEntry.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/model/api/CourseEntry.java
@@ -1,14 +1,17 @@
 package org.edx.mobile.model.api;
 
 import android.content.Context;
+import android.support.annotation.Nullable;
 
 import com.google.inject.Inject;
 
 import org.edx.mobile.social.SocialMember;
 import org.edx.mobile.util.Config;
+import org.edx.mobile.util.UrlUtil;
 import org.edx.mobile.util.images.CourseCardUtils;
 
 import java.io.Serializable;
+import java.net.URISyntaxException;
 import java.util.List;
 
 @SuppressWarnings("serial")
@@ -34,10 +37,7 @@ public class CourseEntry implements Serializable {
     private String discussion_url;
     private SocialURLModel social_urls;
     private CoursewareAccess courseware_access;
-
-    @Inject
-    Config config;
-
+    
     public LatestUpdateModel getLatest_updates() {
         return latest_updates;
     }
@@ -54,8 +54,9 @@ public class CourseEntry implements Serializable {
         this.start = start;
     }
 
-    public String getCourse_image(Config config) {
-        return config.getApiHostURL() + course_image;
+    @Nullable
+    public String getCourse_image(@Nullable String baseURL) {
+        return UrlUtil.makeAbsolute(course_image, baseURL);
     }
 
     public void setCourse_image(String course_image) {

--- a/VideoLocker/src/main/java/org/edx/mobile/util/UrlUtil.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/UrlUtil.java
@@ -1,0 +1,26 @@
+package org.edx.mobile.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Created by aleffert on 3/31/16.
+ */
+public class UrlUtil {
+
+    // Resolves a URL against a base URL. If the url is already absolute,
+    // it just returns it. If the URL is relative it will resolve it against the base URL
+    public static String makeAbsolute(String url, String base) {
+        if (url == null || base == null) {
+            return null;
+        }
+        try {
+            URI baseUri = new URI(base);
+            URI result = baseUri.resolve(url);
+            return result.toString();
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDashboardFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDashboardFragment.java
@@ -162,7 +162,7 @@ public class CourseDashboardFragment extends BaseFragment {
         super.onActivityCreated(savedInstanceState);
         if (courseData == null || !isCoursewareAccessible) return;
 
-        final String headerImageUrl = courseData.getCourse().getCourse_image(environment.getConfig());
+        final String headerImageUrl = courseData.getCourse().getCourse_image(environment.getConfig().getApiHostURL());
         Glide.with(CourseDashboardFragment.this)
                 .load(headerImageUrl)
                 .placeholder(R.drawable.edx_map_login)

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDetailFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDetailFragment.java
@@ -39,6 +39,7 @@ import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.services.ServiceManager;
 import org.edx.mobile.task.EnrollForCourseTask;
 import org.edx.mobile.task.GetEnrolledCourseTask;
+import org.edx.mobile.util.UrlUtil;
 import org.edx.mobile.util.WebViewUtil;
 import org.edx.mobile.util.images.CourseCardUtils;
 import org.edx.mobile.util.images.TopAnchorFillWidthTransformation;
@@ -183,7 +184,7 @@ public class CourseDetailFragment extends BaseFragment {
     }
 
     private void setCourseImage() {
-        final String headerImageUrl = environment.getConfig().getApiHostURL() + courseDetail.media.course_image.uri;
+        final String headerImageUrl = courseDetail.media.course_image.getUri(environment.getConfig().getApiHostURL());
         Glide.with(CourseDetailFragment.this)
                 .load(headerImageUrl)
                 .placeholder(R.drawable.edx_map_login)

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseCardViewHolder.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseCardViewHolder.java
@@ -52,7 +52,7 @@ public class CourseCardViewHolder extends BaseListAdapter.BaseViewHolder {
 
     public void setCourseImage(@NonNull String imageUrl) {
         Glide.with(courseImage.getContext())
-                .load(imageUrl)
+                .load((String)null)
                 .placeholder(R.drawable.edx_map)
                 .transform(new TopAnchorFillWidthTransformation(courseImage.getContext()))
                 .into(courseImage);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/FindCoursesListAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/FindCoursesListAdapter.java
@@ -25,7 +25,7 @@ public abstract class FindCoursesListAdapter extends BaseListAdapter<CourseDetai
         final CourseCardViewHolder holder = (CourseCardViewHolder) tag;
         holder.setPadding(tag.position == 0);
         holder.setCourseTitle(courseDetail.name);
-        holder.setCourseImage(environment.getConfig().getApiHostURL() + courseDetail.media.course_image.uri);
+        holder.setCourseImage(courseDetail.media.course_image.getUri(environment.getConfig().getApiHostURL()));
         holder.setDescription(CourseCardUtils.getDescription(courseDetail.org, courseDetail.number, null),
                 CourseCardUtils.getFormattedDate(getContext(), courseDetail));
     }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/MyAllVideoCourseAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/MyAllVideoCourseAdapter.java
@@ -38,7 +38,7 @@ public abstract class MyAllVideoCourseAdapter extends BaseListAdapter<EnrolledCo
         holder.size_of_videos.setText(MemoryUtil.format(getContext(), enrollment.size));
 
         Glide.with(getContext())
-                .load(courseData.getCourse_image(environment.getConfig()))
+                .load(courseData.getCourse_image(environment.getConfig().getApiHostURL()))
                 .placeholder(R.drawable.edx_map)
                 .transform(new TopAnchorFillWidthTransformation(getContext()))
                 .into(holder.courseImage);

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/MyCourseAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/MyCourseAdapter.java
@@ -29,7 +29,7 @@ public abstract class MyCourseAdapter extends BaseListAdapter<EnrolledCoursesRes
         final CourseEntry courseData = enrollment.getCourse();
         holder.setPadding(tag.position == 0);
         holder.setCourseTitle(courseData.getName());
-        holder.setCourseImage(courseData.getCourse_image(environment.getConfig()));
+        holder.setCourseImage(courseData.getCourse_image(environment.getConfig().getApiHostURL()));
 
         if (enrollment.getCourse().hasUpdates()) {
             holder.setHasUpdates(courseData, new OnClickListener() {

--- a/VideoLocker/src/test/java/org/edx/mobile/test/UrlUtilTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/UrlUtilTest.java
@@ -1,0 +1,33 @@
+package org.edx.mobile.test;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import org.edx.mobile.util.UrlUtil;
+
+public class UrlUtilTest extends BaseTestCase {
+
+    @Test
+    public void testRelativeUrlResolves() {
+        String result = UrlUtil.makeAbsolute("/foo/bar", "http://example.com");
+        assertEquals(result, "http://example.com/foo/bar");
+    }
+
+    @Test
+    public void testAbsoluteURLNotChanged() {
+        String result = UrlUtil.makeAbsolute("http://somedomain.com/foo/bar", "http://otherdomain.com");
+        assertEquals(result, "http://somedomain.com/foo/bar");
+    }
+
+    @Test
+    public void testMalformedURLReturnsNull() {
+        String result = UrlUtil.makeAbsolute("/somepath", "@:");
+        assertNull(result);
+    }
+
+    @Test
+    public void testNullInputGivesNullOutput() {
+        assertNull(UrlUtil.makeAbsolute(null, "http://otherdomain.com"));
+        assertNull(UrlUtil.makeAbsolute("http://otherdomain.com", null));
+    }
+}


### PR DESCRIPTION
We should be properly resolving URLs that *may* be relative. This came
up when it was discovered that the course image is a relative URL and a
proposal was made to make it an absolute one. Obvs we can't actually do
that since we have bad clients in the wild, but it seemed like we should
fix this and have a utility for it in case it comes up again.

I went looking for other places we do this, but couldn't find any