### PR TITLE
Fix forum crashes when view or activity is null

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
@@ -1,5 +1,6 @@
 package org.edx.mobile.view;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
@@ -212,18 +213,22 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
             @Override
             protected void onSuccess(CourseTopics courseTopics) throws Exception {
                 discussionTopic = courseTopics.getCoursewareTopics().get(0).getChildren().get(0);
-                if (!getArguments().getBoolean(ARG_DISCUSSION_HAS_TOPIC_NAME)) {
+                Activity activity = getActivity();
+                if (activity != null &&
+                        !getArguments().getBoolean(ARG_DISCUSSION_HAS_TOPIC_NAME)) {
                     // We only need to set the title here when coming from a deep link
-                    getActivity().setTitle(discussionTopic.getName());
+                    activity.setTitle(discussionTopic.getName());
                 }
 
-                if (populatePostListRunnable != null) {
-                    setProgressDialog(null);
-                    populatePostListRunnable.run();
-                }
+                if (getView() != null) {
+                    if (populatePostListRunnable != null) {
+                        setProgressDialog(null);
+                        populatePostListRunnable.run();
+                    }
 
-                // Now that we have the topic date, we can allow the user to add new posts.
-                createNewPostLayout.setEnabled(true);
+                    // Now that we have the topic date, we can allow the user to add new posts.
+                    createNewPostLayout.setEnabled(true);
+                }
             }
         };
         getTopicsTask.setProgressDialog(loadingIndicator);
@@ -315,6 +320,7 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
                 discussionTopic, postsFilter, postsSort, nextPage) {
             @Override
             public void onSuccess(Page<DiscussionThread> threadsPage) {
+                if (getView() == null) return;
                 ++nextPage;
                 callback.onPageLoaded(threadsPage);
 
@@ -333,6 +339,7 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
 
             @Override
             protected void onException(Exception ex) {
+                if (getView() == null) return;
                 // Don't display any error message if we're doing a silent
                 // refresh, as that would be confusing to the user.
                 if (!callback.isRefreshingSilently()) {


### PR DESCRIPTION
### [MA-2533](https://openedx.atlassian.net/browse/MA-2533), [MA-2537](https://openedx.atlassian.net/browse/MA-2537) & [MA-2539](https://openedx.atlassian.net/browse/MA-2539)

This PR fixes the case when a network task returns (whether it be a
success or a failure) if the fragment has been destroyed due to pager
having moved to another page or the activity being finished, a crash
occurs cuz it can't find a non-null activity context or fragment's view.

### Notes
These problems will automatically be solved once we move to the app to an MVP pattern, whose ticket has already been logged ([MA-2509](https://openedx.atlassian.net/browse/MA-2509)).

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @1zaman 
- [x] Code review: @BenjiLee 
- [ ] Code review: @bguertin 
- [x] Code review: @mdinino 