### PR TITLE
Clean up user data on logout

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/HttpRequestDelegate.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/HttpRequestDelegate.java
@@ -65,12 +65,8 @@ public abstract class HttpRequestDelegate<T> {
 
         // get data from server
         HttpManager.HttpResult result = invokeHttpCall();
-        if ( result.statusCode == HttpStatus.OK ) {
-            try {
-                cacheManager.put(cacheKey, result.body);
-            } catch ( Exception e) {
-               logger.error(e);
-            }
+        if (result.statusCode == HttpStatus.OK) {
+            cacheManager.put(cacheKey, result.body);
             json = result.body;
         }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/cache/CacheManager.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/cache/CacheManager.java
@@ -1,60 +1,61 @@
 package org.edx.mobile.http.cache;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import org.edx.mobile.logger.Logger;
-import org.edx.mobile.util.Sha1Util;
 import org.edx.mobile.util.IOUtils;
+import org.edx.mobile.util.Sha1Util;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
-import java.security.NoSuchAlgorithmException;
 
 @Singleton
 public class CacheManager {
+    private final Logger logger = new Logger(getClass().getName());
 
-    private File cacheFolder;
-    protected final Logger logger = new Logger(getClass().getName());
+    @NonNull
+    private final Context context;
 
     @Inject
-    public CacheManager(Context context) {
-        if (context == null) {
-            logger.warn("Context must not be NULL");
-        }
-        cacheFolder = new File(context.getFilesDir(), "http-cache");
-        if (!cacheFolder.exists()) {
-            cacheFolder.mkdirs();
-        }
+    public CacheManager(@NonNull Context context) {
+        this.context = context;
     }
 
-    public boolean has(String url) throws NoSuchAlgorithmException,
-            UnsupportedEncodingException {
+    public boolean has(String url) {
+        final File cacheDir = getCacheDir();
+        if (cacheDir == null) return false;
+
         String hash = Sha1Util.SHA1(url);
-        File file = new File(cacheFolder, hash);
+        File file = new File(cacheDir, hash);
         return file.exists();
     }
 
-    public void put(String url, String response)
-            throws NoSuchAlgorithmException, UnsupportedEncodingException,
-            IOException {
+    public void put(String url, String response) throws IOException {
+        final File cacheDir = getCacheDir();
+        if (cacheDir == null) throw new IOException("Cache directory not found");
+
         String hash = Sha1Util.SHA1(url);
-        File file = new File(cacheFolder, hash);
+        File file = new File(cacheDir, hash);
         FileOutputStream out = new FileOutputStream(file);
         out.write(response.getBytes());
         out.close();
         logger.debug("Cache.put = " + hash);
     }
 
-    public String get(String url) throws IOException, NoSuchAlgorithmException {
+    public String get(String url) throws IOException {
+        final File cacheDir = getCacheDir();
+        if (cacheDir == null) throw new IOException("Cache directory not found");
+
         String hash = Sha1Util.SHA1(url);
-        File file = new File(cacheFolder, hash);
+        File file = new File(cacheDir, hash);
 
         if (!file.exists()) {
             logger.debug("Cache.get failed, not cached");
@@ -67,5 +68,16 @@ public class CacheManager {
         in.close();
         logger.debug("Cache.get = " + hash);
         return cache;
+    }
+
+    @Nullable
+    private File getCacheDir() {
+        final File appDir = context.getFilesDir();
+        if (appDir != null) {
+            final File cacheDir = new File(appDir, "http-cache");
+            cacheDir.mkdirs();
+            return cacheDir;
+        }
+        return null;
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/DbStructure.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/DbStructure.java
@@ -6,17 +6,18 @@ package org.edx.mobile.module.db;
  *
  */
 public final class DbStructure {
-    
+
     public static final String NAME = "downloads.db";
-    //Updated to Version 4 to add flag to indicate that video is only available for web
-    //Updated to Version 5 to create a new table to record learning history for assessment
-    public static final int VERSION = 5;
+    // Updated to Version 4 to add flag to indicate that video is only available for web
+    // Updated to Version 5 to create a new table to record learning history for assessment
+    // Updated to Version 6 to swap every occurrence of username field to its SHA1 hash
+    public static final int VERSION = 6;
 
     public static final class Table {
         public static final String DOWNLOADS = "downloads";
         public static final String ASSESSMENT = "assessment";
     }
-    
+
     public static final class Column {
         public static final String ID = "_id";
         public static final String USERNAME = "username";

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/IDatabase.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/IDatabase.java
@@ -1,5 +1,7 @@
 package org.edx.mobile.module.db;
 
+import android.support.annotation.Nullable;
+
 import org.edx.mobile.model.VideoModel;
 import org.edx.mobile.model.db.DownloadEntry.DownloadedState;
 import org.edx.mobile.model.db.DownloadEntry.WatchedState;
@@ -468,5 +470,9 @@ public interface IDatabase {
      */
     boolean isUnitAccessed(DataCallback<Boolean> callback, String unitId);
 
+    /**
+     * Get the list of course ids for which a specific user has downloaded atleast 1 video.
+     */
+    List<String> getUniqueCourseIdsForDownloadedVideos(@Nullable DataCallback<List<String>> callback);
 
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/DbHelper.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/DbHelper.java
@@ -1,11 +1,21 @@
 package org.edx.mobile.module.db.impl;
 
+import android.content.ContentValues;
 import android.content.Context;
+import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.os.Environment;
 
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.module.db.DbStructure;
+import org.edx.mobile.util.AppConstants;
+import org.edx.mobile.util.FileUtil;
+import org.edx.mobile.util.Sha1Util;
+import org.edx.mobile.util.TextUtils;
+
+import java.io.File;
+import java.util.Arrays;
 
 /**
  * This class is an implementation of {@link SQLiteOpenHelper} and handles
@@ -14,17 +24,18 @@ import org.edx.mobile.module.db.DbStructure;
  *
  */
 class DbHelper extends SQLiteOpenHelper {
-
     private SQLiteDatabase sqliteDb;
+    private Context context;
     protected final Logger logger = new Logger(getClass().getName());
 
     public DbHelper(Context context) {
         super(context, DbStructure.NAME, null, DbStructure.VERSION);
+        this.context = context;
     }
 
     @Override
     public void onCreate(SQLiteDatabase db) {
-        String sql = "CREATE TABLE "                        + DbStructure.Table.DOWNLOADS 
+        String sql = "CREATE TABLE "                        + DbStructure.Table.DOWNLOADS
                 + " ("
                 + DbStructure.Column.ID                     + " INTEGER PRIMARY KEY AUTOINCREMENT, "
                 + DbStructure.Column.USERNAME               + " TEXT, "
@@ -52,7 +63,7 @@ class DbHelper extends SQLiteOpenHelper {
         db.execSQL(sql);
 
         createAssessmentTable(db);
-        
+
         logger.debug("Database created");
     }
 
@@ -69,52 +80,127 @@ class DbHelper extends SQLiteOpenHelper {
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-        try {
-            String upgradeToV2 =
-                    "ALTER TABLE "    + DbStructure.Table.DOWNLOADS + " ADD COLUMN "
-                                      + DbStructure.Column.UNIT_URL + " TEXT ";
+        String upgradeToV2 =
+                "ALTER TABLE " + DbStructure.Table.DOWNLOADS + " ADD COLUMN "
+                        + DbStructure.Column.UNIT_URL + " TEXT ";
 
-            String[] upgradeToV3 = new String[] {
-                    "ALTER TABLE "    + DbStructure.Table.DOWNLOADS + " ADD COLUMN "
-                                      + DbStructure.Column.URL_HIGH_QUALITY + " TEXT ",
+        String[] upgradeToV3 = new String[]{
+                "ALTER TABLE " + DbStructure.Table.DOWNLOADS + " ADD COLUMN "
+                        + DbStructure.Column.URL_HIGH_QUALITY + " TEXT ",
 
-                    "ALTER TABLE "    + DbStructure.Table.DOWNLOADS + " ADD COLUMN "
-                                      + DbStructure.Column.URL_LOW_QUALITY + " TEXT ",
+                "ALTER TABLE " + DbStructure.Table.DOWNLOADS + " ADD COLUMN "
+                        + DbStructure.Column.URL_LOW_QUALITY + " TEXT ",
 
-                    "ALTER TABLE "    + DbStructure.Table.DOWNLOADS + " ADD COLUMN "
-                                      + DbStructure.Column.URL_YOUTUBE + " TEXT "};
+                "ALTER TABLE " + DbStructure.Table.DOWNLOADS + " ADD COLUMN "
+                        + DbStructure.Column.URL_YOUTUBE + " TEXT "};
 
-            String upgradeToV4 =
-                    "ALTER TABLE "    + DbStructure.Table.DOWNLOADS + " ADD COLUMN "
-                            + DbStructure.Column.VIDEO_FOR_WEB_ONLY + " BOOLEAN ";
+        String upgradeToV4 =
+                "ALTER TABLE " + DbStructure.Table.DOWNLOADS + " ADD COLUMN "
+                        + DbStructure.Column.VIDEO_FOR_WEB_ONLY + " BOOLEAN ";
 
-            if ( oldVersion == 1 ) {
-                // upgrade from 1 to 2
-                db.execSQL(upgradeToV2);
+        if (oldVersion == 1) {
+            // upgrade from 1 to 2
+            db.execSQL(upgradeToV2);
+        }
+
+        if (oldVersion < 3) {
+            // upgrade to version 3
+            for (String query : upgradeToV3) {
+                db.execSQL(query);
             }
+        }
 
-            if ( oldVersion < 3 ) {
-                // upgrade to version 3
-                for (String query : upgradeToV3) {
-                    db.execSQL(query);
+        if (oldVersion < 4) {
+            // upgrade to version 4
+            db.execSQL(upgradeToV4);
+        }
+
+        if (oldVersion < 5) {
+            createAssessmentTable(db);
+        }
+
+        if (oldVersion < 6) {
+            db.beginTransaction();
+            try {
+                final File externalAppDir = FileUtil.getExternalAppDir(context);
+                final String previousAppDirPath = TextUtils.join("/", Arrays.<CharSequence>asList(
+                        Environment.getExternalStorageDirectory().getAbsolutePath(),
+                        "Android", "data", context.getPackageName())).toString();
+                if (externalAppDir != null) {
+                    Cursor cursor = db.query(false, DbStructure.Table.DOWNLOADS,
+                            new String[]{DbStructure.Column.ID, DbStructure.Column.USERNAME,
+                                    DbStructure.Column.FILEPATH}, null, null, null, null, null, null);
+                    if (cursor != null) {
+                        try {
+                            final int idIndex = cursor.getColumnIndexOrThrow(DbStructure.Column.ID);
+                            final int usernameIndex = cursor.getColumnIndexOrThrow(DbStructure.Column.USERNAME);
+                            final int filePathIndex = cursor.getColumnIndexOrThrow(DbStructure.Column.FILEPATH);
+
+                            while (cursor.moveToNext()) {
+                                final String id = cursor.getString(idIndex);
+                                final String username = cursor.getString(usernameIndex);
+                                final String filePath = cursor.getString(filePathIndex);
+                                final String hashedUsername = Sha1Util.SHA1(username);
+
+                                final String previousDirPath = TextUtils.join(
+                                        "/", Arrays.<CharSequence>asList(previousAppDirPath,
+                                                username)) + "/";
+                                if (!filePath.startsWith(previousDirPath)) {
+                                    db.delete(DbStructure.Table.DOWNLOADS,
+                                            DbStructure.Column.ID + "= ?", new String[]{id});
+                                    continue;
+                                }
+
+                                final String newFilePath = filePath.replaceFirst(
+                                        "^" + previousDirPath,
+                                        TextUtils.join("/", Arrays.<CharSequence>asList(
+                                                externalAppDir.getAbsolutePath(),
+                                                AppConstants.Directories.VIDEOS,
+                                                hashedUsername)) + "/");
+
+                                // First update the name and path of the videos directory
+                                final File previousDir = new File(previousAppDirPath, username);
+                                if (previousDir.exists()) {
+                                    final File newDir = new File(externalAppDir,
+                                            TextUtils.join("/", Arrays.<CharSequence>asList(
+                                                    AppConstants.Directories.VIDEOS,
+                                                    hashedUsername)).toString());
+                                    if (!((newDir.mkdirs() || newDir.exists()) &&
+                                            previousDir.renameTo(newDir))) {
+                                        continue;
+                                    }
+                                }
+
+                                // Then update the database row
+                                final ContentValues updatedValues = new ContentValues();
+                                updatedValues.put(DbStructure.Column.USERNAME, hashedUsername);
+                                updatedValues.put(DbStructure.Column.FILEPATH, newFilePath);
+                                db.update(DbStructure.Table.DOWNLOADS, updatedValues,
+                                        DbStructure.Column.ID + "= ?", new String[]{id});
+                            }
+                        } finally {
+                            cursor.close();
+                        }
+
+                        // Now migrate the subtitles directory
+                        final File previousSrtDir = new File(externalAppDir, "srtFolder");
+                        if (previousSrtDir.exists()) {
+                            final File newSrtDir = new File(externalAppDir,
+                                    AppConstants.Directories.VIDEOS + "/" + AppConstants.Directories.SUBTITLES);
+                            newSrtDir.mkdirs();
+                            previousSrtDir.renameTo(newSrtDir);
+                        }
+                    }
+                    db.setTransactionSuccessful();
+                    logger.debug("Database upgraded from " + oldVersion + " to " + newVersion);
                 }
-            }
 
-            if ( oldVersion < 4 ) {
-                // upgrade to version 4
-                db.execSQL(upgradeToV4);
+            } finally {
+                db.endTransaction();
             }
-
-            if ( oldVersion < 5 ){
-                createAssessmentTable(db);
-            }
-
-            logger.debug("Database upgraded from " + oldVersion + " to " + newVersion);
-        }catch(Exception e){
-            logger.error(e);
         }
     }
-    
+
     /**
      * Returns singleton writable {@link SQLiteDatabase} object.
      * @return
@@ -126,11 +212,11 @@ class DbHelper extends SQLiteOpenHelper {
         }
         return sqliteDb;
     }
-    
+
     @Override
     public synchronized void close() {
         super.close();
-        
+
         sqliteDb = null;
         logger.debug("Database closed");
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/IDatabaseImpl.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/IDatabaseImpl.java
@@ -15,6 +15,7 @@ import org.edx.mobile.module.db.DataCallback;
 import org.edx.mobile.module.db.DbStructure;
 import org.edx.mobile.module.db.IDatabase;
 import org.edx.mobile.module.prefs.LoginPrefs;
+import org.edx.mobile.util.Sha1Util;
 
 import java.util.List;
 
@@ -32,7 +33,8 @@ public class IDatabaseImpl extends IDatabaseBaseImpl implements IDatabase {
 
     @Nullable
     private String username() {
-        return loginPrefs.getUsername();
+        final String username = loginPrefs.getUsername();
+        return (username != null) ? Sha1Util.SHA1(username) : null;
     }
 
     @Override
@@ -750,6 +752,18 @@ public class IDatabaseImpl extends IDatabaseBaseImpl implements IDatabase {
                         DbStructure.Column.DOWNLOADED + "=?",
                 new String[]{courseId, section, subSection, username(),
                         String.valueOf(DownloadedState.DOWNLOADING.ordinal())}, null);
+        op.setCallback(callback);
+        return enqueue(op);
+    }
+
+    @Override
+    public List<String> getUniqueCourseIdsForDownloadedVideos(@Nullable final DataCallback<List<String>> callback) {
+        DbOperationGetColumn<String> op = new DbOperationGetColumn<String>(true,
+                DbStructure.Table.DOWNLOADS,
+                new String[]{DbStructure.Column.EID},
+                DbStructure.Column.USERNAME + "=? AND " + DbStructure.Column.DOWNLOADED + "=?",
+                new String[]{username(), String.valueOf(DownloadedState.DOWNLOADED.ordinal())},
+                null, String.class);
         op.setCallback(callback);
         return enqueue(op);
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/download/IDownloadManagerImpl.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/download/IDownloadManagerImpl.java
@@ -78,37 +78,33 @@ public class IDownloadManagerImpl implements IDownloadManager {
         if(!isDownloadManagerEnabled())
             return dmid;
 
-        try {
-            // skip if URL is not valid
-            if(url == null) {
-                // URL is null
-                return dmid;
-            }
-            url = url.trim();
-            if (url.length() == 0) {
-                // URL is empty
-                return dmid;
-            }
-            
-            logger.debug("Starting download: " + url);
-            
-            Uri target = Uri.fromFile(new File(destFolder, Sha1Util.SHA1(url)));
-            Request request = new Request(Uri.parse(url));
-            request.setDestinationUri(target);
-            request.setNotificationVisibility(Request.VISIBILITY_HIDDEN);
-            request.setVisibleInDownloadsUi(false);
-
-            if (wifiOnly) {
-                request.setAllowedNetworkTypes(Request.NETWORK_WIFI);
-            } else {
-                request.setAllowedNetworkTypes(Request.NETWORK_WIFI | Request.NETWORK_MOBILE);
-            }
-    
-            dmid = dm.enqueue(request);
-        } catch(Exception ex) {
-            logger.error(ex);
+        // skip if URL is not valid
+        if(url == null) {
+            // URL is null
+            return dmid;
         }
-        
+        url = url.trim();
+        if (url.length() == 0) {
+            // URL is empty
+            return dmid;
+        }
+
+        logger.debug("Starting download: " + url);
+
+        Uri target = Uri.fromFile(new File(destFolder, Sha1Util.SHA1(url)));
+        Request request = new Request(Uri.parse(url));
+        request.setDestinationUri(target);
+        request.setNotificationVisibility(Request.VISIBILITY_HIDDEN);
+        request.setVisibleInDownloadsUi(false);
+
+        if (wifiOnly) {
+            request.setAllowedNetworkTypes(Request.NETWORK_WIFI);
+        } else {
+            request.setAllowedNetworkTypes(Request.NETWORK_WIFI | Request.NETWORK_MOBILE);
+        }
+
+        dmid = dm.enqueue(request);
+
         return dmid;
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
@@ -214,6 +214,14 @@ public class PrefManager {
         public void setLastCourseStructureFetch(String courseId, long timestamp) {
             super.put(Key.LAST_COURSE_STRUCTURE_FETCH + "_" + courseId, timestamp);
         }
+
+        public boolean isVideosCacheRestored() {
+            return getBoolean(Key.VIDEOS_CACHE_RESTORED, false);
+        }
+
+        public void setIsVideosCacheRestored(boolean restored) {
+            super.put(Key.VIDEOS_CACHE_RESTORED, restored);
+        }
     }
 
     /**
@@ -226,6 +234,10 @@ public class PrefManager {
         public static final String FEATURES = "features";
         public static final String APP_INFO = "pref_app_info";
         public static final String USER_PREF = "pref_user";
+
+        public static String[] getAll() {
+            return new String[]{LOGIN, WIFI, VIDEOS, FEATURES, APP_INFO, USER_PREF};
+        }
     }
 
     /**
@@ -254,6 +266,12 @@ public class PrefManager {
         public static final String AppSettingNeedSyncWithParse = "AppSettingNeedSyncWithParse";
         public static final String UserPrefVideoModel = "UserPrefVideoModel";
         public static final String LAST_COURSE_STRUCTURE_FETCH = "LastCourseStructureFetch";
+        /**
+         * For downloaded videos to appear in order on the My Videos screen, we need
+         * to have the videos' courses data cached. This is the key to a persistent
+         * flag which marks whether the cache has been restored
+         */
+        public static final String VIDEOS_CACHE_RESTORED = "VideosCacheRestored";
 
 
     }
@@ -264,5 +282,15 @@ public class PrefManager {
          */
         public static final String BACKEND_FACEBOOK = "facebook";
         public static final String BACKEND_GOOGLE = "google-oauth2";
+    }
+
+    /**
+     * Clears all the shared preferences that are used in the app.
+     */
+    public static void nukeSharedPreferences() {
+        for (String prefName : Pref.getAll()) {
+            MainApplication.application.getSharedPreferences(
+                    prefName, Context.MODE_PRIVATE).edit().clear().apply();
+        }
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/storage/Storage.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/storage/Storage.java
@@ -85,9 +85,14 @@ public class Storage implements IStorage {
                 //on mobile network even if user has "Only on wifi" settings as ON
                 downloadPreference = false;
             }
+
+            // Fail the download if download directory isn't available
+            final File downloadDirectory = pref.getDownloadDirectory();
+            if (downloadDirectory == null) return -1;
+
             // there is no any download ever marked for this URL
             // so, add a download and map download info to given video
-            long dmid = dm.addDownload(pref.getDownloadFolder(), model.getVideoUrl(),
+            long dmid = dm.addDownload(downloadDirectory, model.getVideoUrl(),
                     downloadPreference);
             if(dmid==-1){
                 //Download did not start for the video because of an issue in DownloadManager

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/player/TranscriptManager.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/player/TranscriptManager.java
@@ -1,61 +1,49 @@
 package org.edx.mobile.player;
 
 import android.content.Context;
-import android.os.Environment;
+import android.support.annotation.Nullable;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import org.edx.mobile.R;
+import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.api.TranscriptModel;
+import org.edx.mobile.util.AppConstants;
+import org.edx.mobile.util.FileUtil;
+import org.edx.mobile.util.IOUtils;
 import org.edx.mobile.util.Sha1Util;
 import org.edx.mobile.util.TranscriptDownloader;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
-import java.security.NoSuchAlgorithmException;
 import java.util.LinkedHashMap;
-import org.edx.mobile.logger.Logger;
-import org.edx.mobile.util.IOUtils;
 
 @Singleton
 public class TranscriptManager {
-
-    private File transcriptFolder;
-    private Context context;
     private final Logger logger = new Logger(getClass().getName());
+    private final Context context;
 
     @Inject
     public TranscriptManager(Context context) {
-        try{
-            this.context = context;
-            File android = new File(Environment.getExternalStorageDirectory(), "Android");
-            File downloadsDir = new File(android, "data");
-            File packDir = new File(downloadsDir, context.getPackageName());
-            transcriptFolder = new File(packDir, "srtFolder");
-            if(!transcriptFolder.exists()){
-                transcriptFolder.mkdirs();
-            }
-        }catch(Exception e){
-            logger.error(e);
-        }
+        this.context = context;
     }
 
     /**
      * This function checks if the file exists for that link
      * @param url
-     * @return 
-     * @throws NoSuchAlgorithmException
-     * @throws UnsupportedEncodingException
+     * @return
      */
-    public boolean has(String url) throws NoSuchAlgorithmException,
-    UnsupportedEncodingException {
+    public boolean has(String url) {
+        final File transcriptDir = getTranscriptDir();
+        if (transcriptDir == null) return false;
+
         String hash = Sha1Util.SHA1(url);
-        File file = new File(transcriptFolder, hash);
+        File file = new File(transcriptDir, hash);
         return file.exists();
     }
 
@@ -64,15 +52,14 @@ public class TranscriptManager {
      * This function is used to saved contents of a String to a file
      * @param url - Url of Transcript
      * @param response - This is the String which needs to be saved into a file
-     * @throws NoSuchAlgorithmException
-     * @throws UnsupportedEncodingException
      * @throws IOException
      */
-    public void put(String url, String response)
-            throws NoSuchAlgorithmException, UnsupportedEncodingException,
-            IOException {
+    public void put(String url, String response) throws IOException {
+        final File transcriptDir = getTranscriptDir();
+        if (transcriptDir == null) throw new IOException("Transcript directory not found");
+
         String hash = Sha1Util.SHA1(url);
-        File file = new File(transcriptFolder, hash);
+        File file = new File(transcriptDir, hash);
         FileOutputStream out = new FileOutputStream(file);
         out.write(response.getBytes());
         out.close();
@@ -84,26 +71,23 @@ public class TranscriptManager {
      * @param url - This is the URL for SRT files
      * @return String - This is the response of the File contents
      * @throws IOException
-     * @throws NoSuchAlgorithmException
      */
-    public String get(String url) throws IOException, NoSuchAlgorithmException {
-        try{
-            String hash = Sha1Util.SHA1(url);
-            File file = new File(transcriptFolder, hash);
-            if (!file.exists()) { 
-                // not in cache
-                return null;
-            }
+    public String get(String url) throws IOException {
+        final File transcriptDir = getTranscriptDir();
+        if (transcriptDir == null) throw new IOException("Transcript directory not found");
 
-            FileInputStream in = new FileInputStream(file);
-            String cache = IOUtils.toString(in, Charset.defaultCharset());
-            in.close();
-            logger.debug("Cache.get=" + hash);
-            return cache;
-        }catch(Exception e){
-            logger.error(e);
+        String hash = Sha1Util.SHA1(url);
+        File file = new File(transcriptDir, hash);
+        if (!file.exists()) {
+            // not in cache
+            return null;
         }
-        return null;
+
+        FileInputStream in = new FileInputStream(file);
+        String cache = IOUtils.toString(in, Charset.defaultCharset());
+        in.close();
+        logger.debug("Cache.get=" + hash);
+        return cache;
     }
 
 
@@ -112,35 +96,28 @@ public class TranscriptManager {
      * @param url - This is the URL for SRT files
      * @return String - This is the response of the File contents
      * @throws IOException
-     * @throws NoSuchAlgorithmException
      */
-    public InputStream getInputStream(String url) throws IOException, NoSuchAlgorithmException {
-        try{
-            String hash = Sha1Util.SHA1(url);
-            File file = new File(transcriptFolder, hash);
-            if (!file.exists()) { 
-                // not in cache
-                return null;
-            }
+    public InputStream getInputStream(String url) throws IOException {
+        final File transcriptDir = getTranscriptDir();
+        if (transcriptDir == null) throw new IOException("Transcript directory not found");
 
-            InputStream in = new FileInputStream(file);
-            return in;
-        }catch(Exception e){
-            logger.error(e);
+        String hash = Sha1Util.SHA1(url);
+        File file = new File(transcriptDir, hash);
+        if (!file.exists()) {
+            // not in cache
+            return null;
         }
-        return null;
+
+        return new FileInputStream(file);
     }
 
 
     /**
      * This function is used to handle downloading of SRT files and saving them
      * @param downloadLink
-     * @throws NoSuchAlgorithmException
-     * @throws UnsupportedEncodingException
      */
-    public void startTranscriptDownload(final String downloadLink) 
-            throws NoSuchAlgorithmException, UnsupportedEncodingException{
-        //Uri target = Uri.fromFile(new File(transcriptFolder, Sha1Util.SHA1(downloadLink)));
+    public void startTranscriptDownload(final String downloadLink) {
+        //Uri target = Uri.fromFile(new File(transcriptDir, Sha1Util.SHA1(downloadLink)));
         if(downloadLink==null){
             return;
         }
@@ -148,20 +125,16 @@ public class TranscriptManager {
         //If file is not present in the Folder, then start downloading
         if(!has(downloadLink)) {
             TranscriptDownloader td = new TranscriptDownloader(context, downloadLink) {
-                
+
                 @Override
                 public void onDownloadComplete(String response) {
                     try {
                         put(downloadLink, response);
-                    } catch (NoSuchAlgorithmException e) {
-                        logger.error(e);
-                    } catch (UnsupportedEncodingException e) {
-                        logger.error(e);
                     } catch (IOException e) {
                         logger.error(e);
                     }
                 }
-                
+
                 @Override
                 public void handle(Exception ex) {
                     logger.error(ex);
@@ -182,58 +155,22 @@ public class TranscriptManager {
         }
 
         if(transcript.chineseUrl!=null){
-            try {
-                startTranscriptDownload(transcript.chineseUrl);
-            } catch (NoSuchAlgorithmException e) {
-                logger.error(e);
-            } catch (UnsupportedEncodingException e) {
-                logger.error(e);
-            }
+            startTranscriptDownload(transcript.chineseUrl);
         }
         if(transcript.englishUrl!=null){
-            try {
-                startTranscriptDownload(transcript.englishUrl);
-            } catch (NoSuchAlgorithmException e) {
-                logger.error(e);
-            } catch (UnsupportedEncodingException e) {
-                logger.error(e);
-            }
+            startTranscriptDownload(transcript.englishUrl);
         }
         if(transcript.frenchUrl!=null){
-            try {
-                startTranscriptDownload(transcript.frenchUrl);
-            } catch (NoSuchAlgorithmException e) {
-                logger.error(e);
-            } catch (UnsupportedEncodingException e) {
-                logger.error(e);
-            }
+            startTranscriptDownload(transcript.frenchUrl);
         }
         if(transcript.germanUrl!=null){
-            try {
-                startTranscriptDownload(transcript.germanUrl);
-            } catch (NoSuchAlgorithmException e) {
-                logger.error(e);
-            } catch (UnsupportedEncodingException e) {
-                logger.error(e);
-            }
+            startTranscriptDownload(transcript.germanUrl);
         }
         if(transcript.portugueseUrl!=null){
-            try {
-                startTranscriptDownload(transcript.portugueseUrl);
-            } catch (NoSuchAlgorithmException e) {
-                logger.error(e);
-            } catch (UnsupportedEncodingException e) {
-                logger.error(e);
-            }
+            startTranscriptDownload(transcript.portugueseUrl);
         }
         if(transcript.spanishUrl!=null){
-            try {
-                startTranscriptDownload(transcript.spanishUrl);
-            } catch (NoSuchAlgorithmException e) {
-                logger.error(e);
-            } catch (UnsupportedEncodingException e) {
-                logger.error(e);
-            }
+            startTranscriptDownload(transcript.spanishUrl);
         }
     }
 
@@ -249,35 +186,35 @@ public class TranscriptManager {
         LinkedHashMap<String, InputStream> transcriptList = new LinkedHashMap<String, InputStream>();
         try{
             if(transcript.chineseUrl!=null){
-                transcriptList.put(context.getString(R.string.cc_chinese_code), 
+                transcriptList.put(context.getString(R.string.cc_chinese_code),
                         fetchTranscriptResponse(transcript.chineseUrl));
             }
 
             if(transcript.englishUrl!=null){
-                transcriptList.put(context.getString(R.string.cc_english_code), 
+                transcriptList.put(context.getString(R.string.cc_english_code),
                         fetchTranscriptResponse(transcript.englishUrl));
             }
 
             if(transcript.frenchUrl!=null){
-                transcriptList.put(context.getString(R.string.cc_french_code), 
+                transcriptList.put(context.getString(R.string.cc_french_code),
                         fetchTranscriptResponse(transcript.frenchUrl));
             }
-            
+
             if(transcript.germanUrl!=null){
-                transcriptList.put(context.getString(R.string.cc_german_code), 
+                transcriptList.put(context.getString(R.string.cc_german_code),
                         fetchTranscriptResponse(transcript.germanUrl));
             }
 
             if(transcript.portugueseUrl!=null){
-                transcriptList.put(context.getString(R.string.cc_portugal_code), 
+                transcriptList.put(context.getString(R.string.cc_portugal_code),
                         fetchTranscriptResponse(transcript.portugueseUrl));
             }
 
             if(transcript.spanishUrl!=null){
-                transcriptList.put(context.getString(R.string.cc_spanish_code), 
+                transcriptList.put(context.getString(R.string.cc_spanish_code),
                         fetchTranscriptResponse(transcript.spanishUrl));
             }
-            
+
             return transcriptList;
         }catch(Exception e){
             logger.error(e);
@@ -301,14 +238,20 @@ public class TranscriptManager {
                 response = getInputStream(url);
             return response;
             }
-        } catch (NoSuchAlgorithmException e) {
-            logger.error(e);
-        } catch (UnsupportedEncodingException e) {
-            logger.error(e);
         } catch (IOException e) {
             logger.error(e);
-        } catch (Exception e) {
-            logger.error(e);
+        }
+        return null;
+    }
+
+    @Nullable
+    private File getTranscriptDir() {
+        final File externalAppDir = FileUtil.getExternalAppDir(context);
+        if (externalAppDir != null) {
+            final File videosDir = new File(externalAppDir, AppConstants.Directories.VIDEOS);
+            final File transcriptDir = new File(videosDir, AppConstants.Directories.SUBTITLES);
+            transcriptDir.mkdirs();
+            return transcriptDir;
         }
         return null;
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/task/EnqueueDownloadTask.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/task/EnqueueDownloadTask.java
@@ -11,27 +11,26 @@ import org.edx.mobile.player.TranscriptManager;
 import java.util.List;
 
 public abstract class EnqueueDownloadTask extends Task<Long> {
-
-
     @Inject
     @NonNull
     TranscriptManager transcriptManager;
     @NonNull
     List<DownloadEntry> downloadList;
+
     public EnqueueDownloadTask(@NonNull Context context, @NonNull List<DownloadEntry> downloadList) {
         super(context);
         this.downloadList = downloadList;
     }
 
     @Override
-    public Long call( ) throws Exception{
+    public Long call() throws Exception {
         int count = 0;
         for (DownloadEntry de : downloadList) {
-            if(environment.getStorage().addDownload(de)!=-1){
+            if (environment.getStorage().addDownload(de) != -1) {
                 count++;
+                transcriptManager.downloadTranscriptsForVideo(de.transcript);
             }
-            transcriptManager.downloadTranscriptsForVideo(de.transcript);
         }
-        return (long)count;
+        return (long) count;
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/task/RestoreVideosCacheDataTask.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/task/RestoreVideosCacheDataTask.java
@@ -1,0 +1,44 @@
+package org.edx.mobile.task;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import com.google.inject.Inject;
+
+import org.edx.mobile.base.MainApplication;
+import org.edx.mobile.core.EdxEnvironment;
+import org.edx.mobile.http.OkHttpUtil;
+import org.edx.mobile.module.prefs.PrefManager;
+
+import java.util.List;
+
+public class RestoreVideosCacheDataTask extends Task<Void> {
+    @Inject
+    private EdxEnvironment environment;
+
+    private RestoreVideosCacheDataTask(@NonNull Context context) {
+        super(context);
+    }
+
+    public static void executeInstanceIfNeeded(@NonNull Context context) {
+        PrefManager.UserPrefManager prefs = new PrefManager.UserPrefManager(MainApplication.application);
+        if (!prefs.isVideosCacheRestored()) {
+            new RestoreVideosCacheDataTask(context).execute();
+        }
+    }
+
+    @Override
+    public Void call() throws Exception {
+        List<String> courseIds = environment.getDatabase().getUniqueCourseIdsForDownloadedVideos(null);
+        for (String courseId : courseIds) {
+            environment.getServiceManager().getCourseStructure(courseId, OkHttpUtil.REQUEST_CACHE_TYPE.IGNORE_CACHE);
+        }
+        return null;
+    }
+
+    @Override
+    protected void onSuccess(Void aVoid) throws Exception {
+        PrefManager.UserPrefManager prefManager = new PrefManager.UserPrefManager(context);
+        prefManager.setIsVideosCacheRestored(true);
+    }
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/user/UserAPI.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/user/UserAPI.java
@@ -26,7 +26,6 @@ import org.edx.mobile.view.common.TaskProgressCallback;
 
 import java.io.File;
 import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -182,7 +181,7 @@ public class UserAPI {
         if (tryCache) {
             try {
                 json = cache.get(cacheKey);
-            } catch (IOException | NoSuchAlgorithmException e) {
+            } catch (IOException e) {
                 logger.debug(e.toString());
             }
         }
@@ -195,7 +194,7 @@ public class UserAPI {
                 // cache result
                 try {
                     cache.put(cacheKey, json);
-                } catch (IOException | NoSuchAlgorithmException e) {
+                } catch (IOException e) {
                     logger.debug(e.toString());
                 }
             } else {
@@ -205,7 +204,7 @@ public class UserAPI {
                 // Otherwise fall back to fetching from the cache
                 try {
                     json = cache.get(cacheKey);
-                } catch (IOException | NoSuchAlgorithmException e) {
+                } catch (IOException e) {
                     logger.debug(e.toString());
                     throw new HttpResponseStatusException(response.code());
                 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/AppConstants.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/AppConstants.java
@@ -1,7 +1,7 @@
 package org.edx.mobile.util;
 
-
-public class AppConstants {
+public enum AppConstants {
+    ;
 
     @Deprecated // This is not a constant. Should move it to the activity and use savedInstanceState.
     public static boolean myVideosDeleteMode = false;
@@ -11,4 +11,20 @@ public class AppConstants {
     public static final String VIDEOLIST_BACK_PRESSED = "offline_video_back_pressed";
 
     public static final double MILLISECONDS_PER_SECOND = 1000.00;
+
+    /**
+     * This class defines the names of various directories which are used for
+     * storing application data.
+     */
+    public static final class Directories {
+        /**
+         * The name of the directory which is used to store downloaded videos.
+         */
+        public static final String VIDEOS = "videos";
+        /**
+         * The name of the directory which is used to store subtitles of the
+         * downloaded videos.
+         */
+        public static final String SUBTITLES = "subtitles";
+    }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/FileUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/FileUtil.java
@@ -1,17 +1,36 @@
 package org.edx.mobile.util;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Collections;
+import java.util.List;
 
-/**
- * Created by miankhalid on 8/3/15.
- */
 public class FileUtil {
     private static final int DEFAULT_BUFFER_SIZE = 1024 * 4;
+
+    // Make this class non-instantiable
+    private FileUtil() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Utility function for getting the app's external storage directory.
+     *
+     * @param context The current context.
+     * @return The app's external storage directory.
+     */
+    @Nullable
+    public static File getExternalAppDir(@NonNull Context context) {
+        File externalFilesDir = context.getExternalFilesDir(null);
+        return (externalFilesDir != null ? externalFilesDir.getParentFile() : null);
+    }
 
     /**
      * Returns the text of a file as a String object
@@ -21,13 +40,13 @@ public class FileUtil {
      * @return The text content of the file
      */
     public static String loadTextFileFromAssets
-            (Context context, String fileName) throws IOException {
+    (Context context, String fileName) throws IOException {
         InputStream inputStream = context.getAssets().open(fileName);
         try {
             OutputStream outputStream = new ByteArrayOutputStream();
             try {
                 byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
-                for (int n; (n = inputStream.read(buffer)) >= 0;) {
+                for (int n; (n = inputStream.read(buffer)) >= 0; ) {
                     outputStream.write(buffer, 0, n);
                 }
                 return outputStream.toString();
@@ -37,5 +56,38 @@ public class FileUtil {
         } finally {
             inputStream.close();
         }
+    }
+
+    /**
+     * Deletes a file or directory and all its content recursively.
+     *
+     * @param fileOrDirectory The file or directory that needs to be deleted.
+     */
+    public static void deleteRecursive(@NonNull File fileOrDirectory) {
+        deleteRecursive(fileOrDirectory, Collections.EMPTY_LIST);
+    }
+
+    /**
+     * Deletes a file or directory and all its content recursively.
+     *
+     * @param fileOrDirectory The file or directory that needs to be deleted.
+     * @param exceptions      Names of the files or directories that need to be skipped while deletion.
+     */
+    public static void deleteRecursive(@NonNull File fileOrDirectory,
+                                       @NonNull List<String> exceptions) {
+        if (exceptions.contains(fileOrDirectory.getName())) return;
+
+        if (fileOrDirectory.isDirectory()) {
+            File[] filesList = fileOrDirectory.listFiles();
+            if (filesList != null) {
+                for (File child : filesList) {
+                    deleteRecursive(child, exceptions);
+                }
+            }
+        }
+
+        // Don't break the recursion upon encountering an error
+        // noinspection ResultOfMethodCallIgnored
+        fileOrDirectory.delete();
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/SecurityUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/SecurityUtil.java
@@ -1,0 +1,61 @@
+package org.edx.mobile.util;
+
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.support.annotation.NonNull;
+
+import org.edx.mobile.logger.Logger;
+import org.edx.mobile.module.db.DbStructure;
+import org.edx.mobile.module.prefs.PrefManager;
+
+import java.io.File;
+import java.util.Collections;
+
+/**
+ * Utility class dealing with the security of a user's personal information data.
+ */
+public class SecurityUtil {
+    private static final Logger logger = new Logger(SecurityUtil.class);
+
+    // Make this class non-instantiable
+    private SecurityUtil() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Clears the app's data directory, external storage directory and shared preferences,
+     * with the exceptions of downloaded videos and videos database.
+     *
+     * @param context The current context.
+     */
+    public static void clearUserData(@NonNull Context context) {
+        // Clear the data directory
+        PackageManager packageManager = context.getPackageManager();
+        try {
+            PackageInfo packageInfo = packageManager.getPackageInfo(context.getPackageName(), 0);
+            File dataDir = new File(packageInfo.applicationInfo.dataDir);
+            File[] filesList = dataDir.listFiles();
+            if (filesList != null) {
+                for (final File child : filesList) {
+                    FileUtil.deleteRecursive(child, Collections.singletonList(DbStructure.NAME));
+                }
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+            // Should never happen as we've given our app's package name to getPackageInfo function.
+            logger.error(e);
+        }
+
+        // Now clear the App's external storage directory
+        File externalAppDir = FileUtil.getExternalAppDir(context);
+        File[] filesList = externalAppDir.listFiles();
+        if (filesList != null) {
+            for (final File child : filesList) {
+                FileUtil.deleteRecursive(child, Collections.singletonList(AppConstants.Directories.VIDEOS));
+            }
+        }
+
+        // Now clear the shared preferences
+        PrefManager.nukeSharedPreferences();
+    }
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/Sha1Util.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/Sha1Util.java
@@ -1,27 +1,33 @@
 package org.edx.mobile.util;
 
+import android.support.annotation.NonNull;
+
+import org.edx.mobile.logger.Logger;
+
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 public class Sha1Util {
+    private static final Logger logger = new Logger(Sha1Util.class);
 
     /**
-     * Returns SHA1 hash of the given text.
-     * @param text
-     * @return
-     * @throws NoSuchAlgorithmException
-     * @throws UnsupportedEncodingException
+     * @param text The plain text to hash.
+     * @return SHA1 hash of the given text or the plain text if hashing failed.
      */
-    public static String SHA1(String text) throws NoSuchAlgorithmException,
-            UnsupportedEncodingException {
-        MessageDigest md = MessageDigest.getInstance("SHA-1");
-        md.update(text.getBytes("iso-8859-1"), 0, text.length());
-        byte[] sha1hash = md.digest();
-        return convertToHex(sha1hash);
+    public static String SHA1(@NonNull String text) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            md.update(text.getBytes("iso-8859-1"), 0, text.length());
+            byte[] sha1hash = md.digest();
+            return convertToHex(sha1hash);
+        } catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
+            logger.error(e);
+            return text;
+        }
     }
 
-    private static String convertToHex(byte[] data) {
+    public static String convertToHex(@NonNull byte[] data) {
         StringBuilder buf = new StringBuilder();
         for (byte b : data) {
             int halfbyte = (b >>> 4) & 0x0F;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.java
@@ -12,6 +12,7 @@ import android.view.ViewGroup;
 
 import org.edx.mobile.R;
 import org.edx.mobile.base.BaseFragment;
+import org.edx.mobile.base.MainApplication;
 import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.databinding.FragmentMyCoursesListBinding;
 import org.edx.mobile.databinding.PanelFindCourseBinding;
@@ -27,6 +28,7 @@ import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.prefs.LoginPrefs;
+import org.edx.mobile.task.RestoreVideosCacheDataTask;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.util.ViewAnimationUtil;
 import org.edx.mobile.view.adapters.MyCoursesAdapter;
@@ -69,6 +71,9 @@ public class MyCoursesListFragment extends BaseFragment implements NetworkObserv
         };
         environment.getSegment().trackScreenView(ISegment.Screens.MY_COURSES);
         EventBus.getDefault().register(this);
+
+        // Restore cache of the courses for which the user has downloaded any videos
+        RestoreVideosCacheDataTask.executeInstanceIfNeeded(MainApplication.application);
     }
 
     @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/NavigationFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/NavigationFragment.java
@@ -246,7 +246,7 @@ public class NavigationFragment extends BaseFragment {
 
             @Override
             public void onClick(View v) {
-                environment.getRouter().forceLogout(getActivity(), environment.getSegment(), environment.getNotificationDelegate());
+                environment.getRouter().performManualLogout(getActivity(), environment.getSegment(), environment.getNotificationDelegate());
             }
         });
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
@@ -24,6 +24,7 @@ import org.edx.mobile.module.notification.NotificationDelegate;
 import org.edx.mobile.module.prefs.LoginPrefs;
 import org.edx.mobile.profiles.UserProfileActivity;
 import org.edx.mobile.util.Config;
+import org.edx.mobile.util.SecurityUtil;
 import org.edx.mobile.view.dialog.WebViewDialogActivity;
 import org.edx.mobile.view.my_videos.MyVideosActivity;
 
@@ -264,11 +265,16 @@ public class Router {
     }
 
     /**
-     * this method can be called either through UI [ user clicks LOGOUT button],
-     * or programmatically
+     * Clear the login data and exit to the splash screen. This should only be called internally;
+     * for handling manual logout,
+     * {@link #performManualLogout(Context, ISegment, NotificationDelegate)} should be used instead.
+     *
+     * @param context  The context.
+     * @param segment  The segment object.
+     * @param delegate The notification delegate.
+     * @see #performManualLogout(Context, ISegment, NotificationDelegate)
      */
     public void forceLogout(Context context, ISegment segment, NotificationDelegate delegate) {
-        loginAPI.logOut();
         loginPrefs.clear();
 
         EventBus.getDefault().post(new LogoutEvent());
@@ -279,6 +285,23 @@ public class Router {
         delegate.unsubscribeAll();
 
         showSplashScreen(context);
+    }
+
+    /**
+     * Clears all the user data, revokes the refresh and access tokens, and exit to the splash
+     * screen. This should only be called in response to manual logout by the user; for performing
+     * logout internally (e.g. in response to refresh token expiration),
+     * {@link #forceLogout(Context, ISegment, NotificationDelegate)} should be used instead.
+     *
+     * @param context  The context.
+     * @param segment  The segment object.
+     * @param delegate The notification delegate.
+     * @see #forceLogout(Context, ISegment, NotificationDelegate)
+     */
+    public void performManualLogout(Context context, ISegment segment, NotificationDelegate delegate) {
+        loginAPI.logOut();
+        forceLogout(context, segment, delegate);
+        SecurityUtil.clearUserData(context);
     }
 
     public void showHandouts(Activity activity, EnrolledCoursesResponse courseData) {

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/test/BrowserUtilTest.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/test/BrowserUtilTest.java
@@ -7,10 +7,10 @@ import org.edx.mobile.util.BrowserUtil;
 import org.junit.Test;
 import org.robolectric.RuntimeEnvironment;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-public class UtilTests extends BaseTestCase {
-
+public class BrowserUtilTest extends BaseTestCase {
     @Test
     public void testBrowserOpenUrl() throws Exception {
         String url = "https://courses.edx.org/register";

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/test/Sha1UtilTest.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/test/Sha1UtilTest.java
@@ -1,0 +1,20 @@
+package org.edx.mobile.test;
+
+import org.edx.mobile.util.Sha1Util;
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
+public class Sha1UtilTest extends BaseTestCase {
+    @Test
+    public void testSha1Hashing() {
+        assertEquals("94ca247fff5ad413788a1c8d8c80394a246dba1c", Sha1Util.SHA1("khalid"));
+        assertEquals("d52f2b07afef758721dd630fcbc15f83fa2e42aa", Sha1Util.SHA1("some_vague_string"));
+    }
+
+    @Test
+    public void testConvertToHex() {
+        assertEquals("6b68616c6964", Sha1Util.convertToHex("khalid".getBytes()));
+        assertEquals("736f6d655f76616775655f737472696e67", Sha1Util.convertToHex("some_vague_string".getBytes()));
+    }
+}

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/test/module/DownloadTests.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/test/module/DownloadTests.java
@@ -27,7 +27,7 @@ public class DownloadTests extends BaseTestCase {
     public void testAddDownload() throws Exception {
         File dir = null;
         try {
-           dir = new UserPrefs(RuntimeEnvironment.application, MainApplication.getEnvironment(RuntimeEnvironment.application).getLoginPrefs()).getDownloadFolder();
+           dir = new UserPrefs(RuntimeEnvironment.application, MainApplication.getEnvironment(RuntimeEnvironment.application).getLoginPrefs()).getDownloadDirectory();
         }catch (Exception ex){
             // it happens in CI environment and we should skip the test.
             print( "dir is null, it happens in CI environment and we should skip the test.");


### PR DESCRIPTION
### Description

[MA-2515](https://openedx.atlassian.net/browse/MA-2515)

The PR does 4 main things:

1. Nuke user data except videos and downloads database.
2. Runs migrations of the database to hash the usernames to their SHA1 counterparts.
3. Runs migrations to change the legacy directory structure of how we store videos and their subtitles.
4. Silently fetch and cache course structure of the courses we have downloaded videos of.

### Notes
- To properly test this PR, first make a build out of current master and then overwrite the build from this PR to view the migrations in action.
- Results of migrations are more visible if testing is being done on the emulator (cuz we can see whatever files we want to see from Android Device Monitor).

### Testing
- [x] Manual tests this PR should pass

Following tests should pass on this PR:

1. Make a build from master, download some videos and then make a build from this branch. The directory that stores videos should be updated i.e. previously the videos were stored like this `sdcard/org.edx.mobile/staff/(SHA1_hash_of_video_name)`, now it should appear as `sdcard/org.edx.mobile/videos/(SHA1_of_username)/(SHA1_hash_of_video_name)`.
2. `srtFiles` has been renamed to `subtitles` and has been moved inside `videos` folder.
3. The username field in the database should now have SHA1 representation of the username.
4. After logout, in the app's directory only `databases/download.db` should be there and in the app's external directory only the `videos` folder should remain.

- [x] Database migrations are backwards-compatible

Database has been upgraded from version 5 to version 6.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @1zaman 
- [x] Code review: @BenjiLee 
- [x] Code review: @mdinino  
- [ ] Code review: @bguertin  