### PR TITLE
Whole author label made tappable only

### DIFF
--- a/VideoLocker/res/layout/discussion_responses_thread_row.xml
+++ b/VideoLocker/res/layout/discussion_responses_thread_row.xml
@@ -67,10 +67,11 @@
                 app:iconColor="@color/edx_grayscale_neutral_base"
                 app:iconName="fa-thumb-tack" />
 
-            <include
-                layout="@layout/discussion_author_layout"
+            <include layout="@layout/discussion_author_layout" />
+
+            <Space
                 android:layout_width="0dp"
-                android:layout_height="wrap_content"
+                android:layout_height="0dp"
                 android:layout_weight="1" />
 
             <include layout="@layout/number_responses_or_comments_layout" />

--- a/VideoLocker/res/layout/row_discussion_comment.xml
+++ b/VideoLocker/res/layout/row_discussion_comment.xml
@@ -31,14 +31,18 @@
 
         <TextView
             android:id="@+id/discussion_comment_author_text_view"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:textDirection="locale"
             android:padding="@dimen/discussion_responses_box_padding"
             android:textColor="@color/edx_grayscale_neutral_base"
+            android:textDirection="locale"
             android:textSize="@dimen/edx_xxx_small"
             tools:text="Brian 10 minutes ago" />
+
+        <Space
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
 
         <TextView
             android:id="@+id/discussion_comment_count_report_text_view"


### PR DESCRIPTION
Fixes [MA-2266](https://openedx.atlassian.net/browse/MA-2266)

Previously on some screens the author attribution TextView took the
leftover width by other views in the same row to fill it. Causing some
area besides the TextView's actual text to be tappable as well.

This PR fixes the issue by changing the width of all such TextViews to
wrap_content.