### PR TITLE
Remove unused C2DM permission

### DIFF
--- a/VideoLocker/AndroidManifest.xml
+++ b/VideoLocker/AndroidManifest.xml
@@ -31,11 +31,6 @@
     <!-- Sticky broadcast passing a message from one screen and display on another -->
     <uses-permission android:name="android.permission.BROADCAST_STICKY"/>
 
-    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
-    <permission android:protectionLevel="signature"
-        android:name="org.edx.mobile.permission.C2D_MESSAGE" />
-    <uses-permission android:name="org.edx.mobile.permission.C2D_MESSAGE" />
-
     <application
         android:allowBackup="true"
         android:supportsRtl="${supportsRtl}"


### PR DESCRIPTION
This declaration can cause problems if used in multiple apps, since the permission name must be unique.

Since we aren't actually using this permission (and in fact this isn't the modern way to use GCM), let's just remove it.

@BenjiLee 