### PR TITLE
Clean up brand colors in colors.xml

### DIFF
--- a/VideoLocker/res/drawable/custom_progress_bar_horizontal_error.xml
+++ b/VideoLocker/res/drawable/custom_progress_bar_horizontal_error.xml
@@ -32,8 +32,8 @@
 
                 <gradient
                     android:angle="0"
-                    android:endColor="@color/progress_wheel_color"
-                    android:startColor="@color/progress_wheel_color" 
+                    android:endColor="@color/edx_error_accent"
+                    android:startColor="@color/edx_error_accent"
                     />
             </shape>
         </clip>

--- a/VideoLocker/res/drawable/custom_progress_bar_horizontal_success.xml
+++ b/VideoLocker/res/drawable/custom_progress_bar_horizontal_success.xml
@@ -32,8 +32,8 @@
 
                 <gradient
                     android:angle="0"
-                    android:endColor="@color/red_download_failed_text"
-                    android:startColor="@color/red_download_failed_text" 
+                    android:endColor="@color/edx_success_accent"
+                    android:startColor="@color/edx_success_accent"
                     />
             </shape>
         </clip>

--- a/VideoLocker/res/drawable/delete_btn_selector.xml
+++ b/VideoLocker/res/drawable/delete_btn_selector.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_pressed="true" android:drawable="@color/cyan_text_navigation"  />
-    <item android:state_enabled="false" android:drawable="@color/delete_btn_disabled"  />
-    <item android:state_enabled="true" android:drawable="@color/delete_panel_bg"  />
-</selector>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <selector>
+            <item
+                android:drawable="@color/delete_btn_disabled"
+                android:state_enabled="false" />
+            <item
+                android:drawable="@color/delete_panel_bg"
+                android:state_enabled="true" />
+        </selector>
+    </item>
+    <item android:drawable="@drawable/light_selectable_box_overlay" />
+</layer-list>

--- a/VideoLocker/res/drawable/edx_enroll_button.xml
+++ b/VideoLocker/res/drawable/edx_enroll_button.xml
@@ -2,7 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="@color/edx_utility_success" />
+            <solid android:color="@color/edx_success_accent" />
             <corners android:radius="@dimen/edx_box_radius" />
         </shape>
     </item>

--- a/VideoLocker/res/layout/activity_login.xml
+++ b/VideoLocker/res/layout/activity_login.xml
@@ -82,7 +82,7 @@
                             android:layout_marginTop="8dp"
                             android:gravity="center"
                             android:text="@string/forgot_password"
-                            android:textColor="@color/cyan_text_navigation"
+                            android:textColor="@color/text_navigation"
                             android:textSize="12sp" />
 
                         <FrameLayout
@@ -129,7 +129,7 @@
                             android:layout_height="wrap_content"
                             android:gravity="center"
                             android:linksClickable="true"
-                            android:textColor="@color/cyan_text_navigation"
+                            android:textColor="@color/text_navigation"
                             android:textSize="11sp"
                             tools:text="@string/licensing_agreement" />
 

--- a/VideoLocker/res/layout/activity_register.xml
+++ b/VideoLocker/res/layout/activity_register.xml
@@ -160,7 +160,7 @@
                 android:gravity="center"
                 android:linksClickable="true"
                 android:text="@string/licensing_agreement"
-                android:textColor="@color/cyan_text_navigation"
+                android:textColor="@color/text_navigation"
                 android:textSize="11sp"
                 android:layout_marginTop="2dp"
                 android:visibility="gone"/>

--- a/VideoLocker/res/layout/dialog_wifi_confirm.xml
+++ b/VideoLocker/res/layout/dialog_wifi_confirm.xml
@@ -55,7 +55,7 @@
         android:layout_marginBottom="5dp"
         android:gravity="center"
         android:text="@string/error_invalid_email"
-        android:textColor="@color/red_error_text"
+        android:textColor="@color/edx_error_text"
         android:textSize="16sp"
         android:visibility="gone" />
 

