### PR TITLE
respect disabled social signups in registration layout

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/social/SocialFactory.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/social/SocialFactory.java
@@ -63,8 +63,11 @@ public class SocialFactory {
             return config.getGoogleConfig().isEnabled();
         } else if (type == SOCIAL_SOURCE_TYPE.TYPE_FACEBOOK) {
             return config.getFacebookConfig().isEnabled();
+        } else if (type == SOCIAL_SOURCE_TYPE.TYPE_UNKNOWN) {
+            return config.getGoogleConfig().isEnabled()
+                    || config.getFacebookConfig().isEnabled();
         }
-        return true;
+        return false;
     }
 
 }


### PR DESCRIPTION
### Description

[OSPR-1367](https://openedx.atlassian.net/browse/OSPR-1367)

Social signups (Facebook and Google) are disabled by default config, but the panel is still displayed by registration activity. RegisterActivity checks against SOCIAL_SOURCE_TYPE.TYPE_UNKNOWN but the SocialFactory did not validate against this option and returned true for isSocialFeatureEnabled. Fixed this to return false by default (neither Google nor Facebook enabled) and to check properly for an enabled provider when TYPE_UNKNOWN is passed to the isSocialFeatureEnabled function. Social signup panel is therefore hidden by default (will not display empty when neither provider is enabled).

### Notes

Didn't add any tests as this is simply a (bug) fix to an existing function and all tests still run as expected with default config. 
