### PR TITLE
Removed unused string that transifex was complaining about

### DIFF
--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -381,12 +381,6 @@
     <string name="view_button_text">View</string>
     <!-- Error text when downloading an item fails -->
     <string name="download_failed_text">Download Failed</string>
-    <!-- Message indicating a number of videos has begun. Argument is a number -->
-    <plurals name="downloading_count_videos">
-        <item quantity="zero">Download Failed</item>
-        <item quantity="one">Downloading {quantity} video</item>
-        <item quantity="other">Downloading {quantity} videos</item>
-    </plurals>
     <!-- Alert dialog title to confirm download of a large quantity of data -->
     <string name="download_exceed_title">Large Download</string>
     <!-- Message shown a single video download begins -->


### PR DESCRIPTION
@bguertin

Transifex complains that English only required 2 plurals. We would have to remove this. Additionally, I guess we would have to add another state in the code for a failed download (WIP)?