### PR TITLE
Remove obsolete Config override that causes problems in Android Studio

### DIFF
--- a/VideoLocker/src/test/java/org/edx/mobile/view/CourseUnitNavigationActivityTest.java
+++ b/VideoLocker/src/test/java/org/edx/mobile/view/CourseUnitNavigationActivityTest.java
@@ -52,9 +52,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
-// The SDK version needs to be lesser than Lollipop because of this
-// issue: https://github.com/robolectric/robolectric/issues/1810
-@Config(sdk = 19)
 public class CourseUnitNavigationActivityTest extends CourseBaseActivityTest {
     /**
      * Method for defining the subclass of {@link CourseUnitNavigationActivity}


### PR DESCRIPTION
This annotation is causing `CourseUnitNavigationActivityTest` to fail when run from Android Studio.

As it turns out, we no longer need the annotation, so I removed it.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @BenjiLee 
