### PR TITLE
Enable landscape orientation for forums

### DIFF
--- a/VideoLocker/AndroidManifest.xml
+++ b/VideoLocker/AndroidManifest.xml
@@ -61,7 +61,7 @@
             android:label="@string/app_name"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar" />
-        
+
         <activity
             android:name="org.edx.mobile.view.LoginActivity"
             android:label="@string/app_name"
@@ -71,7 +71,7 @@
             android:configChanges="keyboardHidden|orientation"
             >
         </activity>
-        
+
         <activity
             android:name="org.edx.mobile.view.MyCoursesListActivity"
             android:label="@string/app_name"
@@ -93,28 +93,37 @@
 
         <activity
             android:name=".view.CourseDiscussionTopicsActivity"
-            android:label="@string/app_name"
-            android:screenOrientation="portrait"
-            >
-        </activity>
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:label="@string/app_name" />
 
-        <activity android:name=".view.CourseDiscussionPostsActivity"
-            android:label="@string/app_name"
-            android:screenOrientation="portrait"
-            >
-        </activity>
+        <activity
+            android:name=".view.CourseDiscussionPostsActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:label="@string/app_name" />
 
-        <activity android:name=".view.CourseDiscussionCommentsActivity"
-            android:label="@string/app_name"
-            android:screenOrientation="portrait"
-            >
-        </activity>
+        <activity
+            android:name=".view.CourseDiscussionCommentsActivity"
+            android:label="@string/app_name" />
 
-        <activity android:name=".view.CourseDiscussionResponsesActivity"
-            android:label="@string/app_name"
-            android:screenOrientation="portrait"
-            >
-        </activity>
+        <activity
+            android:name=".view.CourseDiscussionResponsesActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:label="@string/app_name" />
+
+        <activity
+            android:name="org.edx.mobile.view.DiscussionAddPostActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:label="@string/discussion_post_create_new_post" />
+
+        <activity
+            android:name="org.edx.mobile.view.DiscussionAddResponseActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:label="@string/discussion_add_response_title" />
+
+        <activity
+            android:name="org.edx.mobile.view.DiscussionAddCommentActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:label="@string/discussion_add_comment_title" />
 
         <activity
             android:name="org.edx.mobile.view.CourseUnitNavigationActivity"
@@ -130,14 +139,14 @@
             android:screenOrientation="portrait"
             >
         </activity>
-         
+
         <activity
             android:name="org.edx.mobile.view.MyVideosTabActivity"
             android:label="@string/label_my_videos"
             android:screenOrientation="portrait"
             >
         </activity>
-        
+
         <activity
             android:name="org.edx.mobile.view.DownloadListActivity"
             android:label="@string/title_download"
@@ -168,7 +177,7 @@
             android:label="@string/find_courses_title"
             android:screenOrientation="portrait">
         </activity>
-        
+
         <activity
             android:name="org.edx.mobile.view.VideoListActivity"
             android:label="@string/app_name"
@@ -182,21 +191,6 @@
         <activity
             android:name=".view.CourseAnnouncementsActivity"
             android:label="@string/announcement_title"
-            android:screenOrientation="portrait" />
-
-        <activity
-            android:name="org.edx.mobile.view.DiscussionAddCommentActivity"
-            android:label="@string/discussion_add_comment_title"
-            android:screenOrientation="portrait" />
-
-        <activity
-            android:name="org.edx.mobile.view.DiscussionAddResponseActivity"
-            android:label="@string/discussion_add_response_title"
-            android:screenOrientation="portrait" />
-
-        <activity
-            android:name="org.edx.mobile.view.DiscussionAddPostActivity"
-            android:label="@string/discussion_post_create_new_post"
             android:screenOrientation="portrait" />
 
         <activity
@@ -243,20 +237,20 @@
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>
         </receiver>
-         
+
         <!-- Setup for Code Coverage -->
         <instrumentation
             android:name="org.edx.mobile.instrumentation.EdxInstrumentation"
             android:targetPackage="org.edx.mobile" >
         </instrumentation>
-	
+
         <!-- adb shell am broadcast -a org.edx.mobile.END_EMMA -->
         <receiver android:name="org.edx.mobile.instrumentation.EndEmmaBroadcast" >
             <intent-filter>
                 <action android:name="org.edx.mobile.END_EMMA" />
             </intent-filter>
         </receiver>
-		 
+
         <!-- Setup Google -->
         <meta-data android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />

