### PR TITLE
MA-2362 a11y improvements to Login screen

### DIFF
--- a/VideoLocker/res/layout/activity_login.xml
+++ b/VideoLocker/res/layout/activity_login.xml
@@ -59,20 +59,46 @@
                         android:paddingLeft="44dp"
                         android:paddingRight="44dp">
 
-                        <EditText
-                            android:id="@+id/email_et"
-                            style="@style/edit_text_style"
+                        <android.support.design.widget.TextInputLayout
+                            android:id="@+id/usernameWrapper"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:paddingStart="-4dp"
+                            android:paddingEnd="-4dp"
+                            android:paddingLeft="-4dp"
+                            android:paddingRight="-4dp"
                             android:hint="@string/email_username"
-                            android:inputType="textEmailAddress"
-                            android:maxLength="100" />
+                            android:textColorHint="@color/grey_text">
 
-                        <EditText
-                            android:id="@+id/password_et"
-                            style="@style/edit_text_style"
-                            android:layout_marginTop="8dp"
+                            <android.support.design.widget.TextInputEditText
+                                android:id="@+id/email_et"
+                                android:inputType="textEmailAddress"
+                                android:maxLength="100"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"/>
+
+                        </android.support.design.widget.TextInputLayout>
+
+                        <android.support.design.widget.TextInputLayout
+                            android:id="@+id/passwordWrapper"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:paddingStart="-4dp"
+                            android:paddingEnd="-4dp"
+                            android:paddingLeft="-4dp"
+                            android:paddingRight="-4dp"
                             android:hint="@string/password"
-                            android:inputType="textPassword"
-                            android:maxLength="100" />
+                            android:textColorHint="@color/grey_text">
+
+                            <android.support.design.widget.TextInputEditText
+                                android:id="@+id/password_et"
+                                android:layout_marginTop="8dp"
+                                android:inputType="textPassword"
+                                android:maxLength="100"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"/>
+
+                        </android.support.design.widget.TextInputLayout>
 
                         <TextView
                             android:id="@+id/forgot_password_tv"
@@ -80,9 +106,9 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="8dp"
-                            android:gravity="center"
-                            android:focusable="true"
                             android:background="@drawable/selectable_box_overlay"
+                            android:focusable="true"
+                            android:gravity="center"
                             android:text="@string/forgot_password"
                             android:textColor="@color/text_navigation"
                             android:textSize="12sp" />
@@ -90,16 +116,17 @@
                         <FrameLayout
                             android:id="@+id/login_button_layout"
                             style="@style/edX.Widget.SignInButtonLayout"
-                            android:focusable="true"
-                            android:contentDescription="@string/login_btn">
+                            android:contentDescription="@string/login_btn"
+                            android:focusable="true">
 
                             <TextView
                                 android:id="@+id/login_btn_tv"
                                 style="@style/edX.Widget.SignInButton"
                                 android:text="@string/login" />
 
-                            <include layout="@layout/button_progress_indicator"
-                                android:id="@+id/progress"/>
+                            <include
+                                android:id="@+id/progress"
+                                layout="@layout/button_progress_indicator" />
                         </FrameLayout>
 
                         <LinearLayout
@@ -110,8 +137,9 @@
 
                             <include layout="@layout/view_signin_title_row" />
 
-                            <include layout="@layout/panel_social_auth"
-                                android:id="@+id/social_auth"/>
+                            <include
+                                android:id="@+id/social_auth"
+                                layout="@layout/panel_social_auth" />
                         </LinearLayout>
 
                         <TextView
@@ -122,7 +150,7 @@
                             android:layout_marginTop="7dp"
                             android:gravity="center"
                             android:text="@string/by_signing_up"
-                            android:textColor="@color/grey_redirected_txt"
+                            android:textColor="@color/grey_text"
                             android:textSize="11sp" />
 
                         <TextView
@@ -131,11 +159,11 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_gravity="center"
-                            android:gravity="center"
-                            android:textColor="@color/text_navigation"
                             android:background="@drawable/selectable_box_overlay"
-                            android:textSize="11sp"
                             android:focusable="true"
+                            android:gravity="center"
+                            android:textColor="@color/edx_brand_primary_base"
+                            android:textSize="11sp"
                             tools:text="@string/licensing_agreement" />
 
                         <TextView
@@ -170,8 +198,9 @@
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true">
 
-            <include layout="@layout/panel_custom_action_bar"
-                android:id="@+id/panel_custom_action_bar"/>
+            <include
+                android:id="@+id/panel_custom_action_bar"
+                layout="@layout/panel_custom_action_bar" />
         </LinearLayout>
 
     </RelativeLayout>

--- a/VideoLocker/res/layout/view_signin_title_row.xml
+++ b/VideoLocker/res/layout/view_signin_title_row.xml
@@ -7,10 +7,10 @@
     android:gravity="center" >
 
     <View
-        android:id="@+id/view1"
+        android:id="@+id/left_divider"
         android:layout_width="100dp"
         android:layout_height="1dp"
-        android:background="@color/grey_act_background" />
+        android:background="@color/grey_text" />
 
     <TextView
         android:id="@+id/findcourse_tv"
@@ -20,12 +20,12 @@
         android:layout_marginLeft="12dp"
         android:layout_marginRight="12dp"
         android:text="@string/or_sign_in_with"
-        android:textColor="#CC3c4045"
+        android:textColor="@color/grey_text"
         android:textSize="14sp" />
 
     <View
-        android:id="@+id/view2"
+        android:id="@+id/right_divider"
         android:layout_width="100dp"
         android:layout_height="1dp"
-        android:background="@color/grey_act_background" />
+        android:background="@color/grey_text" />
 </LinearLayout>


### PR DESCRIPTION
### Description

[MA-2362](https://openedx.atlassian.net/browse/MA-2362)

UI changes for a11y. Uses TextInputLayout since the hint and contentdescription cannot both be set for edittext. More discussion in the ticket.

Before:
![screen shot 2016-08-09 at 4 02 04 pm](https://cloud.githubusercontent.com/assets/7101723/17531604/a765c0e2-5e4a-11e6-821c-4c349b0b2bb8.png)
After:
![screen shot 2016-08-09 at 4 05 29 pm](https://cloud.githubusercontent.com/assets/7101723/17531724/1be942ae-5e4b-11e6-95b6-d6dfd1cd8444.png)

### Testing
What to look for:
Sufficient contrast for 
* "Forgot your password?" 
* Place holder text for User/pass

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
@bguertin 
@mdinino 