### PR TITLE
Author Attribution in Discussion UIs

### DIFF
--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -260,22 +260,19 @@
     <string name="discussion_priviledged_author_label_staff">Staff</string>
     <!-- The label to use when indicating a post was authored by a privileged user -->
     <string name="discussion_priviledged_author_attribution">By %s</string>
-    <!-- The date and author of a discussion comment, question, or thread, e.g. "3 days ago by Brian (Staff)" -->
-    <string name="post_attribution">{time} by {author} ({author_label})</string>
-    <!-- The date and author of a discussion comment, question, or thread without the author's label, e.g. "3 days ago by Brian" -->
-    <string name="post_attribution_without_label">{time} by {author}</string>
-    <!-- The date and author of an answer to a discussion question e.g. "Marked as answer 2 days ago by Khalid (Community TA)" -->
-    <string name="answer_author_attribution">Marked as answer {time} by {author} ({author_label})</string>
-    <!-- The date and author of an answer to a discussion question without the author's label e.g. "Marked as answer 2 days ago by Khalid" -->
-    <string name="answer_author_attribution_without_label">Marked as answer {time} by {author}</string>
-    <!-- The date and author of an endorsed response to a discussion thread e.g. "Endorsed 2 days ago by Khalid (Community TA)" -->
-    <string name="endorser_attribution">Endorsed {time} by {author} ({author_label})</string>
-    <!-- The date and author of an endorsed response to a discussion thread without the author's label e.g. "Endorsed 2 days ago by Khalid" -->
-    <string name="endorser_attribution_without_label">Endorsed {time} by {author}</string>
     <!-- Label for the visibility of a discussion post that is only visible to cohort -->
     <string name="discussion_post_visibility_cohort">This post is visible only to {cohort}.</string>
     <!-- Label for the visibility of a discussion post that is visible to everyone -->
     <string name="discussion_post_visibility_everyone">This post is visible to everyone.</string>
+    <!-- Used while constructing the author attribution text for a discussion post e.g. "3 days ago by Brian (Staff)" -->
+    <string name="discussion_post_author_attribution">by {author}</string>
+    <!-- Used while constructing the author attribution text for an answer response e.g. "Marked as answer 2 days ago by Khalid (Community TA)" -->
+    <string name="discussion_post_marked_as_answer">Marked as answer</string>
+    <!-- Used while constructing the author attribution text for an endorsed response e.g. "Endorsed 2 days ago by Khalid" -->
+    <string name="discussion_post_endorsed">Endorsed</string>
+    <!-- Used for putting authorLabel into parenthesis e.g. (Community TA) or (Staff) -->
+    <string name="discussion_post_author_label_attribution">({text})</string>
+
 
     <!--Discussion Responses-->
     <!--Label for question type discussions that are answered-->

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
@@ -3,7 +3,6 @@ package org.edx.mobile.discussion;
 import android.content.Context;
 import android.graphics.Typeface;
 import android.support.annotation.NonNull;
-import android.support.annotation.StringRes;
 import android.support.v4.widget.TextViewCompat;
 import android.text.Html;
 import android.text.SpannableString;
@@ -25,51 +24,18 @@ import org.edx.mobile.R;
 import org.edx.mobile.util.Config;
 import org.edx.mobile.util.ResourceUtil;
 
