### PR TITLE
MA-2569: Made app clear its activity history on logout

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/Router.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/Router.java
@@ -73,10 +73,7 @@ public class Router {
 
     public void showLaunchScreen(Context context) {
         Intent launchIntent = new Intent(context, LaunchActivity.class);
-        if (context instanceof Activity)
-            launchIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        else
-            launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         context.startActivity(launchIntent);
     }
 


### PR DESCRIPTION
### Description

[MA-2569](https://openedx.atlassian.net/browse/MA-2569)

On logout, activity history should be cleared. Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK should do the trick.

Also, there shouldn't be any case where the context is not an instance of an activity, so I removed that case.

### Testing
- [ ] Unit, integration, acceptance tests as appropriate
- Ran the given use case, made sure that issue no longer happened.
- Logged back in, opened, items from nav drawer, logged out. Made sure that app behaved as expected.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @BenjiLee 
- [x] Code review: @bguertin 