--- a/VideoLocker/res/layout/fragment_dialog.xml
+++ b/VideoLocker/res/layout/fragment_dialog.xml
@@ -67,7 +67,7 @@
         android:gravity="center"
         android:padding="5dp"
         android:text="@string/error_invalid_email"
-        android:textColor="@color/red_error_text"
+        android:textColor="@color/edx_error_text"
         android:textSize="14sp"
         android:visibility="gone" />
 

--- a/VideoLocker/res/layout/panel_error_message_with_title.xml
+++ b/VideoLocker/res/layout/panel_error_message_with_title.xml
@@ -25,6 +25,6 @@
         android:layout_height="wrap_content"
         android:gravity="center"
         android:text="@string/error_message"
-        android:textColor="@color/red_error_text"
+        android:textColor="@color/edx_error_text"
         android:textSize="16sp" />
 </LinearLayout>

--- a/VideoLocker/res/layout/panel_find_course.xml
+++ b/VideoLocker/res/layout/panel_find_course.xml
@@ -54,7 +54,7 @@
             android:gravity="center"
             android:linksClickable="true"
             android:text="@string/course_not_listed_text"
-            android:textColor="@color/cyan_text_navigation"
+            android:textColor="@color/text_navigation"
             android:textSize="14sp"
             android:contentDescription="@string/course_not_listed_btn" />
         

--- a/VideoLocker/res/layout/panel_video_only_on_web.xml
+++ b/VideoLocker/res/layout/panel_video_only_on_web.xml
@@ -20,14 +20,14 @@
         android:padding="@dimen/edx_margin"
         android:text="@string/video_only_on_web_label"
         android:textAllCaps="true"
-        android:textColor="@color/cyan_text_navigation"
+        android:textColor="@color/text_navigation"
         android:textSize="14sp"
         tools:targetApi="17" />
 
     <org.edx.mobile.view.custom.IconImageViewXml
         android:layout_width="@dimen/fa_x_large"
         android:layout_height="@dimen/fa_x_large"
-        app:iconColor="@color/cyan_text_navigation"
+        app:iconColor="@color/text_navigation"
         app:iconName="fa-share-square-o" />
 
 </LinearLayout>

--- a/VideoLocker/res/layout/row_course_list.xml
+++ b/VideoLocker/res/layout/row_course_list.xml
@@ -56,7 +56,6 @@
 
                 <TextView
                     android:id="@+id/new_course_content"
-                    style="@style/bold_cyan_text"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"
@@ -68,6 +67,7 @@
                     android:text="@string/new_course_content"
                     android:textAllCaps="true"
                     android:textSize="@dimen/edx_xxx_small"
+                    android:textColor="@color/edx_brand_primary_accent"
                     tools:targetApi="17" />
             </LinearLayout>
 

--- a/VideoLocker/res/layout/row_discussion_user_profile.xml
+++ b/VideoLocker/res/layout/row_discussion_user_profile.xml
@@ -47,7 +47,7 @@
             android:layout_height="wrap_content"
             android:drawablePadding="@dimen/discussion_endorsed_response_icon_padding"
             android:text="@string/discussion_responses_answer"
-            android:textColor="@color/edx_utility_success"
+            android:textColor="@color/edx_success_accent"
             android:textSize="@dimen/edx_x_small"
             android:visibility="gone"
             tools:showIn="@layout/row_discussion_responses_response"

--- a/VideoLocker/res/layout/row_download_list.xml
+++ b/VideoLocker/res/layout/row_download_list.xml
@@ -104,7 +104,7 @@
         android:layout_marginLeft="18dp"
         android:layout_marginStart="18dp"
         android:text="@string/download_failed_text"
-        android:textColor="@color/red_download_failed_text"
+        android:textColor="@color/edx_error_text"
         android:textSize="12sp"
         tools:targetApi="17" />
 

