### PR TITLE
Fix login error messages not being shown

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/authentication/LoginService.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/authentication/LoginService.java
@@ -1,6 +1,7 @@
 package org.edx.mobile.authentication;
 
 import org.edx.mobile.http.ApiConstants;
+import org.edx.mobile.http.RetroHttpException;
 
 import retrofit.http.Field;
 import retrofit.http.FormUrlEncoded;
@@ -20,7 +21,8 @@ public interface LoginService {
     AuthResponse getAccessToken(@Field("grant_type") String grant_type,
                                 @Field("client_id") String client_id,
                                 @Field("username") String username,
-                                @Field("password") String password);
+                                @Field("password") String password)
+            throws RetroHttpException;
 
     /**
      * Depending on the query parameters for this endpoint, a different action will be triggered
@@ -30,5 +32,6 @@ public interface LoginService {
     @POST(ApiConstants.URL_ACCESS_TOKEN)
     AuthResponse refreshAccessToken(@Field("grant_type") String grant_type,
                                     @Field("client_id") String client_id,
-                                    @Field("refresh_token") String refresh_token);
+                                    @Field("refresh_token") String refresh_token)
+            throws RetroHttpException;
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/authentication/LoginTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/authentication/LoginTask.java
@@ -7,11 +7,18 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
 
+import org.edx.mobile.R;
+import org.edx.mobile.exception.LoginErrorMessage;
+import org.edx.mobile.exception.LoginException;
 import org.edx.mobile.http.RetroHttpException;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.services.ServiceManager;
 import org.edx.mobile.task.Task;
+
+import java.io.IOException;
+
+import retrofit.RetrofitError;
 
 public abstract class LoginTask extends Task<AuthResponse>  {
 
@@ -31,12 +38,7 @@ public abstract class LoginTask extends Task<AuthResponse>  {
 
     @Override
     public AuthResponse call() throws Exception {
-        AuthResponse response;
-        try {
-            response = loginAPI.getAccessToken(username, password); }
-        catch (RetroHttpException exception) {
-            return null;
-        }
+        AuthResponse response = loginAPI.getAccessToken(username, password);
 
         // store auth token response
         Gson gson = new GsonBuilder().create();
@@ -48,9 +50,33 @@ public abstract class LoginTask extends Task<AuthResponse>  {
 
         // get profile of this user
         if (response.isSuccess()) {
-            response.profile = api.getProfile();
+            try {
+                response.profile = api.getProfile();
+            } catch (IOException e) {
+                throw new RetroHttpException(RetrofitError.networkError(null, e));
+            } catch (Exception e) {
+                /* TODO: Move the API for getting the user profile data
+                 * to Retrofit, and then post a message appropriate for
+                 * the type of error encountered during the request.
+                 */
+                throwLoginException();
+            }
+            if (!response.hasValidProfile()) {
+                throwLoginException();
+            }
 
         }
         return response;
