### PR TITLE
Fix error reading from failed request body

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/http/HttpConnectivityException.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/HttpConnectivityException.java
@@ -1,0 +1,9 @@
+package org.edx.mobile.http;
+
+import android.support.annotation.NonNull;
+
+public class HttpConnectivityException extends RetroHttpException {
+    public HttpConnectivityException(@NonNull Throwable cause) {
+        super(cause);
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/http/HttpResponseStatusException.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/HttpResponseStatusException.java
@@ -1,0 +1,16 @@
+package org.edx.mobile.http;
+
+import android.support.annotation.NonNull;
+
+public class HttpResponseStatusException extends RetroHttpException {
+    private final int statusCode;
+
+    public HttpResponseStatusException(@NonNull Throwable cause, int statusCode) {
+        super(cause);
+        this.statusCode = statusCode;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/VideoLocker/src/main/java/org/edx/mobile/http/RetroHttpException.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/RetroHttpException.java
@@ -4,26 +4,8 @@ import android.support.annotation.NonNull;
 
 import retrofit.RetrofitError;
 
-/**
- * Should this be the base class of all http exceptions?
- */
 public class RetroHttpException extends RuntimeException {
-
-    @NonNull
-    private final RetrofitError cause;
-
-    public RetroHttpException(@NonNull RetrofitError cause) {
+    public RetroHttpException(@NonNull Throwable cause) {
         super(cause);
-        this.cause = cause;
-    }
-
-    @Override
-    @NonNull
-    public RetrofitError getCause() {
-        return cause;
-    }
-
-    public int getStatusCode() {
-        return cause.getResponse().getStatus();
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/http/RetroHttpExceptionHandler.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/RetroHttpExceptionHandler.java
@@ -19,6 +19,12 @@ public class RetroHttpExceptionHandler implements ErrorHandler {
             String body = new String(((TypedByteArray) response.getBody()).getBytes());
             logger.warn("body = " + body);
             logger.warn("status and reason = " + response.getStatus() + ":" + response.getReason());
+            if (RetrofitError.Kind.HTTP == cause.getKind()) {
+                return new HttpResponseStatusException(cause, response.getStatus());
+            }
+        }
+        if (RetrofitError.Kind.NETWORK == cause.getKind()) {
+            return new HttpConnectivityException(cause);
         }
         return new RetroHttpException(cause);
     }

--- a/VideoLocker/src/main/java/org/edx/mobile/util/images/ErrorUtils.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/images/ErrorUtils.java
@@ -4,44 +4,29 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 
 import org.edx.mobile.R;
-import org.edx.mobile.http.RetroHttpException;
+import org.edx.mobile.http.HttpConnectivityException;
+import org.edx.mobile.http.HttpResponseStatusException;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.util.NetworkUtil;
-
-import retrofit.RetrofitError;
 
 public enum ErrorUtils {
     ;
 
     protected static final Logger logger = new Logger(ErrorUtils.class.getName());
-    
+
     @NonNull
     public static String getErrorMessage(@NonNull Throwable ex, @NonNull Context context) {
         String errorMessage = null;
-        if (ex instanceof RetroHttpException) {
-            RetrofitError cause = ((RetroHttpException) ex).getCause();
-            switch (cause.getKind()) {
-                case NETWORK: {
-                    if (NetworkUtil.isConnected(context)) {
-                        errorMessage = context.getString(R.string.network_connected_error);
-                    } else {
-                        errorMessage = context.getString(R.string.reset_no_network_message);
-                    }
-                    break;
-                }
-                case HTTP: {
-                    if (cause.getResponse() != null) {
-                        final int status = cause.getResponse().getStatus();
-                        if (status == 503) {
-                            errorMessage = context.getString(R.string.network_service_unavailable);
-                        }
-                    }
-                }
-                case CONVERSION:
-                case UNEXPECTED: {
-                    // Use default message
-                    break;
-                }
+        if (ex instanceof HttpConnectivityException) {
+            if (NetworkUtil.isConnected(context)) {
+                errorMessage = context.getString(R.string.network_connected_error);
+            } else {
+                errorMessage = context.getString(R.string.reset_no_network_message);
+            }
+        } else if (ex instanceof HttpResponseStatusException) {
+            final int status = ((HttpResponseStatusException) ex).getStatusCode();
+            if (status == 503) {
+                errorMessage = context.getString(R.string.network_service_unavailable);
             }
         }
         if (null == errorMessage) {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/MyCourseListTabFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/MyCourseListTabFragment.java
@@ -11,6 +11,7 @@ import org.edx.mobile.R;
 import org.edx.mobile.event.EnrolledInCourseEvent;
 import org.edx.mobile.exception.AuthException;
 import org.edx.mobile.http.Api;
+import org.edx.mobile.http.HttpResponseStatusException;
 import org.edx.mobile.http.RetroHttpException;
 import org.edx.mobile.loader.AsyncTaskResult;
 import org.edx.mobile.loader.CoursesAsyncLoader;
@@ -86,8 +87,8 @@ public class MyCourseListTabFragment extends CourseListTabFragment {
                 PrefManager prefs = new PrefManager(getActivity(), PrefManager.Pref.LOGIN);
                 prefs.clearAuth();
                 getActivity().finish();
-            } else if (result.getEx() instanceof RetroHttpException &&
-                    ((RetroHttpException) result.getEx()).getStatusCode() == 401) {
+            } else if (result.getEx() instanceof HttpResponseStatusException &&
+                    ((HttpResponseStatusException) result.getEx()).getStatusCode() == 401) {
                 environment.getRouter().forceLogout(
                         getContext(),
                         environment.getSegment(),


### PR DESCRIPTION
I created a specialized exception class for each of the types of errors we have custom behaviour for. This also prevents us from trying to read the response status from a request with a failed response.

As an added bonus, RetrofitError is no longer exposed to the UI layer, which is great since it's just an implementation detail.