--- a/VideoLocker/res/layout/view_progress_wheel.xml
+++ b/VideoLocker/res/layout/view_progress_wheel.xml
@@ -7,7 +7,7 @@
         android:layout_width="@dimen/fa_xxxx_large"
         android:layout_height="@dimen/fa_xxxx_large"
         android:layout_gravity="center"
-        ProgressWheel:barColor="@color/progress_wheel_color"
+        ProgressWheel:barColor="@color/edx_success_accent"
         ProgressWheel:barWidth="5dp"
         ProgressWheel:contourColor="@android:color/transparent"
         ProgressWheel:progressBarLength="70dp"

--- a/VideoLocker/res/layout/view_register_agreement.xml
+++ b/VideoLocker/res/layout/view_register_agreement.xml
@@ -13,8 +13,8 @@
         style="@style/edit_text_style"
         android:background="@color/white"
         android:textColorHint="@color/hint_grey_text"
-        android:textColorLink="@color/cyan_text_navigation"
-        android:textColor="@color/cyan_text_navigation"
+        android:textColorLink="@color/text_navigation"
+        android:textColor="@color/text_navigation"
         android:clickable="true"
         tools:hint="sample email link: email@domain.org"/>
 

--- a/VideoLocker/res/values/colors.xml
+++ b/VideoLocker/res/values/colors.xml
@@ -50,18 +50,15 @@
     <color name="grey_nav_pressed_background">#888889</color>
     <color name="grey_video_size_text">#9EA7B3</color>
     <color name="grey_text_mycourse">#454951</color>
-    <color name="red_error_text">#F47676</color>
     <color name="red_offline_bar">#BA2E6E</color>
     <color name="grey_act_background">#E2E3E5</color>
+    <color name="text_navigation">@color/edx_brand_primary_base</color>
     <color name="grey_text_tab">#898B8E</color>
-    <color name="cyan_text_navigation">#299ED7</color>
-    <color name="progress_wheel_color">#7DC88F</color>
     <color name="offline_text">#BA2E6E</color>
     <color name="offline_panel">#E6BA2E6E</color>
     <color name="white_list_clicked">#F1F1F2</color>
     <color name="transparent_download_bg">#E63E4247</color>
     <color name="video_section_bg">#3E4247</color>
-    <color name="red_download_failed_text">#fd7575</color>
     <color name="tab_bg">#3E4247</color>
     <color name="delete_panel_bg">#3E4247</color>
     <color name="switch_default_button_color">#C3C3C3</color>
@@ -106,8 +103,9 @@
     <color name="edx_grayscale_neutral_black">#111010</color>
     <color name="edx_grayscale_neutral_black_t">#000000</color>
 
-    <color name="edx_utility_success_dark">#1E8142</color>
-    <color name="edx_utility_success">#25B85A</color>
-    <color name="edx_utility_warning">#FDBC56</color>
-    <color name="edx_utility_error">#B20610</color>
+    <color name="edx_success_text">#1E8142</color>
+    <color name="edx_success_accent">#25B85A</color>
+    <color name="edx_warning_accent">#ffc01f</color>
+    <color name="edx_error_text">#B20610</color>
+    <color name="edx_error_accent">#cb0712</color>
 </resources>

--- a/VideoLocker/res/values/styles.xml
+++ b/VideoLocker/res/values/styles.xml
@@ -205,7 +205,7 @@
 
     <style name="CustomProgressBar" parent="android:Widget.ProgressBar.Horizontal">
         <item name="android:indeterminateOnly">false</item>
-        <item name="android:progressDrawable">@drawable/custom_progress_bar_horizontal_red</item>
+        <item name="android:progressDrawable">@drawable/custom_progress_bar_horizontal_error</item>
         <item name="android:minHeight">3dip</item>
         <item name="android:maxHeight">3dip</item>
     </style>

