### PR TITLE
Add support for parsing dates with microseconds

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/core/RestAdapterProvider.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/core/RestAdapterProvider.java
@@ -28,6 +28,7 @@ public class RestAdapterProvider implements Provider<RestAdapter> {
         Gson gson = new GsonBuilder()
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .setDateFormat(DateUtil.ISO_8601_DATE_TIME_FORMAT)
+                .registerTypeAdapterFactory(new ServerJsonDateAdapterFactory())
                 .serializeNulls()
                 .create();
 

--- a/VideoLocker/src/main/java/org/edx/mobile/core/ServerJsonDateAdapterFactory.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/core/ServerJsonDateAdapterFactory.java
@@ -1,0 +1,80 @@
+package org.edx.mobile.core;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.internal.Streams;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import org.edx.mobile.util.DateUtil;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public class ServerJsonDateAdapterFactory implements TypeAdapterFactory {
+
+    private final List<SimpleDateFormat> dateFormatters;
+
+    public ServerJsonDateAdapterFactory() {
+        dateFormatters = new LinkedList<>();
+        dateFormatters.add(new SimpleDateFormat(DateUtil.ISO_8601_DATE_TIME_FORMAT, Locale.US));
+        dateFormatters.add(new SimpleDateFormat(DateUtil.ISO_8601_DATE_TIME_WITH_MICROSECONDS_FORMAT, Locale.US));
+
+        for(SimpleDateFormat formatter : dateFormatters) {
+            formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        }
+    }
+
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+        if (type.getRawType()!= Date.class) {
+            return null;
+        }
+
+        TypeAdapter<Date> defaultAdapter = (TypeAdapter<Date>) gson.getDelegateAdapter(this, type);
+        return (TypeAdapter<T>) new ServerJsonDateAdapter(defaultAdapter, dateFormatters);
+    }
+
+    final class ServerJsonDateAdapter extends TypeAdapter<Date> {
+        private final TypeAdapter<Date> defaultAdapter;
+        private final List<SimpleDateFormat> dateFormatters;
+
+        ServerJsonDateAdapter(TypeAdapter<Date> defaultAdapter, List<SimpleDateFormat> dateFormatters) {
+            this.defaultAdapter = defaultAdapter;
+            this.dateFormatters = dateFormatters;
+        }
+
+
+        @Override
+        public void write(JsonWriter out, Date value) throws IOException {
+            defaultAdapter.write(out, value);
+        }
+
+        @Override
+        public Date read(JsonReader in) throws IOException {
+            String dateString = in.nextString();
+
+            for (SimpleDateFormat dateFormat : dateFormatters) {
+                // date formatters aren't thread safe, so sync on them
+                synchronized(dateFormat) {
+                    try {
+                        return dateFormat.parse(dateString);
+                    } catch (ParseException ignored) {
+                        // suppress it and try the next loop item
+                    }
+                }
+            }
+            throw new JsonSyntaxException("Couldn't parse date: '" + dateString + "'");
+        }
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/util/DateUtil.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/DateUtil.java
@@ -11,9 +11,6 @@ import org.edx.mobile.logger.Logger;
 @SuppressLint("SimpleDateFormat")
 public class DateUtil {
     public static final String ISO_8601_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
-    // Used by some APIs
-    public static final String ISO_8601_DATE_TIME_WITH_MICROSECONDS_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'";
-
     private static final Logger logger = new Logger(DateUtil.class.getName());
 
     /*

--- a/VideoLocker/src/main/java/org/edx/mobile/util/DateUtil.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/DateUtil.java
@@ -10,8 +10,9 @@ import org.edx.mobile.logger.Logger;
 
 @SuppressLint("SimpleDateFormat")
 public class DateUtil {
-
-    public static final String ISO_8601_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
+    public static final String ISO_8601_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+    // Used by some APIs
+    public static final String ISO_8601_DATE_TIME_WITH_MICROSECONDS_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'";
 
     private static final Logger logger = new Logger(DateUtil.class.getName());
 

--- a/VideoLocker/src/test/java/org/edx/mobile/test/ServerJsonDateAdapterFactoryTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/ServerJsonDateAdapterFactoryTest.java
@@ -1,0 +1,91 @@
+package org.edx.mobile.test;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+
+import org.edx.mobile.core.ServerJsonDateAdapterFactory;
+import org.edx.mobile.util.DateUtil;
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class ServerJsonDateAdapterFactoryTest {
+
+    private Gson newGson() {
+        Gson gson = new GsonBuilder()
+                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                .setDateFormat(DateUtil.ISO_8601_DATE_TIME_FORMAT)
+                .registerTypeAdapterFactory(new ServerJsonDateAdapterFactory())
+                .serializeNulls()
+                .create();
+        return gson;
+    }
+
+    @Test
+    public void testParsingNormalDate() {
+        String dateString = "\"2014-11-06T20:16:45Z\"";
+        Gson gson = newGson();
+        Date date = gson.fromJson(dateString, Date.class);
+
+        assertNotNull(date);
+    }
+
+    @Test
+    public void testParsingMicrosecondsDate() {
+        String dateString = "\"2014-11-06T20:16:45.232333Z\"";
+        Gson gson = newGson();
+        Date date = gson.fromJson(dateString, Date.class);
+
+        assertNotNull(date);
+    }
+
+    @Test
+    public void testParsingNonsenseRaises() {
+        String dateString = "foobar";
+        Gson gson = newGson();
+
+        try {
+            Date date = gson.fromJson(dateString, Date.class);
+            fail("Parsing should raise an exception");
+        }
+        catch (JsonSyntaxException exception) {
+            // expecting failure
+        }
+    }
+
+    @Test
+    public void testSerializingUsesISO8601() throws ParseException {
+        Date baseDate = new Date();
+        Gson gson = newGson();
+        // remove the quotes surrounding the date since it's a json string
+        String dateString = gson.toJson(baseDate).replace("\"", "");
+        SimpleDateFormat formatter = new SimpleDateFormat(DateUtil.ISO_8601_DATE_TIME_FORMAT);
+        Date date = formatter.parse(dateString);
+
+        // Can't the compare the dates directly since they might have different values at sub second precision
+        // so compare them componentwise for the fields we care about
+
+        Calendar baseCalendar = Calendar.getInstance();
+        baseCalendar.setTime(baseDate);
+
+        Calendar parsedCalendar = Calendar.getInstance();
+        parsedCalendar.setTime(date);
+
+        assertEquals(parsedCalendar.get(Calendar.YEAR), baseCalendar.get(Calendar.YEAR));
+        assertEquals(parsedCalendar.get(Calendar.MONTH), baseCalendar.get(Calendar.MONTH));
+        assertEquals(parsedCalendar.get(Calendar.DAY_OF_MONTH), baseCalendar.get(Calendar.DAY_OF_MONTH));
+        assertEquals(parsedCalendar.get(Calendar.MINUTE), baseCalendar.get(Calendar.MINUTE));
+        assertEquals(parsedCalendar.get(Calendar.HOUR), baseCalendar.get(Calendar.HOUR));
+        assertEquals(parsedCalendar.get(Calendar.SECOND), baseCalendar.get(Calendar.SECOND));
+    }
+
+}

--- a/VideoLocker/src/test/java/org/edx/mobile/test/ServerJsonDateAdapterFactoryTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/ServerJsonDateAdapterFactoryTest.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 
+import org.apache.commons.lang.time.DateUtils;
 import org.edx.mobile.core.ServerJsonDateAdapterFactory;
 import org.edx.mobile.util.DateUtil;
 import org.junit.Test;
@@ -13,9 +14,9 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 public class ServerJsonDateAdapterFactoryTest {
@@ -36,7 +37,14 @@ public class ServerJsonDateAdapterFactoryTest {
         Gson gson = newGson();
         Date date = gson.fromJson(dateString, Date.class);
 
-        assertNotNull(date);
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        calendar.setTime(date);
+        assertEquals(2014, calendar.get(Calendar.YEAR));
+        assertEquals(Calendar.NOVEMBER, calendar.get(Calendar.MONTH));
+        assertEquals(6, calendar.get(Calendar.DAY_OF_MONTH));
+        assertEquals(20, calendar.get(Calendar.HOUR_OF_DAY));
+        assertEquals(16, calendar.get(Calendar.MINUTE));
+        assertEquals(45, calendar.get(Calendar.SECOND));
     }
 
     @Test
@@ -45,7 +53,14 @@ public class ServerJsonDateAdapterFactoryTest {
         Gson gson = newGson();
         Date date = gson.fromJson(dateString, Date.class);
 
-        assertNotNull(date);
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        calendar.setTime(date);
+        assertEquals(2014, calendar.get(Calendar.YEAR));
+        assertEquals(Calendar.NOVEMBER, calendar.get(Calendar.MONTH));
+        assertEquals(6, calendar.get(Calendar.DAY_OF_MONTH));
+        assertEquals(20, calendar.get(Calendar.HOUR_OF_DAY));
+        assertEquals(16, calendar.get(Calendar.MINUTE));
+        assertEquals(45, calendar.get(Calendar.SECOND));
     }
 
     @Test
@@ -71,21 +86,8 @@ public class ServerJsonDateAdapterFactoryTest {
         SimpleDateFormat formatter = new SimpleDateFormat(DateUtil.ISO_8601_DATE_TIME_FORMAT);
         Date date = formatter.parse(dateString);
 
-        // Can't the compare the dates directly since they might have different values at sub second precision
-        // so compare them componentwise for the fields we care about
-
-        Calendar baseCalendar = Calendar.getInstance();
-        baseCalendar.setTime(baseDate);
-
-        Calendar parsedCalendar = Calendar.getInstance();
-        parsedCalendar.setTime(date);
-
-        assertEquals(parsedCalendar.get(Calendar.YEAR), baseCalendar.get(Calendar.YEAR));
-        assertEquals(parsedCalendar.get(Calendar.MONTH), baseCalendar.get(Calendar.MONTH));
-        assertEquals(parsedCalendar.get(Calendar.DAY_OF_MONTH), baseCalendar.get(Calendar.DAY_OF_MONTH));
-        assertEquals(parsedCalendar.get(Calendar.MINUTE), baseCalendar.get(Calendar.MINUTE));
-        assertEquals(parsedCalendar.get(Calendar.HOUR), baseCalendar.get(Calendar.HOUR));
-        assertEquals(parsedCalendar.get(Calendar.SECOND), baseCalendar.get(Calendar.SECOND));
+        baseDate = DateUtils.truncate(baseDate, Calendar.SECOND);
+        assertEquals(baseDate.getTime(), date.getTime());
     }
 
 }


### PR DESCRIPTION
Unfortunately, the badges API is funny and returns dates using
microseconds, which is not our usual ISO8601 date handling.

This traps date parsing so that it can handle both cases.