### PR TITLE
Remove RecyclerView loading indicator item animation

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/InfiniteScrollUtils.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/InfiniteScrollUtils.java
@@ -57,6 +57,8 @@ public class InfiniteScrollUtils {
     }
 
     public static <T> InfiniteListController configureRecyclerViewWithInfiniteList(@NonNull final RecyclerView recyclerView, @NonNull final ListContentController<T> adapter, @NonNull final PageLoader<T> pageLoader) {
+        // Don't allow the progress spinner item positioning changes to be animated
+        recyclerView.setItemAnimator(null);
         final LinearLayoutManager linearLayoutManager = new LinearLayoutManager(recyclerView.getContext());
         recyclerView.setLayoutManager(linearLayoutManager);
         final PageLoadController controller = new PageLoadController<>(adapter, pageLoader);


### PR DESCRIPTION
## [MA-2183][]

#598 changed the `RecyclerView` adapters in the discussion module to report the exact dataset changes to the `RecyclerView` instead of just a generic change notification. As a consequence of providing this detailed information, when a new page of items were inserted into the adapter, the `RecyclerView` started to do a slide animation to move the loading indicator item at the bottom to make way for the new items to be inserted. Since this is not a desirable UI, the default item animator is now being removed from the `RecyclerView` as part of it's pagination configuration as performed in `InfiniteScrollUtils`.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @miankhalid
- [x] Code review: @BenjiLee

<sub>@verdanmahmood wanted us to start using the [TNL Pull Request Template][], so here goed nothing 😜  Only the reviewers section seem to be applicable.</sub>

[MA-2183]: https://openedx.atlassian.net/browse/MA-2183
[TNL Pull Request Template]: https://openedx.atlassian.net/wiki/display/TNL/TNL+Pull+Request+Template