### PR TITLE
Null handling for ServerJsonDateAdapterFactory

### DIFF
--- a/VideoLocker/src/test/java/org/edx/mobile/test/ServerJsonDateAdapterFactoryTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/test/ServerJsonDateAdapterFactoryTest.java
@@ -64,6 +64,15 @@ public class ServerJsonDateAdapterFactoryTest {
     }
 
     @Test
+    public void testParsingNull() {
+        String dateString = "null";
+        Gson gson = newGson();
+        Date date = gson.fromJson(dateString, Date.class);
+
+        assertEquals(null, date);
+    }
+
+    @Test
     public void testParsingNonsenseRaises() {
         String dateString = "foobar";
         Gson gson = newGson();


### PR DESCRIPTION
Fixes [MA-2381](https://openedx.atlassian.net/browse/MA-2381)

32c9723 introduced a `TypeAdapterFactory` for handling dates with milliseconds. But it didn't handle the case if server returned `null`. So, when the read function expected a `String` type object, an `IllegalStateException` was raised during the conversion.

Exact exception: 
> org.edx.mobile.http.RetroHttpException: retrofit.RetrofitError: com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected STRING but was NULL

This PR fixes the issue by first peeking for null and then moving on to the normal logic.

@aleffert quick review on this, as its blocking the loading of responses and comments in the Discussion UIs.
@1zaman & @BenjiLee optional review maybe