### PR TITLE
Make RetroHttpException a checked exception

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/http/RetroHttpException.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/RetroHttpException.java
@@ -4,7 +4,7 @@ import android.support.annotation.NonNull;
 
 import retrofit.RetrofitError;
 
-public class RetroHttpException extends RuntimeException {
+public class RetroHttpException extends Exception {
     public RetroHttpException(@NonNull Throwable cause) {
         super(cause);
     }

--- a/VideoLocker/src/main/java/org/edx/mobile/module/storage/IStorage.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/storage/IStorage.java
@@ -2,6 +2,7 @@ package org.edx.mobile.module.storage;
 
 import android.support.annotation.NonNull;
 
+import org.edx.mobile.http.RetroHttpException;
 import org.edx.mobile.interfaces.SectionItemInterface;
 import org.edx.mobile.model.VideoModel;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
@@ -96,14 +97,14 @@ public interface IStorage {
      * videos and no videos downloaded in the course
      * @return
      */
-    @NonNull ArrayList<EnrolledCoursesResponse> getDownloadedCoursesWithVideoCountAndSize();
+    @NonNull ArrayList<EnrolledCoursesResponse> getDownloadedCoursesWithVideoCountAndSize() throws RetroHttpException;
 
     /**
      * Returns list of all recently downloaded videos list
      * The list contains local videos with only course header sorted based on Downloaded Date.
      * @return
      */
-    @NonNull ArrayList<SectionItemInterface> getRecentDownloadedVideosList();
+    @NonNull ArrayList<SectionItemInterface> getRecentDownloadedVideosList() throws RetroHttpException;
 
     /**
      * This DownloadEntry model is fetched and returned from the db

--- a/VideoLocker/src/main/java/org/edx/mobile/module/storage/Storage.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/storage/Storage.java
@@ -9,6 +9,7 @@ import android.support.annotation.Nullable;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
+import org.edx.mobile.http.RetroHttpException;
 import org.edx.mobile.interfaces.SectionItemInterface;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.VideoModel;
@@ -264,7 +265,7 @@ public class Storage implements IStorage {
 
     @Override
     @NonNull
-    public ArrayList<EnrolledCoursesResponse> getDownloadedCoursesWithVideoCountAndSize() {
+    public ArrayList<EnrolledCoursesResponse> getDownloadedCoursesWithVideoCountAndSize() throws RetroHttpException {
         ArrayList<EnrolledCoursesResponse> downloadedCourseList = new ArrayList<>();
 
         List<EnrolledCoursesResponse> enrolledCourses = null;
@@ -302,7 +303,7 @@ public class Storage implements IStorage {
 
     @Override
     @NonNull
-    public ArrayList<SectionItemInterface> getRecentDownloadedVideosList() {
+    public ArrayList<SectionItemInterface> getRecentDownloadedVideosList() throws RetroHttpException {
         ArrayList<SectionItemInterface> recentVideolist = new ArrayList<>();
 
         ArrayList<EnrolledCoursesResponse> courseList = null;


### PR DESCRIPTION
To eliminate the risk not handling exceptions from API calls.