### PR TITLE
Disable create button while topic is loading

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
@@ -115,6 +115,8 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
         super.onViewCreated(view, savedInstanceState);
 
         if (discussionTopic == null) {
+            // Disable the button for adding new posts until the topic is loaded.
+            createNewPostLayout.setEnabled(false);
             // Either we are coming from a deep link or courseware's inline discussion
             fetchDiscussionTopic();
         } else {
@@ -219,6 +221,9 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
                     setProgressDialog(null);
                     populatePostListRunnable.run();
                 }
+
+                // Now that we have the topic date, we can allow the user to add new posts.
+                createNewPostLayout.setEnabled(true);
             }
         };
         getTopicsTask.setProgressDialog(loadingIndicator);


### PR DESCRIPTION
### [MA-2532](https://openedx.atlassian.net/browse/MA-2532)

In case of Inline discussions, the discussionTopic is initially null, so, if we try to navigate to 'Create New Post' screen (which expects a non-null DiscussionTopic object) we encounter a NPE.

This behaviour is fixed, by initially disabling the button which navigates us to the 'Create New Post' screen and enabling it when we have a non-null DiscussionTopic object.

**Quick review anyone ?**

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @1zaman 
- [ ] Code review: @BenjiLee 
- [ ] Code review: @mdinino  