--- a/VideoLocker/res/values/text_styles.xml
+++ b/VideoLocker/res/values/text_styles.xml
@@ -132,10 +132,6 @@
         <item name="android:textColor">@android:color/white</item>
     </style>
 
-    <style name="bold_cyan_text" parent="@style/bold_text">
-        <item name="android:textColor">@color/cyan_text_navigation</item>
-    </style>
-
     <style name="semibold_white_text" parent="@style/semibold_text">
         <item name="android:textColor">@android:color/white</item>
     </style>
@@ -249,7 +245,7 @@
     <style name="registration_error_message" parent="@android:style/Widget.DeviceDefault.TextView">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:textColor">@color/red_error_text</item>
+        <item name="android:textColor">@color/edx_error_text</item>
         <item name="android:gravity" tools:targetApi="17">left|start|center_vertical</item>
         <item name="android:textSize">11sp</item>
         <item name="android:paddingRight">5dp</item>

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DiscussionPostsAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DiscussionPostsAdapter.java
@@ -36,7 +36,7 @@ public class DiscussionPostsAdapter extends BaseListAdapter<DiscussionThread> {
         edx_brand_primary_base = context.getResources().getColor(R.color.edx_brand_primary_base);
         edx_grayscale_neutral_light = context.getResources().getColor(R.color.edx_grayscale_neutral_light);
         edx_brand_secondary_dark = context.getResources().getColor(R.color.edx_brand_secondary_dark);
-        edx_utility_success_dark = context.getResources().getColor(R.color.edx_utility_success_dark);
+        edx_utility_success_dark = context.getResources().getColor(R.color.edx_success_text);
     }
 
     @Override

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DownloadEntryAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DownloadEntryAdapter.java
@@ -34,19 +34,19 @@ public abstract class DownloadEntryAdapter extends BaseListAdapter<DownloadEntry
         switch (item.getStatus()) {
             case PENDING: {
                 progressText = getContext().getString(R.string.download_pending);
-                progressDrawable = R.drawable.custom_progress_bar_horizontal_green;
+                progressDrawable = R.drawable.custom_progress_bar_horizontal_success;
                 errorText = null;
                 break;
             }
             case DOWNLOADING: {
                 progressText = getByteCountProgressText(item);
-                progressDrawable = R.drawable.custom_progress_bar_horizontal_green;
+                progressDrawable = R.drawable.custom_progress_bar_horizontal_success;
                 errorText = null;
                 break;
             }
             case FAILED: {
                 errorText = getContext().getString(R.string.error_download_failed);
-                progressDrawable = R.drawable.custom_progress_bar_horizontal_red;
+                progressDrawable = R.drawable.custom_progress_bar_horizontal_error;
                 if (item.getDownloadedByteCount() > 0) {
                     progressText = getByteCountProgressText(item);
                 } else {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/view_holders/AuthorLayoutViewHolder.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/view_holders/AuthorLayoutViewHolder.java
@@ -46,7 +46,7 @@ public class AuthorLayoutViewHolder {
                 answerTextView,
                 new IconDrawable(context, FontAwesomeIcons.fa_check_square_o)
                         .sizeRes(context, R.dimen.edx_xxx_small)
-                        .colorRes(context, R.color.edx_utility_success),
+                        .colorRes(context, R.color.edx_success_accent),
                 null, null, null);
         RoboGuice.getInjector(context).injectMembers(this);
     }


### PR DESCRIPTION
### Description

[MA-2576](https://openedx.atlassian.net/browse/MA-2576)

Every color now comes from the color palette (`edx_*`) except:
- greys
- "offline bar" (deprecated)
- error bar (deprecated, will use snackbars eventually)

### Things to test
- The download progress in the action bar is now a standard green
- The download progress bar in the download list is now a standard green
- The error text / error progress bar in the download list is now standard reds
- Text links now just use brand base color (which is what happens on edx.org)
- Edit/Cancel/Delete buttons now use a ripple instead of brand highlight

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @BenjiLee 
- [x] Code review: @mdinino 
