### PR TITLE
Updated colors for question threads in the listing

### DIFF
--- a/VideoLocker/res/values/colors.xml
+++ b/VideoLocker/res/values/colors.xml
@@ -125,29 +125,30 @@
     <color name="last_accessed_row_blue">#E5F5FC</color>
 
     <!--  We need to adapt edX color code -->
-    <!--  see  http://ux.edx.org/elements/colors/ -->
-    <color name="edx_brand_primary_x_dark">#003654</color>
-    <color name="edx_brand_primary_dark">#005483</color>
+    <!--  see  http://ux.edx.org/design_elements/colors/ -->
+    <color name="edx_brand_primary_x_dark">#0B344A</color>
+    <color name="edx_brand_primary_dark">#065683</color>
     <color name="edx_brand_primary_base">#0079BC</color>
-    <color name="edx_brand_primary_light">#4CA1D0</color>
-    <color name="edx_brand_primary_x_light">#B2D6EA</color>
+    <color name="edx_brand_primary_light">#53A4D1</color>
+    <color name="edx_brand_primary_x_light">#A6CFE6</color>
     <color name="edx_brand_primary_accent">#0EA6EC</color>
-    <color name="edx_brand_primary_x_accent">#00B2FF</color>
+    <color name="edx_brand_primary_x_accent">#00ABFA</color>
 
-    <color name="edx_brand_secondary_x_dark">#5B283F</color>
-    <color name="edx_brand_secondary_dark">#8E3E63</color>
-    <color name="edx_brand_secondary_x_light">#EFCDDD</color>
-    <color name="edx_brand_secondary_accent">#F26CAA</color>
+    <color name="edx_brand_secondary_x_dark">#50293B</color>
+    <color name="edx_brand_secondary_dark">#8E4164</color>
     <color name="edx_brand_secondary_base">#CB598D</color>
+    <color name="edx_brand_secondary_light">#DB8FB2</color>
+    <color name="edx_brand_secondary_x_light">#EBC5D6</color>
+    <color name="edx_brand_secondary_accent">#F26CAA</color>
 
     <color name="edx_grayscale_neutral_white_t">#FFFFFF</color>
     <color name="edx_grayscale_neutral_white">#FCFCFC</color>
-    <color name="edx_grayscale_neutral_xx_light">#F2F2F2</color>
-    <color name="edx_grayscale_neutral_x_light">#E9E8E8</color>
-    <color name="edx_grayscale_neutral_light">#D3D1D1</color>
+    <color name="edx_grayscale_neutral_xx_light">#EFEFEF</color>
+    <color name="edx_grayscale_neutral_x_light">#E7E6E6</color>
+    <color name="edx_grayscale_neutral_light">#D2D0D0</color>
     <color name="edx_grayscale_neutral_base">#A7A4A4</color>
-    <color name="edx_grayscale_neutral_dark">#646262</color>
-    <color name="edx_grayscale_neutral_x_dark">#424141</color>
+    <color name="edx_grayscale_neutral_dark">#6B6969</color>
+    <color name="edx_grayscale_neutral_x_dark">#4D4B4B</color>
     <color name="edx_grayscale_neutral_black">#111010</color>
     <color name="edx_grayscale_neutral_black_t">#000000</color>
 

--- a/VideoLocker/res/values/colors.xml
+++ b/VideoLocker/res/values/colors.xml
@@ -151,6 +151,7 @@
     <color name="edx_grayscale_neutral_black">#111010</color>
     <color name="edx_grayscale_neutral_black_t">#000000</color>
 
+    <color name="edx_utility_success_dark">#1E8142</color>
     <color name="edx_utility_success">#25B85A</color>
     <color name="edx_utility_warning">#FDBC56</color>
     <color name="edx_utility_error">#B20610</color>

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DiscussionPostsAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DiscussionPostsAdapter.java
@@ -25,12 +25,18 @@ public class DiscussionPostsAdapter extends BaseListAdapter<DiscussionThread> {
     private final int edx_brand_primary_base;
     @ColorInt
     private final int edx_grayscale_neutral_light;
+    @ColorInt
+    private final int edx_brand_secondary_dark;
+    @ColorInt
+    private final int edx_utility_success_dark;
 
     @Inject
     public DiscussionPostsAdapter(Context context, IEdxEnvironment environment) {
         super(context, R.layout.row_discussion_thread, environment);
         edx_brand_primary_base = context.getResources().getColor(R.color.edx_brand_primary_base);
         edx_grayscale_neutral_light = context.getResources().getColor(R.color.edx_grayscale_neutral_light);
+        edx_brand_secondary_dark = context.getResources().getColor(R.color.edx_brand_secondary_dark);
+        edx_utility_success_dark = context.getResources().getColor(R.color.edx_utility_success_dark);
     }
 
     @Override
@@ -38,12 +44,23 @@ public class DiscussionPostsAdapter extends BaseListAdapter<DiscussionThread> {
         ViewHolder holder = (ViewHolder) tag;
 
         {
-            Icon icon = FontAwesomeIcons.fa_comments;
+            Icon icon;
+            @ColorInt
+            final int iconColor;
             if (discussionThread.getType() == DiscussionThread.ThreadType.QUESTION) {
-                icon = discussionThread.isHasEndorsed() ?
-                        FontAwesomeIcons.fa_check_square_o : FontAwesomeIcons.fa_question;
+                if (discussionThread.isHasEndorsed()) {
+                    icon = FontAwesomeIcons.fa_check_square_o;
+                    iconColor = edx_utility_success_dark;
+                } else {
+                    icon = FontAwesomeIcons.fa_question;
+                    iconColor = edx_brand_secondary_dark;
+                }
+            } else {
+                icon = FontAwesomeIcons.fa_comments;
+                iconColor = edx_grayscale_neutral_light;
             }
             holder.discussionPostTypeIcon.setIcon(icon);
+            holder.discussionPostTypeIcon.setIconColor(iconColor);
         }
 
         {


### PR DESCRIPTION
Fixes [MA-2323](https://openedx.atlassian.net/browse/MA-2323)

Separate colors applied for the post-type icon, incase of an answered/unanswered question on the threads list screen.

Here's how the screen looks now:

Before | After
----- | -----
<img src="https://openedx.atlassian.net/secure/attachment/32600/Mobile.png" width="250" /> | <img src="https://cloud.githubusercontent.com/assets/1710804/15359755/36f6f91e-1d24-11e6-8190-a85e1c19a621.png" width="250" />

@1zaman @BenjiLee @mdinino plz review