+    }
+
+    /**
+     * Throw a generic exception about login failure.
+     *
+     * @throws LoginException The exception.
+     */
+    private void throwLoginException() throws LoginException {
+        throw new LoginException(new LoginErrorMessage(
+                context.getString(R.string.login_error),
+                context.getString(R.string.login_failed)));
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/http/HttpConnectivityException.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/HttpConnectivityException.java
@@ -2,8 +2,48 @@ package org.edx.mobile.http;
 
 import android.support.annotation.NonNull;
 
+import java.io.IOException;
+
+import retrofit.RetrofitError;
+
+/**
+ * Thrown when a Retrofit HTTP call fails due to connectivity
+ * issues. Wraps around a {@link RetrofitError} as a checked
+ * exception.
+ */
 public class HttpConnectivityException extends RetroHttpException {
-    public HttpConnectivityException(@NonNull Throwable cause) {
-        super(cause);
+    /**
+     * Validate that the original {@link RetrofitError} is a network
+     * error.
+     *
+     * @param cause The Retrofit exception to validate.
+     * @return The provided Retrofit exception if it's valid.
+     * @throws IllegalArgumentException if validation fails.
+     */
+    private static RetrofitError validate(@NonNull RetrofitError cause) {
+        if (cause.getKind() != RetrofitError.Kind.NETWORK) {
+            throw new IllegalArgumentException();
+        }
+        return cause;
+    }
+
+    /**
+     * Construct a new instance of {@link HttpConnectivityException}
+     * wrapping the provided {@link RetrofitError}.
+     *
+     * @param cause The original Retrofit network exception.
+     */
+    public HttpConnectivityException(@NonNull RetrofitError cause) {
+        super(validate(cause));
+    }
+
+    /**
+     * @return The initial {@link IOException} that
+     *         was the cause of the wrapped
+     *         {@link RetrofitError}.
+     */
+    @NonNull
+    public IOException getRealCause() {
+        return (IOException) getCause().getCause();
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/http/HttpResponseStatusException.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/HttpResponseStatusException.java
@@ -2,15 +2,42 @@ package org.edx.mobile.http;
 
 import android.support.annotation.NonNull;
 
-public class HttpResponseStatusException extends RetroHttpException {
-    private final int statusCode;
+import retrofit.RetrofitError;
 
-    public HttpResponseStatusException(@NonNull Throwable cause, int statusCode) {
-        super(cause);
-        this.statusCode = statusCode;
+/**
+ * Thrown when a Retrofit HTTP call returns an error code. Wraps
+ * around a {@link RetrofitError} as a checked exception.
+ */
+public class HttpResponseStatusException extends RetroHttpException {
+    /**
+     * Validate that the original {@link RetrofitError} is an HTTP error.
+     *
+     * @param cause The Retrofit exception to validate.
+     * @return The provided Retrofit exception if it's valid.
+     * @throws IllegalArgumentException if validation fails.
+     */
+    private static RetrofitError validate(@NonNull RetrofitError cause) {
+        if (cause.getKind() != RetrofitError.Kind.HTTP) {
+            throw new IllegalArgumentException();
+        }
+        return cause;
     }
 
+    /**
+     * Construct a new instance of {@link HttpResponseStatusException}
+     * wrapping the provided {@link RetrofitError}.
+     *
+     * @param cause The original Retrofit network exception.
+     */
+    public HttpResponseStatusException(@NonNull RetrofitError cause) {
+        super(validate(cause));
+    }
+
+    /**
+     * @return The HTTP error code that caused this
+     *         exception.
+     */
     public int getStatusCode() {
-        return statusCode;
+        return getCause().getResponse().getStatus();
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/http/OauthRefreshTokenAuthenticator.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/OauthRefreshTokenAuthenticator.java
@@ -62,13 +62,19 @@ public class OauthRefreshTokenAuthenticator implements Authenticator {
             return null;
         }
 
-        refreshAccessToken(pref);
+        try {
+            refreshAccessToken(pref);
+        } catch (HttpConnectivityException e) {
+            throw e.getRealCause();
+        } catch (RetroHttpException e) {
+            return null;
+        }
         return response.request().newBuilder()
                 .header("Authorization", pref.getCurrentAuth().token_type + " " + pref.getCurrentAuth().access_token)
                 .build();
     }
 
-    private void refreshAccessToken(@NonNull PrefManager pref) {
+    private void refreshAccessToken(@NonNull PrefManager pref) throws RetroHttpException {
         OkHttpClient client = OkHttpUtil.getClient(context);
         RestAdapter restAdapter = new RestAdapter.Builder()
                 .setClient(new Ok3Client(client))

--- a/VideoLocker/src/main/java/org/edx/mobile/http/RetroHttpException.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/RetroHttpException.java
@@ -4,8 +4,30 @@ import android.support.annotation.NonNull;
 
 import retrofit.RetrofitError;
 
+/**
+ * Checked exception wrapper around
+ * {@link RetrofitError}. Specific error types may
+ * be represented by specific subclasses with
+ * appropriate convenience methods.
+ */
 public class RetroHttpException extends Exception {
-    public RetroHttpException(@NonNull Throwable cause) {
+    /**
+     * Construct a new instance of {@link RetroHttpException}
+     * wrapping the provided {@link RetrofitError}.
+     *
+     * @param cause The original Retrofit network exception.
+     */
+    public RetroHttpException(@NonNull RetrofitError cause) {
         super(cause);
+    }
+
+    /**
+     * @return The {@link RetrofitError} that is being
+     *         wrapped by this class.
+     */
+    @Override
+    @NonNull
+    public RetrofitError getCause() {
+        return (RetrofitError) super.getCause();
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/http/RetroHttpExceptionHandler.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/RetroHttpExceptionHandler.java
@@ -20,7 +20,7 @@ public class RetroHttpExceptionHandler implements ErrorHandler {
             logger.warn("body = " + body);
             logger.warn("status and reason = " + response.getStatus() + ":" + response.getReason());
             if (RetrofitError.Kind.HTTP == cause.getKind()) {
-                return new HttpResponseStatusException(cause, response.getStatus());
+                return new HttpResponseStatusException(cause);
             }
         }
         if (RetrofitError.Kind.NETWORK == cause.getKind()) {

--- a/VideoLocker/src/main/java/org/edx/mobile/social/SocialLoginDelegate.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/social/SocialLoginDelegate.java
@@ -180,11 +180,7 @@ public class SocialLoginDelegate {
 
         @Override
         public void onSuccess(ProfileModel result) {
-            try {
-                callback.onUserLoginSuccess(result);
-            } catch (LoginException ex) {
-                super.onException(ex);
-            }
+            callback.onUserLoginSuccess(result);
         }
 
         @Override
@@ -285,7 +281,7 @@ public class SocialLoginDelegate {
     public interface MobileLoginCallback {
         void onSocialLoginSuccess(String accessToken, String backend, Task task);
         void onUserLoginFailure(Exception ex, String accessToken, String backend);
-        void onUserLoginSuccess(ProfileModel profile) throws LoginException;
+        void onUserLoginSuccess(ProfileModel profile);
         boolean showErrorMessage(String header, String message);
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -540,7 +540,7 @@ public class RegisterActivity extends BaseFragmentActivity
     /*
      *  callback if login to edx success using social access_token
      */
-    public void onUserLoginSuccess(ProfileModel profile) throws LoginException {
+    public void onUserLoginSuccess(ProfileModel profile) {
 
         PrefManager pref = new PrefManager(RegisterActivity.this, PrefManager.Pref.LOGIN);
         environment.getSegment().identifyUser(profile.id.toString(), profile.email, "");


### PR DESCRIPTION
### Description

[MA-2547](https://openedx.atlassian.net/browse/MA-2547)

The Retrofit interface for the login APIs weren't defined to throw the custom checked exception wrapper (`RetroHttpException`) that we throw from the global Retrofit error handler. As a result, upon encountering this undeclared checked exception thrown by Retrofit's invocation handler, the framework throws an unchecked `UndeclaredThrowableException` that wraps around it instead, which the caller is not prepared to catch. This has the side-effect of disabling the error handling logic for the login request. This commit fixes the issue by declaring all the method definitions in `LoginService` to throw `RetroHttpException`.

Some other refactoring has also been done as a result of this, and to clean up the login code. The details for that are in the commit messages.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @miankhalid 
- [x] Code review: @BenjiLee