### PR TITLE
MA-2463 Moved receiver from manifest to init

### DIFF
--- a/VideoLocker/AndroidManifest.xml
+++ b/VideoLocker/AndroidManifest.xml
@@ -260,15 +260,6 @@
 
         <service android:name="org.edx.mobile.services.DownloadSpeedService" />
 
-        <receiver
-            android:name="org.edx.mobile.receivers.NetworkConnectivityReceiver"
-            android:label="NetworkChangeReceiver" >
-            <intent-filter>
-                <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />
-                <action android:name="android.net.wifi.WIFI_STATE_CHANGED" />
-            </intent-filter>
-        </receiver>
-
         <!--   Parse Setup -->
         <!--  https://www.parse.com/apps/quickstart#parse_push/android/existing  -->
         <service android:name="com.parse.PushService" />

--- a/VideoLocker/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -4,6 +4,9 @@ package org.edx.mobile.base;
 import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
+import android.content.IntentFilter;
+import android.net.ConnectivityManager;
+import android.net.wifi.WifiManager;
 import android.os.Bundle;
 import android.support.multidex.MultiDexApplication;
 
@@ -23,6 +26,7 @@ import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.notification.NotificationDelegate;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.module.storage.IStorage;
+import org.edx.mobile.receivers.NetworkConnectivityReceiver;
 import org.edx.mobile.util.Config;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.view.Router;
@@ -89,6 +93,9 @@ public abstract class MainApplication extends MultiDexApplication {
                     .withCrashReportingEnabled(false)
                     .start(this);
         }
+
+        registerReceiver(new NetworkConnectivityReceiver(), new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
+        registerReceiver(new NetworkConnectivityReceiver(), new IntentFilter(WifiManager.WIFI_STATE_CHANGED_ACTION));
 
         // initialize Facebook SDK
         boolean isOnZeroRatedNetwork = NetworkUtil.isOnZeroRatedNetwork(getApplicationContext(), config);


### PR DESCRIPTION
### Description

[MA-2463](https://openedx.atlassian.net/browse/MA-2463)

MA-2463 Moved receiver from manifest to init  …
The network connectivity receiver used for offline mode was in the
manifest which caused the app to be launched constantly in the
background. The reciever called the init method of the app which then
reported extraneous app launces to NewRelic. Since offline mode
is only used when the app is being actively used, the reciever
 did not need to be in the Manifest.
### Notes
- Completing downloads will also over report, but not as much as going in and out of network. We should figure out what to do with this in a different task.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @1zaman 
- [x] Code review: @bguertin 
- [x] Code review: @mdinino  
- [ ] Code review: @miankhalid  


