### PR TITLE
Use Git branches/tags for versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,12 @@ notifications:
   email: true
 
 before_script:
+  - git fetch --tags
+  - git fetch --unshallow || true
+  - export DESCRIBE=$(git describe)
+  - export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
+  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
+  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH, DESCRIBE=$DESCRIBE"
   - chmod +x gradlew
   # ARM architecture is used instead of x86 (which is 10x faster) of the lack of support from CI due
   # to complications of creating a virtual machine within a virtual machine. This may be solved

--- a/VideoLocker/build.gradle
+++ b/VideoLocker/build.gradle
@@ -49,6 +49,74 @@ class AndroidHelper {
         }
     }
 }
+/**
+ * Computes a semantic version string, e.g. "1.0" or "2.5.7" by parsing git branches or tags.
+ * Branch name takes priority, otherwise the last annotated tag name will be used.
+ * @return The semantic version string, or "0.0.1" if we failed to determine one.
+ */
+def getVersionName = { ->
+    def description = "0.0.1";
+    try {
+        def branch = System.getenv("BRANCH")
+        if (null == branch || branch.isEmpty()) {
+            def branchout = new ByteArrayOutputStream()
+            exec {
+                commandLine 'git', 'rev-parse', '--abbrev-ref', 'HEAD'
+                standardOutput = branchout
+            }
+            branch = branchout.toString().trim()
+        }
+
+        def hasSemanticVersion = { s ->
+            // This branch/tag contains a semantic version (e.g. "rc/2.6.0" or "release/2.5")
+            return s.indexOf("rc/") >= 0 || s.indexOf("release/") >= 0
+        }
+        if (hasSemanticVersion(branch)) {
+            description = branch;
+        } else {
+            def stdout = new ByteArrayOutputStream()
+            exec {
+                commandLine 'git', 'describe'
+                standardOutput = stdout
+            }
+            def describe = stdout.toString().trim()
+            if (hasSemanticVersion(describe)) {
+                description = describe;
+            }
+        }
+    }
+    catch (e) {
+        logger.error("Could not determine version name", e)
+    }
+    return description.substring(description.indexOf("/") + 1).split("-")[0].trim()
+}
+
+/**
+ * @return An integer representation of the string returned by getVersionName()
+ */
+def getVersionCode = { ->
+    try {
+        def versionName = getVersionName()
+        def semVer = versionName.split('\\.')
+        def vCode;
+        vCode = semVer[0].toInteger() * 1000000 // Major version
+        if (semVer.length > 1) {
+            vCode += semVer[1].toInteger() * 1000 // Minor version
+            if (semVer.length > 2) {
+                vCode += semVer[2].toInteger() * 1 // Patch version
+            }
+        }
+        return vCode
+    } catch (e) {
+        logger.error("Could not determine version code", e)
+        return 1;
+    }
+}
+
+task(version) << {
+    println String.format('%s (%s)', getVersionName(), getVersionCode())
+}
+
 
 dependencies {
     compile project (':android-iconify')
@@ -168,8 +236,8 @@ android {
         minSdkVersion 14
         targetSdkVersion 21
 
-        versionCode 90
-        versionName "2.6.0"
+        versionCode getVersionCode()
+        versionName getVersionName()
 
         renderscriptTargetApi 22
         renderscriptSupportModeEnabled true


### PR DESCRIPTION
### Description

[MA-2314](https://openedx.atlassian.net/browse/MA-2314)

The version name (and version code) will now be determined automatically by using, in this order:
- the version number in the `BRANCH` environment variable (for Travis CI)
- the version number in the git branch name
- the version number reported by `git describe`

For a branch / tag to be considered, it must start with `rc/` or `release/` prefix. E.g. `rc/2.5.0` or `release/2.6`.

The version code will be based on the semantic version, allowing 3 digits between each decimal. For example, the version `2.3.67` will result in a version code of `2003067`.

To quickly see what version would be used if you were to build right now, you can use the new gradle `version` task, for example: `BRANCH=rc/2.3.0 ./gradlew --quiet version` which will print `2.3.0 (2003000)`

### Travis CI

Travis does not expose the branch or fetch tags by default, so I updated the script to expose a `BRANCH` as an environment variable, as well as fetch the tags, so that both branch / tag based versioning will work on Travis as well.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @BenjiLee 
- [ ] Code review: @mdinino 