### PR TITLE
Addresses MA-1871: Video controls TalkBack accessible durring playback

### DIFF
--- a/VideoLocker/res/layout/fragment_course_unit_video.xml
+++ b/VideoLocker/res/layout/fragment_course_unit_video.xml
@@ -15,6 +15,7 @@
         android:layout_height="@dimen/video_player_height"
         android:clickable="true"
         android:contentDescription="@string/video_player"
+        android:importantForAccessibility="no"
         android:orientation="vertical" />
 
     <LinearLayout

--- a/VideoLocker/res/layout/view_course_unit_pager.xml
+++ b/VideoLocker/res/layout/view_course_unit_pager.xml
@@ -4,5 +4,6 @@
     android:id="@+id/pager"
     android:layout_width="match_parent"
     android:layout_height="0px"
-    android:layout_weight="1">
+    android:layout_weight="1"
+    android:importantForAccessibility="no">
 </org.edx.mobile.view.custom.DisableableViewPager>

--- a/VideoLocker/src/main/java/org/edx/mobile/player/IPlayer.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/player/IPlayer.java
@@ -2,44 +2,48 @@ package org.edx.mobile.player;
 
 import android.graphics.Point;
 import android.view.View;
+import android.view.accessibility.AccessibilityEvent;
 
 import java.io.Serializable;
 
 public interface IPlayer extends Serializable {
     
-    static final long serialVersionUID = 5689385691113719237L;
+    long serialVersionUID = 5689385691113719237L;
 
-    public void setUri(String uri, int seekTo) throws Exception;
-    public void setUriAndPlay(String uri, int seekTo) throws Exception;
-    public void restart() throws Exception;
-    public void restart(int seekTo) throws Exception;
-    public boolean isInError();
-    public boolean isPlayingLocally();
-    public void start();
-    public boolean isPlaying();
-    public boolean isPaused();
-    public boolean isFrozen();
-    public void pause();
-    public int getCurrentPosition();
-    public void setFullScreen(boolean isFullScreen);
-    public boolean isFullScreen();
-    public void setPreview(Preview preview);
-    public void release();
-    public void setPlayerListener(IPlayerListener listener);
-    public void setController(PlayerController controller);
-    public void freeze();
-    public void unfreeze();
-    public void setVideoTitle(String title);
-    public int getLastFreezePosition();
-    public void showController();
-    public void hideController();
-    public void reset();
-    public void setLMSUrl(String url);
-    public void setNextPreviousListeners(View.OnClickListener next, View.OnClickListener prev);
-    public void callSettings(Point p);
-    public void callPlayerSeeked(long previousPos, long nextPos, boolean isRewindClicked);
-    public PlayerController getController();
-    public boolean isReset();
+    void setUri(String uri, int seekTo) throws Exception;
+    void setUriAndPlay(String uri, int seekTo) throws Exception;
+    void restart() throws Exception;
+    void restart(int seekTo) throws Exception;
+    boolean isInError();
+    boolean isPlayingLocally();
+    void start();
+    boolean isPlaying();
+    boolean isPaused();
+    boolean isFrozen();
+    void pause();
+    int getCurrentPosition();
+    void setFullScreen(boolean isFullScreen);
+    boolean isFullScreen();
+    void setPreview(Preview preview);
+    void release();
+    void setPlayerListener(IPlayerListener listener);
+    void setController(PlayerController controller);
+    void freeze();
+    void unfreeze();
+    void setVideoTitle(String title);
+    int getLastFreezePosition();
+    void setAutoHideControls(boolean autoHide);
+    boolean getAutoHideControls();
+    void showController();
+    void hideController();
+    void requestAccessibilityFocusPausePlay();
+    void reset();
+    void setLMSUrl(String url);
+    void setNextPreviousListeners(View.OnClickListener next, View.OnClickListener prev);
+    void callSettings(Point p);
+    void callPlayerSeeked(long previousPos, long nextPos, boolean isRewindClicked);
+    PlayerController getController();
+    boolean isReset();
 
     // methods from PlayerController.MediaPlayerControl interface
     int     getDuration();


### PR DESCRIPTION
[MA-1871](https://openedx.atlassian.net/browse/MA-1871)

- Made sure that video controls (play, rewind, seek, etc) are always available when talkback mode is on, but when talkback is off, reverts to default behavior. This allows the user to always swipe to controls in an intuitive fashion when TB mode is on.
- Ensured that tab order of video controls was appropriate and that TB output was appropriate for control (no code change needed for this)
- Ensured that certain views were not being selected/spoken about in TB mode. Did this for video screen in courses and in my videos.
- Cleaned up warnings

[ ] Unit testing
- Start with TB mode off and logged into app. Downloaded a video.
- In both course screen and my video screen, made sure that controls appeared/hid appropriately. Rotated phone between portrait and landscape and made sure behavior was correct. Ensured that video controls worked appropriately when video ended too.
- Killed app, turned on TB mode.
- In both course screen and my video screen, made sure that controls never went away. Made sure that swiping was intuitive and in the correct order. Made sure that TB output was appropriate. Made sure that all controls worked when double tapped.
-Rotated phone between portrait and landscape mode. Made sure that controls can be swiped to. TB output was appropriate and that controls worked properly in both cases.
- Let video end and made sure that controls didn't disappear.
- Restarted video and then toggled TB mode on/off from controls menu. Made sure that video control behavior worked appropriately.

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @BenjiLee 
- [x] Code review: @brianguertin 
- [ ] Accessibility review: @clrux
