### PR TITLE
Silently refresh threads list upon return

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsActivity.java
@@ -114,10 +114,4 @@ public class CourseDiscussionPostsActivity extends BaseSingleFragmentActivity {
             }
         }
     }
-
-    @Override
-    protected void onRestart() {
-        super.onRestart();
-        ((CourseDiscussionPostsBaseFragment) getFirstFragment()).onRestart();
-    }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsBaseFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsBaseFragment.java
@@ -19,31 +19,22 @@ import roboguice.inject.InjectView;
 
 
 public abstract class CourseDiscussionPostsBaseFragment extends BaseFragment implements InfiniteScrollUtils.PageLoader<DiscussionThread> {
-
     @InjectView(R.id.discussion_posts_listview)
-    ListView discussionPostsListView;
+    protected ListView discussionPostsListView;
 
     @Inject
-    DiscussionPostsAdapter discussionPostsAdapter;
+    protected DiscussionPostsAdapter discussionPostsAdapter;
 
     @Inject
-    Router router;
+    protected Router router;
 
-    EnrolledCoursesResponse courseData;
+    protected EnrolledCoursesResponse courseData;
 
-    InfiniteScrollUtils.InfiniteListController controller;
+    protected InfiniteScrollUtils.InfiniteListController controller;
 
-    /**
-     * Callback to match the restart behaviour with the parent activity.
-     */
-    public abstract void onRestart();
+    protected int nextPage = 1;
 
-    /**
-     * Extension for the child classes to add more functionality to the ListView's onItemClick
-     * function.
-     */
-    public abstract void onItemClick(DiscussionThread thread, AdapterView<?> parent,
-                                     View view, int position, long id);
+    private boolean isRestart = false;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -68,10 +59,26 @@ public abstract class CourseDiscussionPostsBaseFragment extends BaseFragment imp
                     thread.setRead(true);
                     discussionPostsAdapter.getView(position, view, parent);
                 }
-
-                CourseDiscussionPostsBaseFragment.this.onItemClick(thread, parent, view,
-                        position, id);
             }
         });
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+
+        if (isRestart) {
+        /*
+         * If the activity/fragment needs to be reinstantiated upon restoration,
+         * then in some cases the onStart() callback maybe invoked before view
+         * initialization, and thus the controller might not be initialized, and
+         * therefore we need to guard this with a null check.
+         */
+            if (controller != null) {
+                nextPage = 1;
+                controller.resetSilently();
+            }
+        }
+        isRestart = true;
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsSearchFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsSearchFragment.java
@@ -8,7 +8,6 @@ import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
 import android.widget.SearchView;
 
 import org.edx.mobile.R;
@@ -33,8 +32,6 @@ public class CourseDiscussionPostsSearchFragment extends CourseDiscussionPostsBa
     private SearchView discussionTopicsSearchView;
 
     private SearchThreadListTask searchThreadListTask;
-
-    private int nextPage = 1;
 
     @Nullable
     @Override
@@ -122,22 +119,4 @@ public class CourseDiscussionPostsSearchFragment extends CourseDiscussionPostsBa
         super.onResume();
         SoftKeyboardUtil.clearViewFocus(discussionTopicsSearchView);
     }
-
-    @Override
-    public void onRestart() {
-        /*
-        If the activity/fragment needs to be reinstantiated upon restoration,
-        then in some cases the onRestart() callback maybe invoked before view
-        initialization, and thus the controller might not be initialized, and
-        therefore we need to guard this with a null check.
-         */
-        if (controller != null) {
-            nextPage = 1;
-            controller.resetSilently();
-        }
-    }
-
-    @Override
-    public void onItemClick(DiscussionThread thread, AdapterView<?> parent, View view,
-                            int position, long id) {}
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
@@ -80,9 +80,6 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
     @Nullable
     private Runnable populatePostListRunnable;
 
-    private int nextPage = 1;
-    private int mSelectedItem = -1;
-
     private enum EmptyQueryResultsFor {
         FOLLOWING,
         CATEGORY,
@@ -232,32 +229,6 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
     public void onDestroy() {
         super.onDestroy();
         EventBus.getDefault().unregister(this);
-    }
-
-    @Override
-    public void onRestart() {
-        if (postsSort == DiscussionPostsSort.LAST_ACTIVITY_AT && mSelectedItem != -1) {
-            // Move the last viewed thread to the top
-            discussionPostsAdapter.moveToTop(mSelectedItem);
-            mSelectedItem = -1;
-        }
-
-        /*
-        If the activity/fragment needs to be reinstantiated upon restoration,
-        then in some cases the onRestart() callback maybe invoked before view
-        initialization, and thus the controller might not be initialized, and
-        therefore we need to guard this with a null check.
-         */
-        if (controller != null) {
-            nextPage = 1;
-            controller.resetSilently();
-        }
-    }
-
-    @Override
-    public void onItemClick(DiscussionThread thread, AdapterView<?> parent, View view,
-                            int position, long id) {
-        mSelectedItem = position;
     }
 
     @SuppressWarnings("unused")

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/BaseListAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/BaseListAdapter.java
@@ -125,15 +125,6 @@ public abstract class BaseListAdapter<T> extends ArrayAdapter<T> implements OnIt
         notifyDataSetChanged();
     }
 
-    public void moveToTop(int itemPosition) {
-        if (itemPosition < objects.size()) {
-            T item = objects.get(itemPosition);
-            objects.remove(itemPosition);
-            objects.add(0, item);
-            notifyDataSetChanged();
-        }
-    }
-
     /**
      * Clears all items from this adapter.
      */


### PR DESCRIPTION
### [MA-2520](https://openedx.atlassian.net/browse/MA-2520)

- Previously the refresh didn't work in inline discussions.
- Restart logic is now managed by the base fragment and all the logic
related to restart and silent refresh has been moved to
CourseDiscussionPostsBaseFragment.
- Moving a thread to the top of the list upon reading, has been removed
since the requirements have changed.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @1zaman 
- [x] Code review: @BenjiLee 