### PR TITLE
Fix splash due to using Theme.NoDisplay with appcompat

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -137,6 +137,6 @@ public abstract class MainApplication extends MultiDexApplication {
 
     @NonNull
     public static IEdxEnvironment getEnvironment(@NonNull Context context) {
-        return RoboGuice.getInjector(context).getInstance(IEdxEnvironment.class);
+        return RoboGuice.getInjector(context.getApplicationContext()).getInstance(IEdxEnvironment.class);
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/SplashActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/SplashActivity.java
@@ -1,10 +1,13 @@
 package org.edx.mobile.view;
 
+import android.app.Activity;
 import android.os.Bundle;
 
-import org.edx.mobile.base.BaseFragmentActivity;
+import org.edx.mobile.base.MainApplication;
+import org.edx.mobile.core.IEdxEnvironment;
 
-public class SplashActivity extends BaseFragmentActivity {
+// We are extending the normal Activity class here so that we can use Theme.NoDisplay, which does not support AppCompat activities
+public class SplashActivity extends Activity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -15,6 +18,7 @@ public class SplashActivity extends BaseFragmentActivity {
             return; // This stops from opening again from the Splash screen when minimized
         }
 
+        final IEdxEnvironment environment = MainApplication.getEnvironment(this);
         if (environment.getUserPrefs().getProfile() != null) {
             environment.getRouter().showMyCourses(SplashActivity.this);
         } else {


### PR DESCRIPTION
Theme.NoDisplay is not an appcompat theme, so it crashes when used with an app compat activity.

Since we don't need any app compat features, I just changed this activity to extend normal `Activity`

## Reviewers
- [x] Code review: @BenjiLee 
