### PR TITLE
Profile fixes (relating to "accomplishments" tab)

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/profiles/ScrollingPreferenceChild.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/profiles/ScrollingPreferenceChild.java
@@ -1,0 +1,5 @@
+package org.edx.mobile.profiles;
+
+public interface ScrollingPreferenceChild {
+    boolean prefersScrollingHeader();
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/profiles/ScrollingPreferenceParent.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/profiles/ScrollingPreferenceParent.java
@@ -1,0 +1,5 @@
+package org.edx.mobile.profiles;
+
+public interface ScrollingPreferenceParent {
+    void onChildScrollingPreferenceChanged();
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/profiles/UserProfileBioFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/profiles/UserProfileBioFragment.java
@@ -2,7 +2,6 @@ package org.edx.mobile.profiles;
 
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
-import android.support.annotation.IntegerRes;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
@@ -17,12 +16,14 @@ import org.edx.mobile.view.Router;
 
 import javax.inject.Inject;
 
-public class UserProfileBioFragment extends PresenterFragment<UserProfileBioPresenter, UserProfileBioPresenter.ViewInterface> {
+public class UserProfileBioFragment extends PresenterFragment<UserProfileBioPresenter, UserProfileBioPresenter.ViewInterface> implements ScrollingPreferenceChild {
 
     private final Logger logger = new Logger(getClass().getName());
 
     @Inject
     Router router;
+
+    private boolean prefersScrollingHeader = false;
 
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         return DataBindingUtil.inflate(inflater, R.layout.fragment_user_profile_bio, container, false).getRoot();
@@ -66,6 +67,8 @@ public class UserProfileBioFragment extends PresenterFragment<UserProfileBioPres
                 viewHolder.noAboutMe.setVisibility(bio.contentType == UserProfileBioModel.ContentType.NO_ABOUT_ME ? View.VISIBLE : View.GONE);
                 viewHolder.bioText.setVisibility(bio.contentType == UserProfileBioModel.ContentType.ABOUT_ME ? View.VISIBLE : View.GONE);
                 viewHolder.bioText.setText(bio.bioText);
+                prefersScrollingHeader = bio.contentType == UserProfileBioModel.ContentType.ABOUT_ME;
+                ((ScrollingPreferenceParent)getParentFragment()).onChildScrollingPreferenceChanged();
             }
 
             @Override
@@ -73,5 +76,10 @@ public class UserProfileBioFragment extends PresenterFragment<UserProfileBioPres
                 router.showUserProfileEditor(getActivity(), username);
             }
         };
+    }
+
+    @Override
+    public boolean prefersScrollingHeader() {
+        return prefersScrollingHeader;
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/profiles/UserProfileTab.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/profiles/UserProfileTab.java
@@ -9,13 +9,9 @@ public class UserProfileTab {
     @StringRes int displayName;
     private final
     @NonNull
-    String identifier;
-    private final
-    @NonNull
     Class<? extends Fragment> fragmentClass;
 
-    public UserProfileTab(@NonNull String identifier, @StringRes int displayName, @NonNull Class<? extends Fragment> fragmentClass) {
-        this.identifier = identifier;
+    public UserProfileTab(@StringRes int displayName, @NonNull Class<? extends Fragment> fragmentClass) {
         this.displayName = displayName;
         this.fragmentClass = fragmentClass;
     }
@@ -23,11 +19,6 @@ public class UserProfileTab {
     @StringRes
     public int getDisplayName() {
         return displayName;
-    }
-
-    @NonNull
-    public String getIdentifier() {
-        return identifier;
     }
 
     @NonNull

--- a/VideoLocker/src/main/java/org/edx/mobile/profiles/UserProfileTabsInteractor.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/profiles/UserProfileTabsInteractor.java
@@ -17,8 +17,6 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 public class UserProfileTabsInteractor {
-    private static final String BIO_TAB = "PROFILE_TAB_BIO";
-    private static final String PROFILE_TAB_ACCOMPLISHMENTS = "PROFILE_TAB_ACCOMPLISHMENTS";
 
     @NonNull
     private final String username;
@@ -57,7 +55,7 @@ public class UserProfileTabsInteractor {
 
 
     private List<UserProfileTab> builtInTabs() {
-        return Collections.singletonList(new UserProfileTab(BIO_TAB, R.string.profile_tab_bio, UserProfileBioFragment.class));
+        return Collections.singletonList(new UserProfileTab(R.string.profile_tab_bio, UserProfileBioFragment.class));
     }
 
     private void handleBadgesLoaded(@NonNull Page<BadgeAssertion> badges) {
@@ -66,7 +64,7 @@ public class UserProfileTabsInteractor {
         }
         final List<UserProfileTab> knownTabs = new ArrayList<>();
         knownTabs.addAll(builtInTabs());
-        knownTabs.add(new UserProfileTab(PROFILE_TAB_ACCOMPLISHMENTS, R.string.profile_tab_accomplishment, UserProfileAccomplishmentsFragment.class));
+        knownTabs.add(new UserProfileTab(R.string.profile_tab_accomplishment, UserProfileAccomplishmentsFragment.class));
         tabs.onData(knownTabs);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -98,11 +98,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
             return new DiscussionThreadViewHolder(discussionThreadRow);
         }
         if (viewType == RowType.PROGRESS) {
-            View discussionThreadRow = LayoutInflater.
-                    from(parent.getContext()).
-                    inflate(R.layout.list_view_footer_progress, parent, false);
-
-            return new ShowMoreViewHolder(discussionThreadRow);
+            return new LoadingViewHolder(parent);
         }
 
         View discussionResponseRow = LayoutInflater.
@@ -128,7 +124,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
                 bindViewHolderToResponseRow((DiscussionResponseViewHolder) holder, position);
                 break;
             case RowType.PROGRESS:
-                bindViewHolderToShowMoreRow((ShowMoreViewHolder) holder);
+                bindViewHolderToShowMoreRow((LoadingViewHolder) holder);
                 break;
         }
 
@@ -227,7 +223,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
         }
     }
 
-    private void bindViewHolderToShowMoreRow(ShowMoreViewHolder holder) {
+    private void bindViewHolderToShowMoreRow(LoadingViewHolder holder) {
     }
 
 
@@ -421,19 +417,13 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
         discussionThread.incrementCommentCount();
         String parentId = parent.getIdentifier();
         for (ListIterator<DiscussionComment> responseIterator = discussionResponses.listIterator();
-                responseIterator.hasNext();) {
+             responseIterator.hasNext(); ) {
             DiscussionComment response = responseIterator.next();
             if (parentId.equals(response.getIdentifier())) {
                 response.incrementChildCount();
                 notifyItemChanged(1 + responseIterator.previousIndex());
                 break;
             }
-        }
-    }
-
-    public static class ShowMoreViewHolder extends RecyclerView.ViewHolder {
-        public ShowMoreViewHolder(View itemView) {
-            super(itemView);
         }
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/LoadingViewHolder.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/LoadingViewHolder.java
@@ -1,0 +1,15 @@
+package org.edx.mobile.view.adapters;
+
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import org.edx.mobile.R;
+
+public class LoadingViewHolder extends RecyclerView.ViewHolder {
+    public LoadingViewHolder(@NonNull ViewGroup parent) {
+        super(LayoutInflater.from(parent.getContext()).
+                inflate(R.layout.list_view_footer_progress, parent, false));
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/StaticFragmentPagerAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/StaticFragmentPagerAdapter.java
@@ -5,25 +5,33 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
+import android.view.ViewGroup;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Implementation of {@link FragmentPagerAdapter} that takes a static list
  * of Fragments as the items.
  */
-public final class StaticFragmentPagerAdapter extends FragmentPagerAdapter {
-    private final List<Item> items;
+public class StaticFragmentPagerAdapter extends FragmentPagerAdapter {
+    @NonNull
+    private List<Item> items = Collections.emptyList();
+    @NonNull
+    private final Map<Integer, Fragment> positionToFragment = new HashMap<>();
 
     public StaticFragmentPagerAdapter(@NonNull FragmentManager manager, @NonNull Item... items) {
-        this(manager, Arrays.asList(items));
+        super(manager);
+        setItems(Arrays.asList(items));
     }
 
-    public StaticFragmentPagerAdapter(@NonNull FragmentManager manager, @NonNull List<Item> items) {
-        super(manager);
+    public void setItems(@NonNull List<Item> items) {
         this.items = new LinkedList<>(items);
+        notifyDataSetChanged();
     }
 
     @Override
@@ -31,14 +39,32 @@ public final class StaticFragmentPagerAdapter extends FragmentPagerAdapter {
         return items.size();
     }
 
+    // Despite the name, this method is actually used for *instantiating* each fragment
     @Override
     public Fragment getItem(int position) {
         return items.get(position).generateFragment();
     }
 
+    public Fragment getFragment(int position) {
+        return positionToFragment.get(position);
+    }
+
     @Override
     public CharSequence getPageTitle(int position) {
         return items.get(position).title;
+    }
+
+    @Override
+    public Fragment instantiateItem(ViewGroup container, int position) {
+        final Fragment fragment = (Fragment)super.instantiateItem(container, position);
+        positionToFragment.put(position, fragment);
+        return fragment;
+    }
+
+    @Override
+    public void destroyItem(ViewGroup container, int position, Object object) {
+        super.destroyItem(container, position, object);
+        positionToFragment.remove(position);
     }
 
     /**
@@ -86,6 +112,28 @@ public final class StaticFragmentPagerAdapter extends FragmentPagerAdapter {
             }
             fragment.setArguments(args);
             return fragment;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Item item = (Item) o;
+
+            if (fragmentClass != null ? !fragmentClass.equals(item.fragmentClass) : item.fragmentClass != null)
+                return false;
+            if (args != null ? !args.equals(item.args) : item.args != null) return false;
+            return title != null ? title.equals(item.title) : item.title == null;
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = fragmentClass != null ? fragmentClass.hashCode() : 0;
+            result = 31 * result + (args != null ? args.hashCode() : 0);
+            result = 31 * result + (title != null ? title.hashCode() : 0);
+            return result;
         }
     }
 }

--- a/VideoLocker/src/test/java/org/edx/mobile/profiles/AccomplishmentListAdapterTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/profiles/AccomplishmentListAdapterTest.java
@@ -1,0 +1,103 @@
+package org.edx.mobile.profiles;
+
+import android.support.annotation.NonNull;
+import android.support.v4.app.Fragment;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.edx.mobile.test.BaseTestCase;
+import org.edx.mobile.view.adapters.LoadingViewHolder;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class AccomplishmentListAdapterTest extends BaseTestCase {
+    private AccomplishmentListAdapter adapter;
+    @Mock
+    View mockView;
+    @Mock
+    Fragment mockFragment;
+    @Mock
+    AccomplishmentListAdapter.Listener mockListener;
+
+    @Before
+    public void setUp() throws Exception {
+        adapter = new TestableAccomplishmentListAdapterTest("http://example.com/", mockListener);
+    }
+
+    @Test
+    public void getItemCount() {
+        adapter.setItems(Arrays.asList(new BadgeAssertion(), new BadgeAssertion(), new BadgeAssertion()));
+        adapter.setPageLoading(false);
+        assertThat(adapter.getItemCount()).isEqualTo(3);
+        adapter.setPageLoading(true);
+        assertThat(adapter.getItemCount()).isEqualTo(4);
+    }
+
+    @Test
+    public void getItemViewType() {
+        adapter.setItems(Collections.singletonList(new BadgeAssertion()));
+        adapter.setPageLoading(true);
+        assertThat(adapter.getItemViewType(0)).isEqualTo(AccomplishmentListAdapter.RowType.ITEM);
+        assertThat(adapter.getItemViewType(1)).isEqualTo(AccomplishmentListAdapter.RowType.PROGRESS);
+    }
+
+    @Test
+    public void onBindViewHolder_withPositionOfItem_calls_setContent() {
+        final BadgeAssertion badgeAssertion = new BadgeAssertion();
+        adapter.setItems(Collections.singletonList(badgeAssertion));
+        final AccomplishmentListAdapter.ItemViewHolder viewHolder = mock(AccomplishmentListAdapter.ItemViewHolder.class);
+        adapter.onBindViewHolder(viewHolder, 0);
+        verify(viewHolder).setContent(badgeAssertion);
+    }
+
+    @Test
+    public void onBindViewHolder_withPositionOfLoadingIndicator_doesNothing() {
+        adapter.setItems(Collections.<BadgeAssertion>emptyList());
+        adapter.setPageLoading(true);
+        final LoadingViewHolder viewHolder = mock(LoadingViewHolder.class);
+        adapter.onBindViewHolder(viewHolder, 0);
+        verifyZeroInteractions(viewHolder);
+    }
+
+    @Test
+    public void onCreateViewHolder_withItemViewType_returnsItemViewHolder() {
+        final BadgeAssertion badgeAssertion = new BadgeAssertion();
+        adapter.setItems(Collections.singletonList(badgeAssertion));
+        final RecyclerView.ViewHolder viewHolder = adapter.onCreateViewHolder(mock(ViewGroup.class), AccomplishmentListAdapter.RowType.ITEM);
+        assertThat(viewHolder).isInstanceOf(AccomplishmentListAdapter.ItemViewHolder.class);
+    }
+
+    @Test
+    public void onCreateViewHolder_withProgressViewType_returnsLoadingViewHolder() {
+        final RecyclerView.ViewHolder viewHolder = adapter.onCreateViewHolder(mock(ViewGroup.class), AccomplishmentListAdapter.RowType.PROGRESS);
+        assertThat(viewHolder).isInstanceOf(LoadingViewHolder.class);
+    }
+
+    static class TestableAccomplishmentListAdapterTest extends AccomplishmentListAdapter {
+        public TestableAccomplishmentListAdapterTest(@NonNull String imageUrlPrefix, @NonNull Listener listener) {
+            super(imageUrlPrefix, listener);
+        }
+
+        @NonNull
+        @Override
+        protected ItemViewHolder createItemViewHolder(@NonNull ViewGroup parent) {
+            return mock(ItemViewHolder.class);
+        }
+
+        @NonNull
+        @Override
+        protected LoadingViewHolder createProgressViewHolder(@NonNull ViewGroup parent) {
+            return mock(LoadingViewHolder.class);
+        }
+    }
+}

--- a/VideoLocker/src/test/java/org/edx/mobile/profiles/UserProfileAccomplishmentsFragmentTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/profiles/UserProfileAccomplishmentsFragmentTest.java
@@ -1,0 +1,86 @@
+package org.edx.mobile.profiles;
+
+import android.annotation.SuppressLint;
+import android.databinding.DataBindingUtil;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import org.assertj.core.api.Assertions;
+import org.edx.mobile.databinding.FragmentUserProfileAccomplishmentsBinding;
+import org.edx.mobile.view.PresenterFragmentTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+
+public class UserProfileAccomplishmentsFragmentTest extends PresenterFragmentTest<
+        UserProfileAccomplishmentsFragmentTest.TestableUserProfileAccomplishmentsFragment,
+        UserProfileAccomplishmentsPresenter,
+        UserProfileAccomplishmentsPresenter.ViewInterface> {
+
+    FragmentUserProfileAccomplishmentsBinding binding;
+
+    @Mock
+    AccomplishmentListAdapter mockAdapter;
+
+    @Before
+    public void before() {
+        startFragment(new TestableUserProfileAccomplishmentsFragment(mockAdapter));
+        binding = DataBindingUtil.getBinding(fragment.getView());
+        Assertions.assertThat(binding).isNotNull();
+    }
+
+    @Test
+    public void adapterListener_onShare_callsPresenter() {
+        Assertions.assertThat(fragment.listener).isNotNull();
+        final BadgeAssertion badgeAssertion = new BadgeAssertion();
+        fragment.listener.onShare(badgeAssertion);
+        verify(presenter).onClickShare(badgeAssertion);
+    }
+
+    @Test
+    public void setModel_withZeroItemsAndLoadingTrue_setsAdapterItemsAndLoading() {
+        final List<BadgeAssertion> items = Collections.emptyList();
+        view.setModel(new UserProfileAccomplishmentsPresenter.ViewModel(items, true));
+        verify(mockAdapter).setItems(items);
+        verify(mockAdapter).setPageLoading(true);
+    }
+
+    @Test
+    public void setModel_withZeroItemsAndLoadingFalse_setsAdapterItemsAndLoading() {
+        final List<BadgeAssertion> items = Collections.emptyList();
+        view.setModel(new UserProfileAccomplishmentsPresenter.ViewModel(items, false));
+        verify(mockAdapter).setItems(items);
+        verify(mockAdapter).setPageLoading(false);
+    }
+
+    @Test
+    public void prefersScrollingHeader_isTrue() {
+        Assertions.assertThat(fragment.prefersScrollingHeader()).isTrue();
+    }
+
+    @SuppressLint("ValidFragment")
+    public static class TestableUserProfileAccomplishmentsFragment extends UserProfileAccomplishmentsFragment {
+
+        @NonNull
+        private final AccomplishmentListAdapter mockAdapter;
+
+        @Nullable
+        private AccomplishmentListAdapter.Listener listener;
+
+        public TestableUserProfileAccomplishmentsFragment(@NonNull AccomplishmentListAdapter mockAdapter) {
+            this.mockAdapter = mockAdapter;
+        }
+
+        @NonNull
+        @Override
+        protected AccomplishmentListAdapter createAdapter(@NonNull AccomplishmentListAdapter.Listener listener) {
+            this.listener = listener;
+            return mockAdapter;
+        }
+    }
+}

--- a/VideoLocker/src/test/java/org/edx/mobile/profiles/UserProfilePresenterTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/profiles/UserProfilePresenterTest.java
@@ -2,24 +2,19 @@ package org.edx.mobile.profiles;
 
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.prefs.UserPrefs;
-import org.edx.mobile.profiles.UserProfileImageViewModel;
-import org.edx.mobile.profiles.UserProfileInteractor;
-import org.edx.mobile.profiles.UserProfilePresenter;
-import org.edx.mobile.profiles.UserProfileViewModel;
 import org.edx.mobile.test.PresenterTest;
 import org.edx.mobile.util.observer.CachingObservable;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class UserProfilePresenterTest extends PresenterTest<UserProfilePresenter, UserProfilePresenter.ViewInterface> {
@@ -75,6 +70,7 @@ public class UserProfilePresenterTest extends PresenterTest<UserProfilePresenter
         accountObservable.onError(error);
         verify(view).showError(error);
     }
+
     @Test
     public void whenInteractorEmitsProfileImage_setsProfileImageOnView() {
         final UserProfileImageViewModel model = mock(UserProfileImageViewModel.class);
@@ -86,6 +82,13 @@ public class UserProfilePresenterTest extends PresenterTest<UserProfilePresenter
     public void whenInteractorEmitsProfileImageError_noInteractionsWithView() {
         photoObservable.onError(new RuntimeException());
         verify(view, never()).showError(any(Throwable.class));
+    }
+
+    @Test
+    public void whenInteractorEmitsTabs_showsTabsOnView() {
+        final List<UserProfileTab> tabs = Collections.emptyList();
+        tabsObservable.onData(tabs);
+        verify(view).showTabs(tabs);
     }
 
     @Test


### PR DESCRIPTION
Fixes two issues in the new profile layout:
- Fixed a race condition causing loading indicator / loading errors to not be centered correctly
- Fixes centering of empty profile messages
- Fixes the initial scrolling position of the "accomplishments" tab
- Added some unit tests

(This is a follow-up to https://github.com/edx/edx-app-android/pull/692)