### PR TITLE
Profile link fix in Discussion UIs

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
@@ -28,7 +28,6 @@ import org.edx.mobile.util.ResourceUtil;
 
 import java.util.Date;
 import java.util.HashMap;
-import java.util.regex.Pattern;
 
 public abstract class DiscussionTextUtils {
     @Inject
@@ -137,7 +136,7 @@ public abstract class DiscussionTextUtils {
                 // If time is not available, then reduce the whitespaces
                 // surrounding it's placeholder in the template to one.
                 if (TextUtils.isEmpty(formattedTime)) {
-                    formattedText = removeDuplicateWhitespace(formattedText);
+                    formattedText = removeDuplicateWhitespaces(formattedText);
                 }
                 text = formattedText;
             }
@@ -185,14 +184,13 @@ public abstract class DiscussionTextUtils {
         return s.subSequence(start, end);
     }
 
-    public static CharSequence removeDuplicateWhitespace(CharSequence text) {
+    public static CharSequence removeDuplicateWhitespaces(CharSequence text) {
         SpannableStringBuilder builder = new SpannableStringBuilder(text);
-        for (int size = text.length(), i = 0; i < size; i++) {
-            if (Character.isWhitespace(builder.charAt(i))) {
+        for (int i = 0; i < builder.length(); i++) {
+            if (builder.charAt(i) == ' ') {
                 int nextIndex = i + 1;
-                if (nextIndex < size && Character.isWhitespace(builder.charAt(nextIndex))) {
-                    builder.replace(i, nextIndex, " ");
-                    break;
+                if (nextIndex < builder.length() && builder.charAt(nextIndex) == ' ') {
+                    builder.replace(i, nextIndex + 1, " ");
                 }
             }
         }

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
@@ -7,6 +7,7 @@ import android.support.annotation.StringRes;
 import android.support.v4.widget.TextViewCompat;
 import android.text.Html;
 import android.text.SpannableString;
+import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.TextPaint;
 import android.text.TextUtils;
@@ -30,8 +31,6 @@ import java.util.HashMap;
 import java.util.regex.Pattern;
 
 public abstract class DiscussionTextUtils {
-    private static final Pattern PATTERN_DUPLICATE_WHITESPACE = Pattern.compile("\\s+");
-
     @Inject
     private static Config config;
 
@@ -137,7 +136,7 @@ public abstract class DiscussionTextUtils {
                         context.getResources(), finalStringRes, valuesMap));
                 // If time is not available, then reduce the whitespaces
                 // surrounding it's placeholder in the template to one.
-                if (TextUtils.isEmpty(formattedText) || TextUtils.isEmpty(authorLabel)) {
+                if (TextUtils.isEmpty(formattedTime)) {
                     formattedText = removeDuplicateWhitespace(formattedText);
                 }
                 text = formattedText;
@@ -187,7 +186,17 @@ public abstract class DiscussionTextUtils {
     }
 
     public static CharSequence removeDuplicateWhitespace(CharSequence text) {
-        return PATTERN_DUPLICATE_WHITESPACE.matcher(text).replaceAll(" ");
+        SpannableStringBuilder builder = new SpannableStringBuilder(text);
+        for (int size = text.length(), i = 0; i < size; i++) {
+            if (Character.isWhitespace(builder.charAt(i))) {
+                int nextIndex = i + 1;
+                if (nextIndex < size && Character.isWhitespace(builder.charAt(nextIndex))) {
+                    builder.replace(i, nextIndex, " ");
+                    break;
+                }
+            }
+        }
+        return builder;
     }
 
     public static void setEndorsedState(@NonNull TextView target,

--- a/VideoLocker/src/test/java/org/edx/mobile/discussions/DiscussionTextUtilsTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/discussions/DiscussionTextUtilsTest.java
@@ -37,7 +37,7 @@ public class DiscussionTextUtilsTest extends BaseTestCase {
     }
 
     @Test
-    public void test_DuplicateWhitespacesRemoval() {
+    public void test_DuplicatedWhitespaceRemoved() {
         String input = "  start  end  ";
         String expected = " start end ";
         String output = DiscussionTextUtils.removeDuplicateWhitespaces(input).toString();
@@ -48,7 +48,7 @@ public class DiscussionTextUtilsTest extends BaseTestCase {
     public void test_TextInTextViewNotNull() {
         DiscussionTextUtils.setAuthorAttributionText(dummyTextView,
                 DiscussionTextUtils.AuthorAttributionLabel.POST,
-                new IAuthorDataImpl("testAuthor", "testLabel", new Date()),
+                new StubAuthorData("testAuthor", "testLabel", new Date()),
                 dummyClickListener);
         assertNotNull(dummyTextView.getText());
     }
@@ -57,7 +57,7 @@ public class DiscussionTextUtilsTest extends BaseTestCase {
     public void test_AuthorIsTappable() {
         DiscussionTextUtils.setAuthorAttributionText(dummyTextView,
                 DiscussionTextUtils.AuthorAttributionLabel.POST,
-                new IAuthorDataImpl("testAuthor", "testLabel", new Date()),
+                new StubAuthorData("testAuthor", "testLabel", new Date()),
                 dummyClickListener);
         SpannableString cs = (SpannableString) dummyTextView.getText();
         ClickableSpan[] spans = cs.getSpans(0, cs.length(), ClickableSpan.class);
@@ -72,7 +72,7 @@ public class DiscussionTextUtilsTest extends BaseTestCase {
     public void test_AuthorIsTappable_WhenNoCreationDate() {
         DiscussionTextUtils.setAuthorAttributionText(dummyTextView,
                 DiscussionTextUtils.AuthorAttributionLabel.POST,
-                new IAuthorDataImpl("testAuthor", "testLabel", null),
+                new StubAuthorData("testAuthor", "testLabel", null),
                 dummyClickListener);
         ClickableSpan[] spans = getClickableSpans();
         if (config.isUserProfilesEnabled()) {
@@ -86,7 +86,7 @@ public class DiscussionTextUtilsTest extends BaseTestCase {
     public void test_AuthorIsNotTappable_WhenNoAuthor() {
         DiscussionTextUtils.setAuthorAttributionText(dummyTextView,
                 DiscussionTextUtils.AuthorAttributionLabel.POST,
-                new IAuthorDataImpl(null, "testLabel", new Date()),
+                new StubAuthorData(null, "testLabel", new Date()),
                 dummyClickListener);
         ClickableSpan[] spans = getClickableSpans();
         assertTrue(spans.length == 0);
@@ -97,11 +97,11 @@ public class DiscussionTextUtilsTest extends BaseTestCase {
         return spannableString.getSpans(0, spannableString.length(), ClickableSpan.class);
     }
 
-    private static class IAuthorDataImpl implements IAuthorData {
+    private static class StubAuthorData implements IAuthorData {
         String author, authorLabel;
         Date createdDate;
 
-        public IAuthorDataImpl(String author, String authorLabel, Date createdDate) {
+        public StubAuthorData(String author, String authorLabel, Date createdDate) {
             this.author = author;
             this.authorLabel = authorLabel;
             this.createdDate = createdDate;

--- a/VideoLocker/src/test/java/org/edx/mobile/discussions/DiscussionTextUtilsTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/discussions/DiscussionTextUtilsTest.java
@@ -1,0 +1,130 @@
+package org.edx.mobile.discussions;
+
+import android.text.SpannableString;
+import android.text.TextUtils;
+import android.text.style.ClickableSpan;
+import android.widget.TextView;
+
+import org.edx.mobile.discussion.DiscussionTextUtils;
+import org.edx.mobile.discussion.IAuthorData;
+import org.edx.mobile.test.BaseTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * Created by miankhalid on 25/04/2016.
+ */
+public class DiscussionTextUtilsTest extends BaseTestCase {
+
+    private TextView dummyTextView;
+    private Runnable dummyClickListener;
+
+    @Before
+    public void initValues() {
+        dummyTextView = new TextView(context);
+        dummyClickListener = new Runnable() {
+            @Override
+            public void run() {
+                logger.debug("Author clicked");
+            }
+        };
+    }
+
+    @Test
+    public void test_DuplicateWhitespacesRemoval() {
+        String input = "  start  end  ";
+        String expected = " start end ";
+        String output = DiscussionTextUtils.removeDuplicateWhitespaces(input).toString();
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void test_TextInTextViewNotNull() {
+        DiscussionTextUtils.setAuthorAttributionText(dummyTextView,
+                DiscussionTextUtils.AuthorAttributionLabel.POST,
+                new IAuthorDataImpl("testAuthor", "testLabel", new Date()),
+                dummyClickListener);
+        assertNotNull(dummyTextView.getText());
+    }
+
+    @Test
+    public void test_AuthorIsTappable() {
+        DiscussionTextUtils.setAuthorAttributionText(dummyTextView,
+                DiscussionTextUtils.AuthorAttributionLabel.POST,
+                new IAuthorDataImpl("testAuthor", "testLabel", new Date()),
+                dummyClickListener);
+        SpannableString cs = (SpannableString) dummyTextView.getText();
+        ClickableSpan[] spans = cs.getSpans(0, cs.length(), ClickableSpan.class);
+        if (config.isUserProfilesEnabled()) {
+            assertTrue(spans.length > 0);
+        } else {
+            assertTrue(spans.length == 0);
+        }
+    }
+
+    @Test
+    public void test_AuthorIsTappable_WhenNoCreationDate() {
+        DiscussionTextUtils.setAuthorAttributionText(dummyTextView,
+                DiscussionTextUtils.AuthorAttributionLabel.POST,
+                new IAuthorDataImpl("testAuthor", "testLabel", null),
+                dummyClickListener);
+        ClickableSpan[] spans = getClickableSpans();
+        if (config.isUserProfilesEnabled()) {
+            assertTrue(spans.length > 0);
+        } else {
+            assertTrue(spans.length == 0);
+        }
+    }
+
+    @Test
+    public void test_AuthorIsNotTappable_WhenNoAuthor() {
+        DiscussionTextUtils.setAuthorAttributionText(dummyTextView,
+                DiscussionTextUtils.AuthorAttributionLabel.POST,
+                new IAuthorDataImpl(null, "testLabel", new Date()),
+                dummyClickListener);
+        ClickableSpan[] spans = getClickableSpans();
+        assertTrue(spans.length == 0);
+    }
+
+    private ClickableSpan[] getClickableSpans() {
+        SpannableString spannableString = (SpannableString) dummyTextView.getText();
+        return spannableString.getSpans(0, spannableString.length(), ClickableSpan.class);
+    }
+
+    private static class IAuthorDataImpl implements IAuthorData {
+        String author, authorLabel;
+        Date createdDate;
+
+        public IAuthorDataImpl(String author, String authorLabel, Date createdDate) {
+            this.author = author;
+            this.authorLabel = authorLabel;
+            this.createdDate = createdDate;
+        }
+
+        @Override
+        public String getAuthor() {
+            return author;
+        }
+
+        @Override
+        public String getAuthorLabel() {
+            return authorLabel;
+        }
+
+        @Override
+        public Date getCreatedAt() {
+            return createdDate;
+        }
+
+        @Override
+        public boolean isAuthorAnonymous() {
+            return TextUtils.isEmpty(author);
+        }
+    }
+}


### PR DESCRIPTION
Fixes [MA-2286](https://openedx.atlassian.net/browse/MA-2286)

Previous implementation of `removeDuplicateWhitespace` [done here] (https://github.com/edx/edx-app-android/pull/670/files#diff-f0965130e69dcf6a44193af8da3227b4R189) removed the Span properties from the `CharSequence` due to the usage of `replaceAll` function in the `String` class. I've changed the implementation to use `SpannableStringBuilder` which maintains the Span properties.

@aleffert @BenjiLee quik review