### PR TITLE
Showing no handouts message if the result html is empty

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseHandoutFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseHandoutFragment.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
+import android.text.Html;
 import android.text.TextUtils;
 import android.util.Xml.Encoding;
 import android.view.LayoutInflater;
@@ -95,7 +96,9 @@ public class CourseHandoutFragment extends BaseFragment {
                     return;
                 }
 
-                if (result != null && (!TextUtils.isEmpty(result.handouts_html))) {
+                if (result != null
+                        && (!TextUtils.isEmpty(result.handouts_html))
+                        && (!TextUtils.isEmpty(Html.fromHtml(result.handouts_html).toString()))) {
                     populateHandouts(result);
                 } else {
                     CourseHandoutFragment.this.showErrorMessage(R.string.no_handouts_to_display,


### PR DESCRIPTION
### Description

This is fixes a problem that if the instructor opens the handouts section in studio and closes it, the text editor will automatically generate an empty HTML list `<ol></ol>` for the handouts, and this is unremovable even if we try to remove it. In the mobile app, if a learner tries to to open *Handouts* section in the *course dashboard*, an empty page will be shown since the resulted response will be as follows:

`D/org.edx.mobile.http.Api: handout={"handouts_html":"<ol></ol>"}`

what app shows is:

<img src ="https://cloud.githubusercontent.com/assets/11036472/17130013/144e6768-531f-11e6-8418-6c54247f6fe1.png" height="600" />

The expected message to show: 

<img src ="https://cloud.githubusercontent.com/assets/11036472/17130021/1bd7effe-531f-11e6-88b8-3ad140931aa7.png" height="600" />
### Notes
Clicking *Edit* button in course handouts in *Studio* for the first time will generate this:

![screen shot 2016-07-26 at 10 45 24 am](https://cloud.githubusercontent.com/assets/11036472/17130026/209381fc-531f-11e6-9c81-a9a56e270db2.png)
