### PR TITLE
MA-2275 Logout button stays put when selecting search bar

### DIFF
--- a/VideoLocker/AndroidManifest.xml
+++ b/VideoLocker/AndroidManifest.xml
@@ -148,6 +148,7 @@
         <activity
             android:name=".view.WebViewFindCoursesActivity"
             android:label="@string/find_courses_title"
+            android:windowSoftInputMode="adjustPan"
             android:screenOrientation="portrait">
         </activity>
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MA-2275

@miankhalid @mikekatz @1zaman 

This only seems to be an issue in places where we can bring up a soft keyboard when the navigation panel is open, which is probably only this screen (and maybe other screens that will be using a menu search bar). The menu options are not affected because they are set top align with the top, while the version number and logout button are because it is set to align with the bottom.