### PR TITLE
Add title and content descriptions for profile screen

### DIFF
--- a/VideoLocker/AndroidManifest.xml
+++ b/VideoLocker/AndroidManifest.xml
@@ -225,7 +225,7 @@
         <activity android:name=".profiles.UserProfileActivity"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoShadow"
-            android:label=""/>
+            android:label="@string/profile_title"/>
 
         <activity android:name=".view.EditUserProfileActivity"
             android:screenOrientation="portrait"/>

--- a/VideoLocker/res/values/strings.xml
+++ b/VideoLocker/res/values/strings.xml
@@ -546,6 +546,16 @@
     <string name="forum_unfollow">Unfollow</string>
 
     <!-- User Profiles -->
+    <!-- Window title for the user profile screen -->
+    <string name="profile_title">Profile</string>
+    <!-- The accessibility description for the name section -->
+    <string name="profile_name_description">Name: {name}</string>
+    <!-- The accessibility description for the language section -->
+    <string name="profile_language_description">Language: {language}</string>
+    <!-- The accessibility description for the location section -->
+    <string name="profile_location_description">Location: {location}</string>
+    <!-- The accessibility description for the "About Me" section -->
+    <string name="profile_about_me_description">About me: {about_me}</string>
     <!-- Label for toolbar icon that launches the edit profile screen for the current user -->
     <string name="profile_toolbar_edit_button">Edit</string>
     <!-- Shown when viewing your own profile and you are not sharing a full profile -->

--- a/VideoLocker/src/main/java/org/edx/mobile/profiles/UserProfileBioFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/profiles/UserProfileBioFragment.java
@@ -11,6 +11,7 @@ import android.view.ViewGroup;
 import org.edx.mobile.R;
 import org.edx.mobile.databinding.FragmentUserProfileBioBinding;
 import org.edx.mobile.logger.Logger;
+import org.edx.mobile.util.ResourceUtil;
 import org.edx.mobile.view.PresenterFragment;
 import org.edx.mobile.view.Router;
 
@@ -67,6 +68,7 @@ public class UserProfileBioFragment extends PresenterFragment<UserProfileBioPres
                 viewHolder.noAboutMe.setVisibility(bio.contentType == UserProfileBioModel.ContentType.NO_ABOUT_ME ? View.VISIBLE : View.GONE);
                 viewHolder.bioText.setVisibility(bio.contentType == UserProfileBioModel.ContentType.ABOUT_ME ? View.VISIBLE : View.GONE);
                 viewHolder.bioText.setText(bio.bioText);
+                viewHolder.bioText.setContentDescription(ResourceUtil.getFormattedString(getResources(), R.string.profile_about_me_description, "about_me", bio.bioText));
                 prefersScrollingHeader = bio.contentType == UserProfileBioModel.ContentType.ABOUT_ME;
                 ((ScrollingPreferenceParent)getParentFragment()).onChildScrollingPreferenceChanged();
             }

--- a/VideoLocker/src/main/java/org/edx/mobile/profiles/UserProfileFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/profiles/UserProfileFragment.java
@@ -28,6 +28,7 @@ import org.edx.mobile.module.analytics.ISegment;
 import org.edx.mobile.module.prefs.UserPrefs;
 import org.edx.mobile.user.UserAPI;
 import org.edx.mobile.util.Config;
+import org.edx.mobile.util.ResourceUtil;
 import org.edx.mobile.util.images.ErrorUtils;
 import org.edx.mobile.view.PresenterFragment;
 import org.edx.mobile.view.Router;
@@ -123,17 +124,6 @@ public class UserProfileFragment extends PresenterFragment<UserProfilePresenter,
     protected UserProfilePresenter.ViewInterface createView() {
         viewHolder = DataBindingUtil.getBinding(getView());
 
-        viewHolder.appbar.addOnOffsetChangedListener(new AppBarLayout.OnOffsetChangedListener() {
-            @Override
-            public void onOffsetChanged(AppBarLayout appBarLayout, int verticalOffset) {
-                if (verticalOffset <= -viewHolder.nameText.getBottom()) {
-                    getActivity().setTitle(getUsername());
-                } else {
-                    getActivity().setTitle("");
-                }
-            }
-        });
-
         viewHolder.profileSectionPager.addOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener() {
             @Override
             public void onPageSelected(int position) {
@@ -166,6 +156,8 @@ public class UserProfileFragment extends PresenterFragment<UserProfilePresenter,
                     viewHolder.languageContainer.setVisibility(View.GONE);
                 } else {
                     viewHolder.languageText.setText(profile.language);
+                    viewHolder.languageText.setContentDescription(ResourceUtil.getFormattedString(
+                            getResources(), R.string.profile_language_description, "language", profile.language));
                     viewHolder.languageContainer.setVisibility(View.VISIBLE);
                 }
 
@@ -173,6 +165,8 @@ public class UserProfileFragment extends PresenterFragment<UserProfilePresenter,
                     viewHolder.locationContainer.setVisibility(View.GONE);
                 } else {
                     viewHolder.locationText.setText(profile.location);
+                    viewHolder.locationText.setContentDescription(ResourceUtil.getFormattedString(
+                            getResources(), R.string.profile_location_description, "location", profile.location));
                     viewHolder.locationContainer.setVisibility(View.VISIBLE);
                 }
 
@@ -231,6 +225,8 @@ public class UserProfileFragment extends PresenterFragment<UserProfilePresenter,
             @Override
             public void setName(@NonNull String name) {
                 viewHolder.nameText.setText(name);
+                viewHolder.nameText.setContentDescription(ResourceUtil.getFormattedString(
+                        getResources(), R.string.profile_name_description, "name", name));
             }
 
             @Override


### PR DESCRIPTION
[MA-2718][]

Previously, `UserProfileFragment` set the username as the Activity title if the username was scrolled out of the visible layout, as there was no predefined title. However, since there is now a static title defined for `UserProfileActivity`, this behaviour has been removed.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @miankhalid 
- [ ] Code review: @BenjiLee
- [x] Code review: @bguertin
- [x] UI strings/error msgs review: @catong

[MA-2718]: https://openedx.atlassian.net/browse/MA-2718