--- a/VideoLocker/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
@@ -108,12 +108,6 @@ public abstract class BaseFragmentActivity extends BaseAppActivity
             bar.setDisplayShowHomeEnabled(true);
             bar.setDisplayHomeAsUpEnabled(true);
             bar.setIcon(android.R.color.transparent);
-            //If activity is in landscape, hide the Action bar
-            if (isLandscape()) {
-                bar.hide();
-            } else {
-                bar.show();
-            }
         }
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/util/SoftKeyboardUtil.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/SoftKeyboardUtil.java
@@ -9,9 +9,9 @@ import android.view.inputmethod.InputMethodManager;
 public class SoftKeyboardUtil {
 
     /**
-     * Hides the soft keyboard
+     * Hides the soft keyboard.
      *
-     * @param activity The reference of the activity displaying the keyboard
+     * @param activity The reference of the activity displaying the keyboard.
      */
     public static void hide(@NonNull final Activity activity) {
         final InputMethodManager iManager = (InputMethodManager) activity.
@@ -20,5 +20,19 @@ public class SoftKeyboardUtil {
         if (view != null && iManager != null) {
             iManager.hideSoftInputFromWindow(view.getWindowToken(), 0);
         }
+    }
+
+    /**
+     * Hides the soft keyboard by clearing view's focus.
+     *
+     * @param view The view whose focus needs to be cleared.
+     */
+    public static void clearViewFocus(@NonNull final View view) {
+        view.post(new Runnable() {
+            @Override
+            public void run() {
+                view.clearFocus();
+            }
+        });
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsSearchFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsSearchFragment.java
@@ -114,12 +114,7 @@ public class CourseDiscussionPostsSearchFragment extends CourseDiscussionPostsBa
     @Override
     public void onResume() {
         super.onResume();
-        discussionTopicsSearchView.post(new Runnable() {
-            @Override
-            public void run() {
-                discussionTopicsSearchView.clearFocus();
-            }
-        });
+        SoftKeyboardUtil.clearViewFocus(discussionTopicsSearchView);
     }
 
     @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionTopicsFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionTopicsFragment.java
@@ -24,6 +24,7 @@ import org.edx.mobile.discussion.DiscussionTopicDepth;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.task.GetTopicListTask;
+import org.edx.mobile.util.SoftKeyboardUtil;
 import org.edx.mobile.view.adapters.DiscussionTopicsAdapter;
 
 import java.util.ArrayList;
@@ -144,11 +145,6 @@ public class CourseDiscussionTopicsFragment extends BaseFragment {
     @Override
     public void onResume() {
         super.onResume();
-        discussionTopicsSearchView.post(new Runnable() {
-            @Override
-            public void run() {
-                discussionTopicsSearchView.clearFocus();
-            }
-        });
+        SoftKeyboardUtil.clearViewFocus(discussionTopicsSearchView);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
@@ -1,5 +1,6 @@
 package org.edx.mobile.view;
 
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.text.Editable;
@@ -24,6 +25,7 @@ import org.edx.mobile.discussion.DiscussionThread;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.task.CreateCommentTask;
+import org.edx.mobile.util.SoftKeyboardUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -152,5 +154,13 @@ public class DiscussionAddCommentFragment extends BaseFragment {
         createCommentTask.setTaskProcessCallback(null);
         createCommentTask.setProgressDialog(createCommentProgressBar);
         createCommentTask.execute();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            SoftKeyboardUtil.clearViewFocus(editTextNewComment);
+        }
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddPostFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddPostFragment.java
@@ -1,6 +1,7 @@
 package org.edx.mobile.view;
 
 import android.app.Activity;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.annotation.StringRes;
 import android.support.v4.view.ViewCompat;
@@ -264,4 +265,11 @@ public class DiscussionAddPostFragment extends BaseFragment {
         getTopicListTask.execute();
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            SoftKeyboardUtil.clearViewFocus(titleEditText);
+        }
+    }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddResponseActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddResponseActivity.java
@@ -5,11 +5,7 @@ import android.support.v4.app.Fragment;
 
 import com.google.inject.Inject;
 
-import org.edx.mobile.R;
 import org.edx.mobile.base.BaseSingleFragmentActivity;
-import org.edx.mobile.discussion.DiscussionComment;
-
-import roboguice.inject.InjectExtra;
 
 public class DiscussionAddResponseActivity extends BaseSingleFragmentActivity {
     @Inject

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
@@ -1,5 +1,6 @@
 package org.edx.mobile.view;
 
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.text.Editable;
@@ -24,6 +25,7 @@ import org.edx.mobile.discussion.DiscussionThread;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.task.CreateCommentTask;
+import org.edx.mobile.util.SoftKeyboardUtil;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -146,5 +148,13 @@ public class DiscussionAddResponseFragment extends BaseFragment {
         createCommentTask.setTaskProcessCallback(null);
         createCommentTask.setProgressDialog(createCommentProgressBar);
         createCommentTask.execute();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            SoftKeyboardUtil.clearViewFocus(editTextNewComment);
+        }
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyRecentVideosFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyRecentVideosFragment.java
@@ -120,12 +120,6 @@ public class MyRecentVideosFragment extends MyVideosBaseFragment implements IPla
             showDeletePanel(getView());
 
             videoListView.setOnItemClickListener(adapter);
-        } else {
-            // probably the landscape player view, so hide action bar
-            ActionBar bar = ((AppCompatActivity)getActivity()).getSupportActionBar();
-            if (bar != null) {
-                bar.hide();
-            }
         }
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyVideosTabActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyVideosTabActivity.java
@@ -1,6 +1,5 @@
 package org.edx.mobile.view;
 
-import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.design.widget.TabLayout;
 import android.support.v4.view.PagerAdapter;
@@ -34,10 +33,10 @@ public class MyVideosTabActivity extends BaseVideosDownloadStateActivity {
         initializeTabs();
 
         // Full-screen video in landscape.
-        if (getResources().getConfiguration().orientation ==
-                Configuration.ORIENTATION_LANDSCAPE) {
+        if (isLandscape()) {
             getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                     WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            setActionBarVisible(false);
         }
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/VideoListActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/VideoListActivity.java
@@ -2,7 +2,6 @@ package org.edx.mobile.view;
 
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
-import android.content.res.Configuration;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.app.FragmentManager;
@@ -76,10 +75,10 @@ public class VideoListActivity extends BaseVideosDownloadStateActivity
         listFragment.setCallback(this);
 
         // Full-screen video in landscape.
-        if (getResources().getConfiguration().orientation ==
-                Configuration.ORIENTATION_LANDSCAPE) {
+        if (isLandscape()) {
             getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                     WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            setActionBarVisible(false);
         }
     }
 

--- a/VideoLocker/src/test/java/org/edx/mobile/view/BaseFragmentActivityTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/BaseFragmentActivityTest.java
@@ -118,41 +118,6 @@ public abstract class BaseFragmentActivityTest extends UiTest {
     }
 
     /**
-     * Generic method to assert action bar visibility state on a specified orientation
-     *
-     * @param orientation The orientation it should be tested on
-     * @param expected    The expected visibility state
-     */
-    private void assertActionBarShowing(int orientation, boolean expected) {
-        ActivityController<? extends BaseFragmentActivity> controller =
-                Robolectric.buildActivity(getActivityClass()).withIntent(getIntent());
-        BaseFragmentActivity activity = controller.get();
-        activity.getResources().getConfiguration().orientation = orientation;
-        controller.create().start();
-        ActionBar bar = activity.getSupportActionBar();
-        assumeNotNull(bar);
-        assertEquals(expected, bar.isShowing());
-    }
-
-    /**
-     * Testing whether action bar is displayed in portrait orientation
-     */
-    @Test
-    @Config(qualifiers = "port")
-    public void showActionBarOnPortraitTest() {
-        assertActionBarShowing(Configuration.ORIENTATION_PORTRAIT, true);
-    }
-
-    /**
-     * Testing whether action bar is hidden in landscape orientation
-     */
-    @Test
-    @Config(qualifiers = "land")
-    public void hideActionBarOnLandscapeTest() {
-        assertActionBarShowing(Configuration.ORIENTATION_LANDSCAPE, false);
-    }
-
-    /**
      * Generic method for asserting pending transition animation
      *
      * @param shadowActivity The shadow activity


### PR DESCRIPTION
Fixes [MA-2317](https://openedx.atlassian.net/browse/MA-2317)

- Hiding action bar in `onStart` function of `BaseFragmentActivity` has been
removed in favour of on-demand removal in respective activities that
are meant to go full screen.
- While in landscape, if we go to screens like Add Post/Response/Comment
keyboard is hidden forcefully, so that a user can first see the screen, instead of
inputting text in whatever view that has focus initially.

@aleffert @1zaman @BenjiLee plz review