### PR TITLE
Created a content description string that forces edX annunciation.

### DIFF
--- a/VideoLocker/build.gradle
+++ b/VideoLocker/build.gradle
@@ -265,6 +265,12 @@ android {
         def platformName = config.get('PLATFORM_NAME')
         resValue "string", "platform_name", platformName
 
+        def phoneticPlatformName = config.get('PHONETIC_PLATFORM_NAME')
+        if (phoneticPlatformName == null) {
+            phoneticPlatformName = platformName
+        }
+        resValue "string", "phonetic_platform_name", phoneticPlatformName
+
         def fabric = config.get('FABRIC')
         if (fabric?.get('ENABLED')) {
             def fabric_key = fabric?.get('FABRIC_KEY')

--- a/VideoLocker/res/layout/activity_discovery_launch.xml
+++ b/VideoLocker/res/layout/activity_discovery_launch.xml
@@ -15,7 +15,7 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="75dp"
             android:layout_marginTop="75dp"
-            android:contentDescription="@string/app_name"
+            android:contentDescription="@string/phonetic_app_name"
             android:src="@drawable/edx_logo" />
 
         <LinearLayout

--- a/VideoLocker/res/layout/activity_launch.xml
+++ b/VideoLocker/res/layout/activity_launch.xml
@@ -15,7 +15,7 @@
             android:layout_height="wrap_content"
             android:layout_centerHorizontal="true"
             android:layout_marginTop="60dp"
-            android:contentDescription="@string/app_name"
+            android:contentDescription="@string/phonetic_app_name"
             android:src="@drawable/edx_logo" />
 
         <LinearLayout

--- a/VideoLocker/res/layout/activity_login.xml
+++ b/VideoLocker/res/layout/activity_login.xml
@@ -38,7 +38,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_centerHorizontal="true"
-                            android:contentDescription="@string/app_name"
+                            android:contentDescription="@null"
                             android:scaleType="fitXY"
                             android:src="@drawable/edx_map_login" />
 
@@ -47,7 +47,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_centerInParent="true"
-                            android:contentDescription="@string/app_name"
+                            android:contentDescription="@string/phonetic_app_name"
                             android:src="@drawable/edx_logo_login" />
                     </RelativeLayout>
 

--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">@string/platform_name</string>
+    <string name="phonetic_app_name">@string/phonetic_platform_name</string>
 
     <!-- Certificates -->
 


### PR DESCRIPTION
### Description

[MA-2650](https://openedx.atlassian.net/browse/MA-2650)

On launch screen, set the content description to "Ed-X". This will force TalkBack mode to annunciate EdX. Also created a new string resource file called content_descriptions.xml to store all content description strings.

Testing
- [ ] Unit, integration, acceptance tests as appropriate
 - In TalkBack mode, navigate to logo on launch screen. Ensure that the TTS sounds like "Ed-X".

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @miankhalid  
- [ ] Code review: @1zaman   
- [x] Code review: @bguertin 
- [ ] Accessibility review: @cptvitamin
- [ ] FYI @andy-armstrong 