+import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.regex.Pattern;
+import java.util.List;
 
 public abstract class DiscussionTextUtils {
-    private static final Pattern PATTERN_DUPLICATE_WHITESPACE = Pattern.compile("\\s+");
-
     @Inject
     private static Config config;
 
     private DiscussionTextUtils() {
     }
 
-    /**
-     * Encapsulates the two variants of author attribution strings, i.e. with and without authorLabel.
-     */
-    public enum AuthorAttributionLabel {
-        POST(R.string.post_attribution, R.string.post_attribution_without_label),
-        ANSWER(R.string.answer_author_attribution, R.string.answer_author_attribution_without_label),
-        ENDORSEMENT(R.string.endorser_attribution, R.string.endorser_attribution_without_label);
-
-        @StringRes
-        private final int stringRes, noLabelStringRes;
-
-        AuthorAttributionLabel(@StringRes int stringRes, @StringRes int noLabelStringRes) {
-            this.stringRes = stringRes;
-            this.noLabelStringRes = noLabelStringRes;
-        }
-
-        /**
-         * @return The string resource with authorLabel included.
-         */
-        @StringRes
-        public int getStringRes() {
-            return stringRes;
-        }
-
-        /**
-         * @return The string resource without the authorLabel.
-         */
-        @StringRes
-        public int getNoLabelStringRes() {
-            return noLabelStringRes;
-        }
-    }
+    public enum AuthorAttributionLabel {POST, ANSWER, ENDORSEMENT}
 
     public static void setAuthorAttributionText(@NonNull TextView textView,
                                                 @NonNull AuthorAttributionLabel authorAttributionLabel,
@@ -79,7 +45,6 @@ public abstract class DiscussionTextUtils {
                 System.currentTimeMillis(), onAuthorClickListener);
     }
 
-
     public static void setAuthorAttributionText(@NonNull TextView textView,
                                                 @NonNull AuthorAttributionLabel authorAttributionLabel,
                                                 @NonNull final IAuthorData authorData,
@@ -88,23 +53,27 @@ public abstract class DiscussionTextUtils {
         final CharSequence text;
         {
             final Context context = textView.getContext();
+            List<CharSequence> joinableStrings = new ArrayList<>();
+            boolean isEndorsed = false;
+            switch (authorAttributionLabel) {
+                case ANSWER:
+                    isEndorsed = true;
+                    joinableStrings.add(context.getString(R.string.discussion_post_marked_as_answer));
+                    break;
+                case ENDORSEMENT:
+                    isEndorsed = true;
+                    joinableStrings.add(context.getString(R.string.discussion_post_endorsed));
+                    break;
+            }
+
             final Date dateCreated = authorData.getCreatedAt();
-            final CharSequence formattedTime = dateCreated == null ? null :
-                    getRelativeTimeSpanString(context, initialTimeStampMs, dateCreated.getTime());
+            if (dateCreated != null) {
+                joinableStrings.add(getRelativeTimeSpanString(context, initialTimeStampMs,
+                        dateCreated.getTime()));
+            }
 
             final String author = authorData.getAuthor();
-            if (TextUtils.isEmpty(author)) {
-                switch (authorAttributionLabel) {
-                    case POST:
-                        text = formattedTime;
-                        break;
-                    default:
-                        text = null;
-                        break;
-                }
-            } else {
-                final String authorLabel = authorData.getAuthorLabel();
-
+            if (!TextUtils.isEmpty(author)) {
                 final SpannableString authorSpan = new SpannableString(author);
                 if (config.isUserProfilesEnabled() && !authorData.isAuthorAnonymous()) {
                     authorSpan.setSpan(new ClickableSpan() {
@@ -122,39 +91,34 @@ public abstract class DiscussionTextUtils {
                     authorSpan.setSpan(new StyleSpan(Typeface.BOLD), 0, authorSpan.length(),
                             Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                 }
+                joinableStrings.add(ResourceUtil.getFormattedString(context.getResources(),
+                        R.string.discussion_post_author_attribution, "author", authorSpan));
+            }
 
-                @StringRes int finalStringRes;
-                HashMap<String, CharSequence> valuesMap = new HashMap<>();
-                valuesMap.put("time", formattedTime);
-                valuesMap.put("author", authorSpan);
-                if (authorLabel != null) {
-                    finalStringRes = authorAttributionLabel.getStringRes();
-                    valuesMap.put("author_label", authorLabel);
-                } else {
-                    finalStringRes = authorAttributionLabel.getNoLabelStringRes();
-                }
-                CharSequence formattedText = trim(ResourceUtil.getFormattedString(
-                        context.getResources(), finalStringRes, valuesMap));
-                // If time is not available, then reduce the whitespaces
-                // surrounding it's placeholder in the template to one.
-                if (TextUtils.isEmpty(formattedText) || TextUtils.isEmpty(authorLabel)) {
-                    formattedText = removeDuplicateWhitespace(formattedText);
-                }
-                text = formattedText;
+            final String authorLabel = authorData.getAuthorLabel();
+            if (!TextUtils.isEmpty(authorLabel)) {
+                joinableStrings.add(ResourceUtil.getFormattedString(context.getResources(),
+                        R.string.discussion_post_author_label_attribution, "text", authorLabel));
+            }
+
+            int joinableStringsSize = joinableStrings.size();
+            if (joinableStringsSize == 0 || (isEndorsed && joinableStringsSize == 1)) {
+                text = null;
+            } else {
+                text = org.edx.mobile.util.TextUtils.join(" ", joinableStrings);
             }
         }
-
-        textView.setText(text);
         if (TextUtils.isEmpty(text)) {
             textView.setVisibility(View.GONE);
         } else {
+            textView.setText(text);
             // Allow ClickableSpan to trigger clicks
             textView.setMovementMethod(new LinkMovementMethod());
         }
     }
 
-    private static CharSequence getRelativeTimeSpanString(@NonNull Context context, long nowMs,
-                                                          long timeMs) {
+    public static CharSequence getRelativeTimeSpanString(@NonNull Context context, long nowMs,
+                                                         long timeMs) {
         if (nowMs - timeMs < DateUtils.SECOND_IN_MILLIS) {
             return context.getString(R.string.just_now);
         } else {
@@ -184,10 +148,6 @@ public abstract class DiscussionTextUtils {
         }
 
         return s.subSequence(start, end);
-    }
-
-    public static CharSequence removeDuplicateWhitespace(CharSequence text) {
-        return PATTERN_DUPLICATE_WHITESPACE.matcher(text).replaceAll(" ");
     }
 
     public static void setEndorsedState(@NonNull TextView target,

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
@@ -7,11 +7,10 @@ import android.support.v4.widget.TextViewCompat;
 import android.text.Html;
 import android.text.SpannableString;
 import android.text.Spanned;
-import android.text.TextPaint;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
 import android.text.method.LinkMovementMethod;
-import android.text.style.ClickableSpan;
+import android.text.style.ForegroundColorSpan;
 import android.text.style.StyleSpan;
 import android.view.View;
 import android.widget.TextView;
@@ -76,20 +75,23 @@ public abstract class DiscussionTextUtils {
             if (!TextUtils.isEmpty(author)) {
                 final SpannableString authorSpan = new SpannableString(author);
                 if (config.isUserProfilesEnabled() && !authorData.isAuthorAnonymous()) {
-                    authorSpan.setSpan(new ClickableSpan() {
-                        @Override
-                        public void onClick(View widget) {
-                            onAuthorClickListener.run();
-                        }
-
-                        @Override
-                        public void updateDrawState(TextPaint ds) {
-                            super.updateDrawState(ds);
-                            ds.setUnderlineText(false);
-                        }
-                    }, 0, authorSpan.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+                    // Change the author text color and style
+                    authorSpan.setSpan(new ForegroundColorSpan(
+                                    context.getResources().getColor(R.color.edx_brand_primary_base)),
+                            0, authorSpan.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
                     authorSpan.setSpan(new StyleSpan(Typeface.BOLD), 0, authorSpan.length(),
                             Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+                    // Set the click listener on the whole textView
+                    textView.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View v) {
+                            onAuthorClickListener.run();
+                        }
+                    });
+                } else {
+                    textView.setOnClickListener(null);
+                    textView.setClickable(false);
                 }
                 joinableStrings.add(ResourceUtil.getFormattedString(context.getResources(),
                         R.string.discussion_post_author_attribution, "author", authorSpan));
@@ -112,8 +114,6 @@ public abstract class DiscussionTextUtils {
             textView.setVisibility(View.GONE);
         } else {
             textView.setText(text);
-            // Allow ClickableSpan to trigger clicks
-            textView.setMovementMethod(new LinkMovementMethod());
         }
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/util/TextUtils.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/TextUtils.java
@@ -1,0 +1,29 @@
+package org.edx.mobile.util;
+
+import android.text.SpannableStringBuilder;
+
+public class TextUtils {
+    private TextUtils() {
+    }
+
+    /**
+     * Returns a string containing the tokens joined by delimiters.
+     *
+     * @param delimiter The delimiter to use while joining.
+     * @param tokens    An array of {@link CharSequence} to be joined using the delimiter.
+     * @return A {@link CharSequence} joined using the provided delimiter.
+     */
+    public static CharSequence join(CharSequence delimiter, Iterable<CharSequence> tokens) {
+        SpannableStringBuilder sb = new SpannableStringBuilder();
+        boolean firstTime = true;
+        for (CharSequence token : tokens) {
+            if (firstTime) {
+                firstTime = false;
+            } else {
+                sb.append(delimiter);
+            }
+            sb.append(token);
+        }
+        return sb;
+    }
+}

--- a/VideoLocker/src/test/java/org/edx/mobile/discussions/DiscussionTextUtilsTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/discussions/DiscussionTextUtilsTest.java
@@ -1,0 +1,199 @@
+package org.edx.mobile.discussions;
+
+import android.text.SpannableString;
+import android.text.TextUtils;
+import android.text.style.ClickableSpan;
+import android.view.View;
+import android.widget.TextView;
+
+import org.edx.mobile.R;
+import org.edx.mobile.discussion.DiscussionTextUtils;
+import org.edx.mobile.discussion.IAuthorData;
+import org.edx.mobile.test.BaseTestCase;
+import org.edx.mobile.util.ResourceUtil;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Date;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+public class DiscussionTextUtilsTest extends BaseTestCase {
+    @Test
+    public void testSetAuthorAttributionText_AllCombinations() {
+        final TextView textView = new TextView(context);
+
+        // Input values
+        final String author = "author";
+        final String label = "label";
+        final Date creationDate = new Date(1462368150195L); // A day before now
+
+        // Expected output constructs
+        final long now = 1462454550195L; // A day after the creationDate
+        final String relativeTime = "Yesterday";
+        final String outputAuthor = ResourceUtil.getFormattedString(context.getResources(),
+                R.string.discussion_post_author_attribution, "author", author).toString();
+        final String outputAuthorLbl = ResourceUtil.getFormattedString(context.getResources(),
+                R.string.discussion_post_author_label_attribution, "text", label).toString();
+        final String endorsePrefix = context.getString(R.string.discussion_post_endorsed);
+        final String answerPrefix = context.getString(R.string.discussion_post_marked_as_answer);
+
+        // For post
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.POST,
+                new StubAuthorData(author, label, creationDate), now,
+                relativeTime + " " + outputAuthor + " " + outputAuthorLbl);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.POST,
+                new StubAuthorData(null, label, creationDate), now,
+                relativeTime + " " + outputAuthorLbl);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.POST,
+                new StubAuthorData(author, null, creationDate), now,
+                relativeTime + " " + outputAuthor);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.POST,
+                new StubAuthorData(author, label, null), now,
+                outputAuthor + " " + outputAuthorLbl);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.POST,
+                new StubAuthorData(null, null, creationDate), now,
+                relativeTime);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.POST,
+                new StubAuthorData(author, null, null), now,
+                outputAuthor);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.POST,
+                new StubAuthorData(null, label, null), now,
+                outputAuthorLbl);
+
+        // For endorsed
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.ENDORSEMENT,
+                new StubAuthorData(author, label, creationDate), now,
+                endorsePrefix + " " + relativeTime + " " + outputAuthor + " " + outputAuthorLbl);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.ENDORSEMENT,
+                new StubAuthorData(null, label, creationDate), now,
+                endorsePrefix + " " + relativeTime + " " + outputAuthorLbl);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.ENDORSEMENT,
+                new StubAuthorData(author, null, creationDate), now,
+                endorsePrefix + " " + relativeTime + " " + outputAuthor);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.ENDORSEMENT,
+                new StubAuthorData(author, label, null), now,
+                endorsePrefix + " " + outputAuthor + " " + outputAuthorLbl);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.ENDORSEMENT,
+                new StubAuthorData(null, null, creationDate), now,
+                endorsePrefix + " " + relativeTime);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.ENDORSEMENT,
+                new StubAuthorData(author, null, null), now,
+                endorsePrefix + " " + outputAuthor);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.ENDORSEMENT,
+                new StubAuthorData(null, label, null), now,
+                endorsePrefix + " " + outputAuthorLbl);
+
+        // For answer
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.ANSWER,
+                new StubAuthorData(author, label, creationDate), now,
+                answerPrefix + " " + relativeTime + " " + outputAuthor + " " + outputAuthorLbl);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.ANSWER,
+                new StubAuthorData(null, label, creationDate), now,
+                answerPrefix + " " + relativeTime + " " + outputAuthorLbl);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.ANSWER,
+                new StubAuthorData(author, null, creationDate), now,
+                answerPrefix + " " + relativeTime + " " + outputAuthor);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.ANSWER,
+                new StubAuthorData(author, label, null), now,
+                answerPrefix + " " + outputAuthor + " " + outputAuthorLbl);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.ANSWER,
+                new StubAuthorData(null, null, creationDate), now,
+                answerPrefix + " " + relativeTime);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.ANSWER,
+                new StubAuthorData(author, null, null), now,
+                answerPrefix + " " + outputAuthor);
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.ANSWER,
+                new StubAuthorData(null, label, null), now,
+                answerPrefix + " " + outputAuthorLbl);
+
+        // Empty Case
+        assertSetAuthorAttributionText(textView,
+                DiscussionTextUtils.AuthorAttributionLabel.ANSWER,
+                new StubAuthorData(null, null, null), now,
+                null);
+    }
+
+    private void assertSetAuthorAttributionText(TextView textView,
+                                                DiscussionTextUtils.AuthorAttributionLabel type,
+                                                IAuthorData input,
+                                                long now, String expectedOutput) {
+        final Runnable listener = Mockito.mock(Runnable.class);
+        DiscussionTextUtils.setAuthorAttributionText(textView, type, input, now, listener);
+        if (expectedOutput == null) {
+            assertTrue(textView.getVisibility() == View.GONE);
+        } else {
+            String output = textView.getText().toString();
+            assertEquals(expectedOutput, output);
+            if (!input.isAuthorAnonymous()) {
+                // Test whether author span is clickable or not
+                int start = output.indexOf(input.getAuthor());
+                int end = start + input.getAuthor().length();
+                SpannableString text = (SpannableString) textView.getText();
+                ClickableSpan[] spans = text.getSpans(start, end, ClickableSpan.class);
+                if (config.isUserProfilesEnabled()) {
+                    assertEquals(1, spans.length);
+                    assertEquals(start, text.getSpanStart(spans[0]));
+                    assertEquals(end, text.getSpanEnd(spans[0]));
+                    spans[0].onClick(textView);
+                    Mockito.verify(listener).run();
+                } else {
+                    assertTrue(spans.length == 0);
+                }
+            }
+        }
+    }
+
+    private static class StubAuthorData implements IAuthorData {
+        private final String author, authorLabel;
+        private final Date createdDate;
+
+        public StubAuthorData(String author, String authorLabel, Date createdDate) {
+            this.author = author;
+            this.authorLabel = authorLabel;
+            this.createdDate = createdDate;
+        }
+
+        @Override
+        public String getAuthor() {
+            return author;
+        }
+
+        @Override
+        public String getAuthorLabel() {
+            return authorLabel;
+        }
+
+        @Override
+        public Date getCreatedAt() {
+            return createdDate;
+        }
+
+        @Override
+        public boolean isAuthorAnonymous() {
+            return TextUtils.isEmpty(author);
+        }
+    }
+}

