### PR TITLE
Invalidate refresh token on logout

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/authentication/LoginAPI.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/authentication/LoginAPI.java
@@ -137,6 +137,11 @@ public class LoginAPI {
         logInEvents.sendData(new LogInEvent());
     }
 
+    public void logOut(@NonNull final String refreshToken) throws HttpException {
+        loginService.revokeAccessToken(config.getOAuthClientId(),
+                refreshToken, ApiConstants.TOKEN_TYPE_REFRESH);
+    }
+
     @NonNull
     public AuthResponse registerUsingEmail(@NonNull Bundle parameters) throws Exception {
         register(parameters);

--- a/VideoLocker/src/main/java/org/edx/mobile/authentication/LoginService.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/authentication/LoginService.java
@@ -1,6 +1,7 @@
 package org.edx.mobile.authentication;
 
 import org.edx.mobile.http.ApiConstants;
+import org.edx.mobile.http.ApiConstants.TokenType;
 import org.edx.mobile.http.HttpException;
 import org.edx.mobile.model.api.ProfileModel;
 import org.edx.mobile.model.api.ResetPasswordResponse;
@@ -61,6 +62,20 @@ public interface LoginService {
     AuthResponse exchangeAccessToken(@Field("access_token") String accessToken,
                                      @Field("client_id") String clientId,
                                      @Path(ApiConstants.GROUP_ID) String groupId) throws HttpException;
+
+    /**
+     * Revoke the specified refresh or access token, along with all other tokens based on the same
+     * application grant.
+     * @param clientId The client ID
+     * @param token The refresh or access token to be revoked
+     * @param tokenTypeHint The type of the token to be revoked; This should be either
+     *                      'access_token' or 'refresh_token'
+     */
+    @FormUrlEncoded
+    @POST(ApiConstants.URL_REVOKE_TOKEN)
+    Response revokeAccessToken(@Field("client_id") String clientId,
+                               @Field("token") String token,
+                               @Field("token_type_hint") @TokenType String tokenTypeHint) throws HttpException;
 
     /**
      * Reset password for account associated with an email address.

--- a/VideoLocker/src/main/java/org/edx/mobile/http/ApiConstants.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/ApiConstants.java
@@ -1,9 +1,13 @@
 package org.edx.mobile.http;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.StringDef;
 
 import org.edx.mobile.module.prefs.LoginPrefs;
 import org.edx.mobile.module.prefs.PrefManager;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
 public class ApiConstants {
     public static final String COURSE_ID = "courseId";
@@ -24,6 +28,8 @@ public class ApiConstants {
 
     public static final String URL_EXCHANGE_ACCESS_TOKEN = "/oauth2/exchange_access_token/{" + GROUP_ID + "}/";
 
+    public static final String URL_REVOKE_TOKEN = "/oauth2/revoke_token/";
+
     public static final String URL_LAST_ACCESS_FOR_COURSE ="/api/mobile/v0.5/users/{username}/course_status_info/{courseId}";
 
     public static final String URL_REGISTRATION = "/user_api/v1/account/registration/";
@@ -31,6 +37,14 @@ public class ApiConstants {
     public static final String URL_ENROLLMENT = "/api/enrollment/v1/enrollment";
 
     public static final String URL_COURSE_OUTLINE = "/api/courses/v1/blocks/?course_id={courseId}&username={username}&depth=all&requested_fields={requested_fields}&student_view_data={student_view_data}&block_counts={block_counts}&nav_depth=3";
+
+    public static final String TOKEN_TYPE_ACCESS = "access_token";
+
+    public static final String TOKEN_TYPE_REFRESH = "refresh_token";
+
+    @StringDef({TOKEN_TYPE_ACCESS, TOKEN_TYPE_REFRESH})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface TokenType {}
 
     public static final int STANDARD_PAGE_SIZE = 20;
 

--- a/VideoLocker/src/main/java/org/edx/mobile/task/LogoutTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/LogoutTask.java
@@ -1,0 +1,28 @@
+package org.edx.mobile.task;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import com.google.inject.Inject;
+
+import org.edx.mobile.authentication.LoginAPI;
+import org.edx.mobile.http.HttpException;
+
+public class LogoutTask extends Task<Void> {
+    @Inject
+    private LoginAPI loginAPI;
+
+    @NonNull
+    private final String refreshToken;
+
+    public LogoutTask(@NonNull final Context context, @NonNull final String refreshToken) {
+        super(context);
+        this.refreshToken = refreshToken;
+    }
+
+    @Override
+    public Void call() throws HttpException {
+        loginAPI.logOut(refreshToken);
+        return null;
+    }
+}


### PR DESCRIPTION
### Description

[MA-2511][]

Upon logging out, and before clearing the access and refresh tokens, send a request to the server to revoke the refresh token and all the access tokens granted on it's basis. This request would only go through if the device is online at the time of logging out; otherwise the tokens will just be deleted locally.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @miankhalid 
- [x] Code review: @BenjiLee

[MA-2511]: https://openedx.atlassian.net/browse/MA-2511