### PR TITLE
Move knowledge of last accessed prefs to LastAccessedPrefManager

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
@@ -155,6 +155,15 @@ public class LoginPrefs {
         }
     }
 
+    @Nullable
+    public ProfileImage getProfileImage() {
+        final String json = pref.getString(PrefManager.Key.PROFILE_IMAGE);
+        if (null == json) {
+            return null;
+        }
+        return gson.fromJson(json, ProfileImage.class);
+    }
+
     @NonNull
     private static String segmentKeyFromAuthBackend(@NonNull AuthBackend backend) {
         switch (backend) {

--- a/VideoLocker/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
@@ -2,19 +2,8 @@ package org.edx.mobile.module.prefs;
 
 import android.content.Context;
 import android.content.SharedPreferences.Editor;
-import android.support.annotation.Nullable;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
-import org.edx.mobile.authentication.AuthResponse;
 import org.edx.mobile.base.MainApplication;
-import org.edx.mobile.logger.Logger;
-import org.edx.mobile.model.api.ProfileModel;
-import org.edx.mobile.services.EdxCookieManager;
-import org.edx.mobile.user.ProfileImage;
-import org.edx.mobile.util.DateUtil;
-import org.edx.mobile.util.Sha1Util;
 
 /**
  * This is a Utility for reading and writing to shared preferences.
@@ -25,7 +14,6 @@ public class PrefManager {
 
     private Context context;
     private String prefName;
-    private static final Logger logger = new Logger(PrefManager.class.getName());
 
     //FIXME - we should use MAApplication's context to clean up
     //the code.
@@ -150,130 +138,6 @@ public class PrefManager {
         return defaultValue;
     }
 
-    /**
-     * Returns current user's profile from the preferences.
-     * @return
-     */
-    @Nullable
-    public ProfileModel getCurrentUserProfile() {
-        String json = getString(PrefManager.Key.PROFILE_JSON);
-        if (json == null) {
-            return null;
-        }
-        
-        Gson gson = new GsonBuilder().create();
-        ProfileModel res = gson.fromJson(json, ProfileModel.class);
-
-        return res;
-    }
-
-    /**
-     * @return The current user's {@link ProfileImage} from the preferences.
-     */
-    @Nullable
-    public ProfileImage getCurrentUserProfileImage() {
-        String json = getString(Key.PROFILE_IMAGE);
-        if (json == null) {
-            return null;
-        }
-
-        Gson gson = new GsonBuilder().create();
-        return gson.fromJson(json, ProfileImage.class);
-    }
-    
-    /**
-     * Returns current user's profile from the preferences.
-     * @return
-     */
-    public AuthResponse getCurrentAuth() {
-        String json = getString(PrefManager.Key.AUTH_JSON);
-        if (json == null) {
-            return null;
-        }
-
-        Gson gson = new GsonBuilder().create();
-        AuthResponse res = gson.fromJson(json, AuthResponse.class);
-        
-        return res;
-    }
-
-    /**
-     * Clears auth token info and current profile information from preferences.
-     */
-    public void clearAuth() {
-        put(PrefManager.Key.PROFILE_JSON, null);
-        put(PrefManager.Key.AUTH_JSON, null);
-        put(PrefManager.Key.AUTH_TOKEN_SOCIAL, null);
-        put(PrefManager.Key.AUTH_TOKEN_BACKEND, null);
-        put(PrefManager.Key.AUTH_TOKEN_SOCIAL_COOKIE, null);
-        //assessment webview related session_id
-        EdxCookieManager.getSharedInstance().clearWebWiewCookie(MainApplication.instance());
-    }
-
-    /**
-     *  check if app is currently logged in through Google/Facebook
-     */
-    public boolean hasAuthTokenSocialCookie(){
-        return  null !=  getString(Key.AUTH_TOKEN_SOCIAL_COOKIE);
-    }
-    
-    /**
-     * Stores information of last accesses subsection for given id.
-     * Modification date is also stored for current time.
-     * Synced is marked as FALSE.
-     *
-     * @param subsectionId
-     * @param lastAccessedFlag
-     */
-    public void putLastAccessedSubsection(String subsectionId, boolean lastAccessedFlag) {
-        Editor edit = context.getSharedPreferences(prefName, Context.MODE_PRIVATE).edit();
-        edit.putString(PrefManager.Key.LASTACCESSED_MODULE_ID, subsectionId);
-        edit.putString(PrefManager.Key.LAST_ACCESS_MODIFICATION_TIME, DateUtil.getCurrentTimeStamp());
-        edit.putBoolean(PrefManager.Key.LASTACCESSED_SYNCED_FLAG, lastAccessedFlag);
-        edit.commit();
-    }
-
-    /**
-     * Returns true if given courseId's last access is synced with server, false otherwise.
-     *
-     * @return
-     */
-    public boolean isSyncedLastAccessedSubsection() {
-        return context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
-                .getBoolean(PrefManager.Key.LASTACCESSED_SYNCED_FLAG, true);
-    }
-
-
-    /**
-     * Returns last accessed subsection id for the given course.
-     *
-     * @return
-     */
-    public String getLastAccessedSubsectionId() {
-        return context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
-                .getString(PrefManager.Key.LASTACCESSED_MODULE_ID, null);
-    }
-
-    /**
-     * Returns preference file name that can be used to store information about last accessed subsection.
-     * This preference file name is SHA1 hash of a combination of username, courseId and a constant suffix.
-     *
-     * @param username
-     * @param courseId
-     * @return
-     * @throws Exception
-     */
-    public static String getPrefNameForLastAccessedBy(String username, String courseId) {
-        String raw = username + "-" + courseId + "-last-accessed-subsection_info";
-        try {
-            String hash = Sha1Util.SHA1(raw);
-            return hash;
-        } catch (Exception ex) {
-            logger.error(ex);
-        }
-        return raw;
-    }
-
     public static class AppInfoPrefManager extends PrefManager {
         public AppInfoPrefManager(Context context) {
             super(context, PrefManager.Pref.APP_INFO);
@@ -379,9 +243,6 @@ public class PrefManager {
         public static final String DOWNLOAD_ONLY_ON_WIFI = "download_only_on_wifi";
         public static final String DOWNLOAD_OFF_WIFI_SHOW_DIALOG_FLAG = "download_off_wifi_dialog_flag";
         public static final String TRANSCRIPT_LANGUAGE = "transcript_language";
-        public static final String LAST_ACCESS_MODIFICATION_TIME = "last_access_modification_time";
-        public static final String LASTACCESSED_MODULE_ID = "last_access_module_id";
-        public static final String LASTACCESSED_SYNCED_FLAG = "lastaccess_synced_flag";
         public static final String SEGMENT_KEY_BACKEND = "segment_backend";
         public static final String SPEED_TEST_KBPS = "speed_test_kbps";
         public static final String APP_VERSION_NAME = "app_version_name";

--- a/VideoLocker/src/main/java/org/edx/mobile/module/prefs/UserPrefs.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/module/prefs/UserPrefs.java
@@ -6,6 +6,8 @@ import android.os.Environment;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -33,6 +35,7 @@ public class UserPrefs {
 
     /**
      * Returns true if the "download over wifi only" is turned ON, false otherwise.
+     *
      * @return
      */
     public boolean isDownloadOverWifiOnly() {
@@ -43,15 +46,16 @@ public class UserPrefs {
                 PrefManager.Key.DOWNLOAD_ONLY_ON_WIFI, true);
         return onlyWifi;
     }
-    
+
     /**
      * Returns user storage directory under /Android/data/ folder for the currently logged in user.
      * This is the folder where all video downloads should be kept.
+     *
      * @return
      */
     public File getDownloadFolder() {
         ProfileModel profile = getProfile();
-        
+
         File android = new File(Environment.getExternalStorageDirectory(), "Android");
         File downloadsDir = new File(android, "data");
         File packDir = new File(downloadsDir, context.getPackageName());
@@ -60,21 +64,15 @@ public class UserPrefs {
         try {
             File noMediaFile = new File(edxDir, ".nomedia");
             noMediaFile.createNewFile();
-        }catch (IOException ioException){
+        } catch (IOException ioException) {
             logger.error(ioException);
         }
-        
+
         return edxDir;
     }
 
     @Nullable
     public ProfileModel getProfile() {
         return loginPrefs.getCurrentUserProfile();
-    }
-
-    @Nullable
-    public ProfileImage getProfileImage() {
-        PrefManager pm = new PrefManager(context, PrefManager.Pref.LOGIN);
-        return pm.getCurrentUserProfileImage();
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/services/LastAccessManager.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/services/LastAccessManager.java
@@ -1,5 +1,7 @@
 package org.edx.mobile.services;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
 import android.view.View;
 
@@ -7,9 +9,10 @@ import org.edx.mobile.base.MainApplication;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.api.SyncLastAccessedSubsectionResponse;
 import org.edx.mobile.module.prefs.LoginPrefs;
-import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.task.GetLastAccessedTask;
 import org.edx.mobile.task.SyncLastAccessedTask;
+import org.edx.mobile.util.DateUtil;
+import org.edx.mobile.util.Sha1Util;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -17,9 +20,11 @@ import javax.inject.Singleton;
 @Singleton
 public class LastAccessManager {
 
-    public static interface LastAccessManagerCallback{
+    public interface LastAccessManagerCallback {
         boolean isFetchingLastAccessed();
+
         void setFetchingLastAccessed(boolean accessed);
+
         void showLastAccessedView(String lastAccessedSubSectionId, String courseId, View view);
     }
 
@@ -37,96 +42,163 @@ public class LastAccessManager {
         fetchLastAccessed(callback, null, courseId);
     }
 
-    public void fetchLastAccessed(final LastAccessManagerCallback callback, final View view, final String courseId){
-        try{
-            if(!callback.isFetchingLastAccessed()) {
+    public void fetchLastAccessed(final LastAccessManagerCallback callback, final View view, final String courseId) {
+        try {
+            if (!callback.isFetchingLastAccessed()) {
                 final String username = loginPrefs.getUsername();
-                if(courseId!=null && username!=null){
-                    String prefName = PrefManager.getPrefNameForLastAccessedBy(username, courseId);
-                    final PrefManager prefManager = new PrefManager(MainApplication.instance(), prefName);
+                if (courseId != null && username != null) {
+                    final LastAccessedPrefManager prefManager = new LastAccessedPrefManager(MainApplication.instance(), username, courseId);
                     final String prefModuleId = prefManager.getLastAccessedSubsectionId();
 
                     logger.debug("Last Accessed Module ID from Preferences "
-                        +prefModuleId);
+                            + prefModuleId);
 
                     callback.showLastAccessedView(prefModuleId, courseId, view);
-                    GetLastAccessedTask getLastAccessedTask = new GetLastAccessedTask(MainApplication.instance(),courseId) {
+                    GetLastAccessedTask getLastAccessedTask = new GetLastAccessedTask(MainApplication.instance(), courseId) {
                         @Override
                         public void onSuccess(SyncLastAccessedSubsectionResponse result) {
                             syncWithServerOnSuccess(result, prefModuleId, prefManager, courseId, callback, view);
                         }
+
                         @Override
                         public void onException(Exception ex) {
                             super.onException(ex);
-                            callback.setFetchingLastAccessed( false );
+                            callback.setFetchingLastAccessed(false);
                         }
                     };
 
-                    callback.setFetchingLastAccessed( true );
-                    getLastAccessedTask.execute( );
+                    callback.setFetchingLastAccessed(true);
+                    getLastAccessedTask.execute();
                 }
             }
-        }catch(Exception e){
+        } catch (Exception e) {
             logger.error(e);
         }
     }
 
     private void syncWithServerOnSuccess(SyncLastAccessedSubsectionResponse result,
                                          String prefModuleId,
-                                         PrefManager prefManager,
+                                         LastAccessedPrefManager prefManager,
                                          String courseId,
                                          LastAccessManagerCallback callback,
                                          View view
-                                         ){
-        String server_moduleId = null;
-        if(result!=null && result.getLastVisitedModuleId()!=null){
+    ) {
+        String server_moduleId;
+        if (result != null && result.getLastVisitedModuleId() != null) {
             //Handle the last Visited Module received from Sever
             server_moduleId = result.getLastVisitedModuleId();
             logger.debug("Last Accessed Module ID from Server Get "
-                +server_moduleId);
-            if(prefManager.isSyncedLastAccessedSubsection()){
+                    + server_moduleId);
+            if (prefManager.isSyncedLastAccessedSubsection()) {
                 //If preference last accessed flag is true, put the last access fetched
-                //from server in Prefernces and display it on Last Accessed.
+                //from server in Preferences and display it on Last Accessed.
                 prefManager.putLastAccessedSubsection(server_moduleId, true);
                 callback.showLastAccessedView(server_moduleId, courseId, view);
-            }else{
-                //Preference's last accessed is not synched with server,
+            } else {
+                //Preference's last accessed is not synced with server,
                 //Sync with server and display the result from server on UI.
-                if(prefModuleId!=null && prefModuleId.length()>0){
+                if (prefModuleId != null && prefModuleId.length() > 0) {
                     syncLastAccessedWithServer(prefManager, view, prefModuleId, courseId, callback);
                 }
             }
-        }else{
+        } else {
             //There is no Last Accessed module on the server
-            if(prefModuleId!=null && prefModuleId.length()>0){
+            if (prefModuleId != null && prefModuleId.length() > 0) {
                 syncLastAccessedWithServer(prefManager, view, prefModuleId, courseId, callback);
             }
         }
-        callback.setFetchingLastAccessed( false );
+        callback.setFetchingLastAccessed(false);
     }
 
 
-    private void syncLastAccessedWithServer(final PrefManager prefManager,
+    private void syncLastAccessedWithServer(final LastAccessedPrefManager prefManager,
                                             final View view,
                                             String prefModuleId,
                                             final String courseId,
-                                            final LastAccessManagerCallback callback){
-        try{
+                                            final LastAccessManagerCallback callback) {
+        try {
             SyncLastAccessedTask syncLastAccessTask = new SyncLastAccessedTask(
-                MainApplication.instance(),courseId, prefModuleId) {
+                    MainApplication.instance(), courseId, prefModuleId) {
                 @Override
                 public void onSuccess(SyncLastAccessedSubsectionResponse result) {
-                    if(result!=null && result.getLastVisitedModuleId()!=null){
+                    if (result != null && result.getLastVisitedModuleId() != null) {
                         prefManager.putLastAccessedSubsection(result.getLastVisitedModuleId(), true);
                         logger.debug("Last Accessed Module ID from Server Sync "
-                            +result.getLastVisitedModuleId());
-                         callback.showLastAccessedView(result.getLastVisitedModuleId(), courseId, view);
+                                + result.getLastVisitedModuleId());
+                        callback.showLastAccessedView(result.getLastVisitedModuleId(), courseId, view);
                     }
                 }
             };
-            syncLastAccessTask.execute( );
-        }catch(Exception e){
+            syncLastAccessTask.execute();
+        } catch (Exception e) {
             logger.error(e);
+        }
+    }
+
+    public void setLastAccessed(@NonNull String courseId, @NonNull String subsectionId) {
+        new LastAccessedPrefManager(MainApplication.instance(), loginPrefs.getUsername(), courseId)
+                .putLastAccessedSubsection(subsectionId, false);
+    }
+
+    private static class LastAccessedPrefManager {
+
+        // Preference keys
+        private static final String LAST_ACCESS_MODIFICATION_TIME = "last_access_modification_time";
+        private static final String LAST_ACCESSED_MODULE_ID = "last_access_module_id";
+        private static final String LAST_ACCESSED_SYNCED_FLAG = "lastaccess_synced_flag";
+
+        @NonNull
+        private final Context context;
+
+        @NonNull
+        private final String prefName;
+
+        public LastAccessedPrefManager(@NonNull Context context, @NonNull String username, @NonNull String courseId) {
+            this.context = context;
+            this.prefName = getPrefNameForLastAccessedBy(username, courseId);
+        }
+
+        /**
+         * Stores information of last accesses subsection for given id.
+         * Modification date is also stored for current time.
+         * Synced is marked as FALSE.
+         */
+        public void putLastAccessedSubsection(String subsectionId, boolean lastAccessedFlag) {
+            SharedPreferences.Editor edit = context.getSharedPreferences(prefName, Context.MODE_PRIVATE).edit();
+            edit.putString(LAST_ACCESSED_MODULE_ID, subsectionId);
+            edit.putString(LAST_ACCESS_MODIFICATION_TIME, DateUtil.getCurrentTimeStamp());
+            edit.putBoolean(LAST_ACCESSED_SYNCED_FLAG, lastAccessedFlag);
+            edit.commit();
+        }
+
+        /**
+         * @return true if given courseId's last access is synced with server, false otherwise.
+         */
+        public boolean isSyncedLastAccessedSubsection() {
+            return context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
+                    .getBoolean(LAST_ACCESSED_SYNCED_FLAG, true);
+        }
+
+
+        /**
+         * @return last accessed subsection id for the given course.
+         */
+        public String getLastAccessedSubsectionId() {
+            return context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
+                    .getString(LAST_ACCESSED_MODULE_ID, null);
+        }
+    }
+
+
+    /**
+     * @return preference file name that can be used to store information about last accessed subsection.
+     * This preference file name is SHA1 hash of a combination of username, courseId and a constant suffix.
+     */
+    private static String getPrefNameForLastAccessedBy(@NonNull String username, @NonNull String courseId) {
+        try {
+            return Sha1Util.SHA1(username + "-" + courseId + "-last-accessed-subsection_info");
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
         }
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseOutlineActivity.java
@@ -4,11 +4,8 @@ import android.os.Bundle;
 import android.support.v4.app.FragmentTransaction;
 
 import org.edx.mobile.R;
-import org.edx.mobile.base.MainApplication;
 import org.edx.mobile.model.course.CourseComponent;
 import org.edx.mobile.module.analytics.ISegment;
-import org.edx.mobile.module.prefs.LoginPrefs;
-import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.services.CourseManager;
 import org.edx.mobile.services.LastAccessManager;
 
@@ -24,9 +21,6 @@ public class CourseOutlineActivity extends CourseVideoListActivity {
 
     @Inject
     CourseManager courseManager;
-
-    @Inject
-    LoginPrefs loginPrefs;
 
     @Inject
     LastAccessManager lastAccessManager;
@@ -82,10 +76,7 @@ public class CourseOutlineActivity extends CourseVideoListActivity {
                     ISegment.Screens.SECTION_OUTLINE, courseData.getCourse().getId(), courseComponent.getInternalName());
 
             // Update the last accessed item reference if we are in the course subsection view
-            String prefName = PrefManager.getPrefNameForLastAccessedBy(
-                    loginPrefs.getUsername(), courseComponent.getCourseId());
-            final PrefManager prefManager = new PrefManager(MainApplication.instance(), prefName);
-            prefManager.putLastAccessedSubsection(courseComponent.getId(), false);
+            lastAccessManager.setLastAccessed(courseComponent.getCourseId(), courseComponent.getId());
         }
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -19,8 +19,8 @@ import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.course.BlockType;
 import org.edx.mobile.model.course.CourseComponent;
 import org.edx.mobile.module.analytics.ISegment;
-import org.edx.mobile.module.prefs.LoginPrefs;
 import org.edx.mobile.module.prefs.PrefManager;
+import org.edx.mobile.services.LastAccessManager;
 import org.edx.mobile.services.ViewPagerDownloadManager;
 import org.edx.mobile.view.adapters.CourseUnitPagerAdapter;
 import org.edx.mobile.view.common.PageViewStateCallback;
@@ -58,18 +58,18 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements 
     private TextView mPreviousUnitLbl;
 
     @Inject
-    LoginPrefs loginPrefs;
+    LastAccessManager lastAccessManager;
 
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        RelativeLayout insertPoint = (RelativeLayout)findViewById(R.id.fragment_container);
+        RelativeLayout insertPoint = (RelativeLayout) findViewById(R.id.fragment_container);
         LayoutInflater inflater = (LayoutInflater) getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
         View v = inflater.inflate(R.layout.view_course_unit_pager, null);
         insertPoint.addView(v, 0,
-            new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+                new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
 
-        pager = (DisableableViewPager)findViewById(R.id.pager);
+        pager = (DisableableViewPager) findViewById(R.id.pager);
         pagerAdapter = new CourseUnitPagerAdapter(getSupportFragmentManager(),
                 environment.getConfig(), unitList, courseData, this);
         pager.setAdapter(pagerAdapter);
@@ -153,17 +153,17 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements 
     }
 
     @Override
-    protected  String getUrlForWebView(){
-        if ( selectedUnit == null ){
+    protected String getUrlForWebView() {
+        if (selectedUnit == null) {
             return ""; //wont happen
         } else {
             return selectedUnit.getWebUrl();
         }
     }
 
-    private void setCurrentUnit(CourseComponent component){
+    private void setCurrentUnit(CourseComponent component) {
         this.selectedUnit = component;
-        if ( this.selectedUnit == null  )
+        if (this.selectedUnit == null)
             return;
 
         courseComponentId = selectedUnit.getId();
@@ -171,10 +171,8 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements 
 
         updateUIForOrientation();
 
-        String prefName = PrefManager.getPrefNameForLastAccessedBy(
-                loginPrefs.getUsername(), selectedUnit.getCourseId());
-        final PrefManager prefManager = new PrefManager(MainApplication.instance(), prefName);
-        prefManager.putLastAccessedSubsection(this.selectedUnit.getId(), false);
+        lastAccessManager.setLastAccessed(selectedUnit.getCourseId(), this.selectedUnit.getId());
+
         Intent resultData = new Intent();
         resultData.putExtra(Router.EXTRA_COURSE_COMPONENT_ID, courseComponentId);
         setResult(RESULT_OK, resultData);
@@ -184,7 +182,7 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements 
         environment.getSegment().trackCourseComponentViewed(selectedUnit.getId(), courseData.getCourse().getId());
     }
 
-    private void tryToUpdateForEndOfSequential(){
+    private void tryToUpdateForEndOfSequential() {
         int curIndex = pager.getCurrentItem();
         setCurrentUnit(pagerAdapter.getUnit(curIndex));
 
@@ -200,13 +198,11 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements 
             String nextUnitSubsectionId = unitList.get(curIndex + 1).getParent().getId();
             if (currentSubsectionId.equalsIgnoreCase(nextUnitSubsectionId)) {
                 mNextUnitLbl.setVisibility(View.GONE);
-            }
-            else {
+            } else {
                 mNextUnitLbl.setText(unitList.get(curIndex + 1).getParent().getDisplayName());
                 mNextUnitLbl.setVisibility(View.VISIBLE);
             }
-        }
-        else {
+        } else {
             // we have reached the end and next button is disabled
             mNextUnitLbl.setVisibility(View.GONE);
         }
@@ -215,51 +211,49 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements 
             String prevUnitSubsectionId = unitList.get(curIndex - 1).getParent().getId();
             if (currentSubsectionId.equalsIgnoreCase(prevUnitSubsectionId)) {
                 mPreviousUnitLbl.setVisibility(View.GONE);
-            }
-            else {
+            } else {
                 mPreviousUnitLbl.setText(unitList.get(curIndex - 1).getParent().getDisplayName());
                 mPreviousUnitLbl.setVisibility(View.VISIBLE);
             }
-        }
-        else {
+        } else {
             // we have reached the start and previous button is disabled
             mPreviousUnitLbl.setVisibility(View.GONE);
         }
     }
 
-    private void updateDataModel(){
+    private void updateDataModel() {
         unitList.clear();
-        if( selectedUnit == null || selectedUnit.getRoot() == null ) {
+        if (selectedUnit == null || selectedUnit.getRoot() == null) {
             logger.warn("selectedUnit is null?");
             return;   //should not happen
         }
 
         //if we want to navigate through all unit of within the parent node,
         //we should use courseComponent instead.   Requirement maybe changed?
-       // unitList.addAll( courseComponent.getChildLeafs() );
+        // unitList.addAll( courseComponent.getChildLeafs() );
         List<CourseComponent> leaves = new ArrayList<>();
 
         PrefManager.UserPrefManager userPrefManager = new PrefManager.UserPrefManager(MainApplication.instance());
-        EnumSet<BlockType> types =  userPrefManager.isUserPrefVideoModel() ?
-                             EnumSet.of(BlockType.VIDEO) : EnumSet.allOf(BlockType.class);
+        EnumSet<BlockType> types = userPrefManager.isUserPrefVideoModel() ?
+                EnumSet.of(BlockType.VIDEO) : EnumSet.allOf(BlockType.class);
         selectedUnit.getRoot().fetchAllLeafComponents(leaves, types);
-        unitList.addAll( leaves );
+        unitList.addAll(leaves);
         pagerAdapter.notifyDataSetChanged();
 
         ViewPagerDownloadManager.instance.setMainComponent(selectedUnit, unitList);
 
         int index = unitList.indexOf(selectedUnit);
-        if ( index >= 0 ){
-            pager.setCurrentItem( index );
+        if (index >= 0) {
+            pager.setCurrentItem(index);
             tryToUpdateForEndOfSequential();
         }
 
-        if ( pagerAdapter  != null )
+        if (pagerAdapter != null)
             pagerAdapter.notifyDataSetChanged();
 
     }
 
-    protected void modeChanged(){
+    protected void modeChanged() {
         onBackPressed();
     }
 
@@ -270,7 +264,7 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements 
         environment.getSegment().trackCourseComponentViewed(selectedUnit.getId(), courseData.getCourse().getId());
     }
 
-    private void updateUIForOrientation(){
+    private void updateUIForOrientation() {
         if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE && CourseUnitPagerAdapter.isCourseUnitVideo(selectedUnit)) {
             getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
             setActionBarVisible(false);
@@ -287,13 +281,17 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements 
         return selectedUnit;
     }
 
-    protected void hideLastAccessedView(View v) { }
+    protected void hideLastAccessedView(View v) {
+    }
 
-    protected void showLastAccessedView(View v, String title, View.OnClickListener listener) {}
+    protected void showLastAccessedView(View v, String title, View.OnClickListener listener) {
+    }
 
     @Override
-    protected void onOnline() {}
+    protected void onOnline() {
+    }
 
     @Override
-    protected void onOffline() {}
+    protected void onOffline() {
+    }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/view_holders/AuthorLayoutViewHolder.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/view_holders/AuthorLayoutViewHolder.java
@@ -17,7 +17,7 @@ import org.edx.mobile.R;
 import org.edx.mobile.discussion.DiscussionTextUtils;
 import org.edx.mobile.discussion.IAuthorData;
 import org.edx.mobile.model.api.ProfileModel;
-import org.edx.mobile.module.prefs.UserPrefs;
+import org.edx.mobile.module.prefs.LoginPrefs;
 import org.edx.mobile.user.ProfileImage;
 import org.edx.mobile.user.ProfileImageProvider;
 import org.edx.mobile.util.Config;
@@ -26,7 +26,7 @@ import roboguice.RoboGuice;
 
 public class AuthorLayoutViewHolder {
     @Inject
-    private UserPrefs userPrefs;
+    private LoginPrefs loginPrefs;
 
     public final ViewGroup profileRow;
     public final ImageView profileImageView;
@@ -65,12 +65,12 @@ public class AuthorLayoutViewHolder {
                  * Background: Currently the POST & PATCH APIs aren't configured to return a user's
                  * {@link ProfileImage} in their response. Since, the currently logged-in user is
                  * the only one that can POST using the app, so, we use the locally stored
-                 * {@link ProfileImage} in {@link UserPrefs} instead.
+                 * {@link ProfileImage} in {@link LoginPrefs} instead.
                  * Incase of PATCH we just use the image that we got in the initial GET call.
                  */
-                ProfileModel profileModel = userPrefs.getProfile();
+                ProfileModel profileModel = loginPrefs.getCurrentUserProfile();
                 if (profileModel != null && authorData.getAuthor().equals(profileModel.username)) {
-                    profileImage = userPrefs.getProfileImage();
+                    profileImage = loginPrefs.getProfileImage();
                 } else {
                     profileImage = null;
                 }


### PR DESCRIPTION
Refactoring only.

I moved all knowledge of "last accessed" preferences into a private class inside `LastAccessManager`, cleaning up all the places that were setting the last accessed preference, as well as removing unnecessary methods from `PrefManager`.

I also moved the `getProfileImage` method into `LoginPrefs`, beside the existing `setProfileImage` method.

I also auto-formatted these files, ignore whitespace: https://github.com/edx/edx-app-android/pull/775/files?w=1

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @BenjiLee 
- [x] Code review: @mdinino 