--- a/VideoLocker/src/test/java/org/edx/mobile/discussions/DiscussionTextUtilsTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/discussions/DiscussionTextUtilsTest.java
@@ -1,8 +1,10 @@
 package org.edx.mobile.discussions;
 
-import android.text.SpannableString;
+import android.graphics.Typeface;
+import android.text.Spanned;
 import android.text.TextUtils;
-import android.text.style.ClickableSpan;
+import android.text.style.ForegroundColorSpan;
+import android.text.style.StyleSpan;
 import android.view.View;
 import android.widget.TextView;
 
@@ -17,6 +19,7 @@ import org.mockito.Mockito;
 import java.util.Date;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
 public class DiscussionTextUtilsTest extends BaseTestCase {
@@ -151,16 +154,30 @@ public class DiscussionTextUtilsTest extends BaseTestCase {
                 // Test whether author span is clickable or not
                 int start = output.indexOf(input.getAuthor());
                 int end = start + input.getAuthor().length();
-                SpannableString text = (SpannableString) textView.getText();
-                ClickableSpan[] spans = text.getSpans(start, end, ClickableSpan.class);
+                Spanned text = (Spanned) textView.getText();
+                StyleSpan[] styleSpans = text.getSpans(start, end, StyleSpan.class);
+                ForegroundColorSpan[] colorSpans = text.getSpans(start, end, ForegroundColorSpan.class);
                 if (config.isUserProfilesEnabled()) {
-                    assertEquals(1, spans.length);
-                    assertEquals(start, text.getSpanStart(spans[0]));
-                    assertEquals(end, text.getSpanEnd(spans[0]));
-                    spans[0].onClick(textView);
+                    // Verify that the author text is bold
+                    assertEquals(1, styleSpans.length);
+                    assertEquals(start, text.getSpanStart(styleSpans[0]));
+                    assertEquals(end, text.getSpanEnd(styleSpans[0]));
+                    assertEquals(Typeface.BOLD, styleSpans[0].getStyle());
+
+                    // Verify that the correct foreground color is set
+                    assertEquals(1, colorSpans.length);
+                    assertEquals(start, text.getSpanStart(colorSpans[0]));
+                    assertEquals(end, text.getSpanEnd(colorSpans[0]));
+                    assertEquals(context.getResources().getColor(R.color.edx_brand_primary_base),
+                            colorSpans[0].getForegroundColor());
+
+                    // Verify that the whole text view is clickable
+                    textView.performClick();
                     Mockito.verify(listener).run();
                 } else {
-                    assertTrue(spans.length == 0);
+                    assertEquals(0, styleSpans.length);
+                    assertEquals(0, colorSpans.length);
+                    assertFalse(textView.isClickable());
                 }
             }
         }

