### PR TITLE
HTML from SRT files are no longer renders in subtitles

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/player/PlayerFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/PlayerFragment.java
@@ -1224,7 +1224,7 @@ public class PlayerFragment extends BaseFragment implements IPlayerListener, Ser
                     if(temp.length()==0){
                         subTitlesTv.setVisibility(View.GONE);
                     }else{
-                        subTitlesTv.setText(Html.fromHtml(temp));
+                        subTitlesTv.setText(temp);
                         subTitlesTv.setVisibility(View.VISIBLE);
                     }
                 }else{


### PR DESCRIPTION
Addresses https://openedx.atlassian.net/browse/MA-2495

Waiting on final confirmation from @clrux that we do NOT want the subtitles to render HTML in the SRT files.