### PR TITLE
Add null data handling in author attribution text

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -282,6 +282,8 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
         holder.socialLayoutViewHolder.threadFollowContainer.setVisibility(View.INVISIBLE);
 
         if (comment.isEndorsed()) {
+            holder.responseAnswerTextView.setVisibility(View.VISIBLE);
+            holder.responseAnswerAuthorTextView.setVisibility(View.VISIBLE);
             DiscussionThread.ThreadType threadType = discussionThread.getType();
             DiscussionTextUtils.AuthorAttributionLabel authorAttributionLabel;
             @StringRes int endorsementTypeStringRes;
@@ -305,8 +307,6 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
                             listener.onClickAuthor(comment.getEndorsedBy());
                         }
                     });
-            holder.responseAnswerTextView.setVisibility(View.VISIBLE);
-            holder.responseAnswerAuthorTextView.setVisibility(View.VISIBLE);
         } else {
             holder.responseAnswerTextView.setVisibility(View.GONE);
             holder.responseAnswerAuthorTextView.setVisibility(View.GONE);


### PR DESCRIPTION
If the author field is `null`, then if it's just the post label, then just the time is shown. Otherwise, for endorsement labels, the text view is hidden. There is also a `null` check added for the date field, to prevent a crash from occurring when accessing it's time in that scenario. Duplicate whitespace are also removed when the date or author label is `null`, since it's placeholders in the string template might be in the middle.

That visibility changes to the text view in `CourseDiscussionResponsesAdapter` have also been changed to be called before invoking this utility method in `DiscussionTextUtils`, since it can now cause it to be hidden.

Fixes [MA-2274][].

[MA-2274]: https://openedx.atlassian.net/browse/MA-2274