--- a/VideoLocker/src/test/java/org/edx/mobile/discussions/DiscussionTextUtilsTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/discussions/DiscussionTextUtilsTest.java
@@ -8,10 +8,12 @@ import android.text.style.StyleSpan;
 import android.view.View;
 import android.widget.TextView;
 
+import org.apache.commons.lang.time.DateUtils;
 import org.edx.mobile.R;
 import org.edx.mobile.discussion.DiscussionTextUtils;
 import org.edx.mobile.discussion.IAuthorData;
 import org.edx.mobile.test.BaseTestCase;
+import org.edx.mobile.test.util.TimeUtilsForTests;
 import org.edx.mobile.util.ResourceUtil;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -30,10 +32,10 @@ public class DiscussionTextUtilsTest extends BaseTestCase {
         // Input values
         final String author = "author";
         final String label = "label";
-        final Date creationDate = new Date(1462368150195L); // A day before now
+        final Date creationDate = new Date(TimeUtilsForTests.DEFAULT_TIME);
 
         // Expected output constructs
-        final long now = 1462454550195L; // A day after the creationDate
+        final long now = DateUtils.addDays(creationDate, 1).getTime(); // A day after the creationDate
         final String relativeTime = "Yesterday";
         final String outputAuthor = ResourceUtil.getFormattedString(context.getResources(),
                 R.string.discussion_post_author_attribution, "author", author).toString();

--- a/VideoLocker/src/test/java/org/edx/mobile/test/BaseTestCase.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/BaseTestCase.java
@@ -9,14 +9,13 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 
-import org.edx.mobile.CustomRobolectricTestRunner;
 import org.edx.mobile.core.EdxDefaultModule;
 import org.edx.mobile.logger.Logger;
+import org.edx.mobile.test.util.TimeUtilsForTests;
 import org.edx.mobile.util.Config;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
 
 import java.io.IOException;
@@ -25,17 +24,18 @@ import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 
 import roboguice.RoboGuice;
 
 @Ignore
 public abstract class BaseTestCase extends BaseTest {
-
     protected final Logger logger = new Logger(getClass().getName());
 
     protected Context context;
     protected Config config;
     protected CustomGuiceModule module;
+
     @Before
     public void setUp() throws Exception {
         context = RuntimeEnvironment.application;
@@ -43,6 +43,8 @@ public abstract class BaseTestCase extends BaseTest {
 
         module = new CustomGuiceModule();
         glueInjections();
+        // Set time zone to a constant value to make time-based tests predictable
+        TimeZone.setDefault(TimeUtilsForTests.DEFAULT_TIME_ZONE);
         print("Started Test Case: " + getClass().getName());
     }
 

--- a/VideoLocker/src/test/java/org/edx/mobile/test/util/TimeUtilsForTests.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/util/TimeUtilsForTests.java
@@ -1,0 +1,41 @@
+package org.edx.mobile.test.util;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public class TimeUtilsForTests {
+    private static String DEFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+    private static SimpleDateFormat dateFormat = new SimpleDateFormat(DEFAULT_DATE_FORMAT, Locale.US);
+
+    // Define a constant time zone to get predictable test parameters.
+    public static final TimeZone DEFAULT_TIME_ZONE = TimeZone.getTimeZone("UTC");
+
+    static {
+        dateFormat.setTimeZone(DEFAULT_TIME_ZONE);
+    }
+
+    // Define a constant time to get predictable test parameters.
+    public static final long DEFAULT_TIME = getMillis("2016-1-1 00:00:00");
+
+    private TimeUtilsForTests() {
+    }
+
+    /**
+     * Converts a given time stamp to milliseconds.
+     *
+     * @param timeStamp A date and time of the format {@link #DEFAULT_DATE_FORMAT}.
+     * @return Milliseconds value of the give timeStamp.
+     */
+    public static long getMillis(String timeStamp) {
+        Date date;
+        try {
+            date = dateFormat.parse(timeStamp);
+        } catch (ParseException e) {
+            return -1L;
+        }
+        return date.getTime();
+    }
+}


### PR DESCRIPTION
Fixes [MA-2286](https://openedx.atlassian.net/browse/MA-2286) & [MA-2266](https://openedx.atlassian.net/browse/MA-2266)

Previous implementation of `removeDuplicateWhitespace` [done here] (https://github.com/edx/edx-app-android/pull/670/files#diff-f0965130e69dcf6a44193af8da3227b4R189) removed the Span properties from the `CharSequence` due to the usage of `replaceAll` function in the `String` class.

I've now overhauled the `setAuthorAttributionText` function to construct the final string step-by-step using null checks on each input (matching the iOS implementation).

**UPDATE**: Whole author attribution has now been made clickable instead of the author text only.

@aleffert @1zaman @BenjiLee plz review