### PR TITLE
Hyperlinks made clickable in discussions

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionTextUtils.java
@@ -9,8 +9,11 @@ import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
+import android.text.method.LinkMovementMethod;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.StyleSpan;
+import android.text.style.URLSpan;
+import android.text.util.Linkify;
 import android.view.View;
 import android.widget.TextView;
 
@@ -154,10 +157,10 @@ public abstract class DiscussionTextUtils {
         }
     }
 
-    public static CharSequence parseHtml(@NonNull String html) {
+    public static Spanned parseHtml(@NonNull String html) {
         // If the HTML contains a paragraph at the end, there will be blank lines following the text
         // Therefore, we need to trim the resulting CharSequence to remove those extra lines
-        return trim(Html.fromHtml(html));
+        return (Spanned) trim(Html.fromHtml(html));
     }
 
     public static CharSequence trim(CharSequence s) {
@@ -190,5 +193,28 @@ public abstract class DiscussionTextUtils {
             target.setVisibility(View.VISIBLE);
         }
 
+    }
+
+    /**
+     * Renders various HTML elements and plain hyperlinks in the given HTML to clickable items
+     * while applying it on the given {@link TextView}.
+     *
+     * @param textView The {@link TextView} which will render the given HTML.
+     * @param html     The HTML to render.
+     */
+    public static void renderHtml(@NonNull TextView textView, @NonNull String html) {
+        Spanned spannedHtml = DiscussionTextUtils.parseHtml(html);
+        URLSpan[] urlSpans = spannedHtml.getSpans(0, spannedHtml.length(), URLSpan.class);
+        textView.setAutoLinkMask(Linkify.ALL);
+        textView.setMovementMethod(LinkMovementMethod.getInstance());
+        textView.setText(spannedHtml);
+
+        SpannableString viewText = (SpannableString) textView.getText();
+        for (final URLSpan spanObj : urlSpans) {
+            final int start = spannedHtml.getSpanStart(spanObj);
+            final int end = spannedHtml.getSpanEnd(spanObj);
+            final int flags = spannedHtml.getSpanFlags(spanObj);
+            viewText.setSpan(spanObj, start, end, flags);
+        }
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
@@ -4,9 +4,7 @@ import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.text.Editable;
-import android.text.Html;
 import android.text.TextWatcher;
-import android.text.util.Linkify;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -102,8 +100,7 @@ public class DiscussionAddCommentFragment extends BaseFragment {
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        textViewResponse.setText(Html.fromHtml(discussionResponse.getRenderedBody()));
-        Linkify.addLinks(textViewResponse, Linkify.ALL);
+        DiscussionTextUtils.renderHtml(textViewResponse, discussionResponse.getRenderedBody());
 
         AuthorLayoutViewHolder authorLayoutViewHolder =
                 new AuthorLayoutViewHolder(getView().findViewById(R.id.discussion_user_profile_row));

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.text.Editable;
 import android.text.Html;
 import android.text.TextWatcher;
+import android.text.util.Linkify;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -102,6 +103,7 @@ public class DiscussionAddCommentFragment extends BaseFragment {
         super.onViewCreated(view, savedInstanceState);
 
         textViewResponse.setText(Html.fromHtml(discussionResponse.getRenderedBody()));
+        Linkify.addLinks(textViewResponse, Linkify.ALL);
 
         AuthorLayoutViewHolder authorLayoutViewHolder =
                 new AuthorLayoutViewHolder(getView().findViewById(R.id.discussion_user_profile_row));

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
@@ -4,9 +4,7 @@ import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.text.Editable;
-import android.text.Html;
 import android.text.TextWatcher;
-import android.text.util.Linkify;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -21,6 +19,7 @@ import org.edx.mobile.base.BaseFragment;
 import org.edx.mobile.discussion.DiscussionComment;
 import org.edx.mobile.discussion.DiscussionCommentPostedEvent;
 import org.edx.mobile.discussion.DiscussionService;
+import org.edx.mobile.discussion.DiscussionTextUtils;
 import org.edx.mobile.discussion.DiscussionThread;
 import org.edx.mobile.http.CallTrigger;
 import org.edx.mobile.http.ErrorHandlingCallback;
@@ -98,8 +97,8 @@ public class DiscussionAddResponseFragment extends BaseFragment {
         super.onViewCreated(view, savedInstanceState);
         textViewTitle.setVisibility(View.VISIBLE);
         textViewTitle.setText(discussionThread.getTitle());
-        textViewResponse.setText(Html.fromHtml(discussionThread.getRenderedBody()));
-        Linkify.addLinks(textViewResponse, Linkify.ALL);
+
+        DiscussionTextUtils.renderHtml(textViewResponse, discussionThread.getRenderedBody());
 
         AuthorLayoutViewHolder authorLayoutViewHolder =
                 new AuthorLayoutViewHolder(getView().findViewById(R.id.discussion_user_profile_row));

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.text.Editable;
 import android.text.Html;
 import android.text.TextWatcher;
+import android.text.util.Linkify;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -98,6 +99,7 @@ public class DiscussionAddResponseFragment extends BaseFragment {
         textViewTitle.setVisibility(View.VISIBLE);
         textViewTitle.setText(discussionThread.getTitle());
         textViewResponse.setText(Html.fromHtml(discussionThread.getRenderedBody()));
+        Linkify.addLinks(textViewResponse, Linkify.ALL);
 
         AuthorLayoutViewHolder authorLayoutViewHolder =
                 new AuthorLayoutViewHolder(getView().findViewById(R.id.discussion_user_profile_row));

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -5,6 +5,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.support.v4.widget.TextViewCompat;
 import android.support.v7.widget.RecyclerView;
+import android.text.method.LinkMovementMethod;
+import android.text.util.Linkify;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -154,6 +156,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
         holder.threadTitleTextView.setText(discussionThread.getTitle());
 
         holder.threadBodyTextView.setText(DiscussionTextUtils.parseHtml(discussionThread.getRenderedBody()));
+        Linkify.addLinks(holder.threadBodyTextView, Linkify.ALL);
 
         String groupName = discussionThread.getGroupName();
         if (groupName == null) {
@@ -292,6 +295,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
         }
 
         holder.responseCommentBodyTextView.setText(DiscussionTextUtils.parseHtml(comment.getRenderedBody()));
+        Linkify.addLinks(holder.responseCommentBodyTextView, Linkify.ALL);
 
         if (discussionThread.isClosed() && comment.getChildCount() == 0) {
             holder.addCommentLayout.setEnabled(false);
@@ -482,6 +486,8 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
             numberResponsesViewHolder = new NumberResponsesViewHolder(itemView);
             socialLayoutViewHolder = new DiscussionSocialLayoutViewHolder(itemView);
             discussionReportViewHolder = new DiscussionReportViewHolder(itemView);
+
+            threadBodyTextView.setMovementMethod(LinkMovementMethod.getInstance());
         }
     }
 
@@ -505,6 +511,8 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
             numberResponsesViewHolder = new NumberResponsesViewHolder(itemView);
             socialLayoutViewHolder = new DiscussionSocialLayoutViewHolder(itemView);
             discussionReportViewHolder = new DiscussionReportViewHolder(itemView);
+
+            responseCommentBodyTextView.setMovementMethod(LinkMovementMethod.getInstance());
         }
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -5,8 +5,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.support.v4.widget.TextViewCompat;
 import android.support.v7.widget.RecyclerView;
-import android.text.method.LinkMovementMethod;
-import android.text.util.Linkify;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -155,8 +153,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
 
         holder.threadTitleTextView.setText(discussionThread.getTitle());
 
-        holder.threadBodyTextView.setText(DiscussionTextUtils.parseHtml(discussionThread.getRenderedBody()));
-        Linkify.addLinks(holder.threadBodyTextView, Linkify.ALL);
+        DiscussionTextUtils.renderHtml(holder.threadBodyTextView, discussionThread.getRenderedBody());
 
         String groupName = discussionThread.getGroupName();
         if (groupName == null) {
@@ -294,8 +291,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
             holder.responseAnswerAuthorTextView.setVisibility(View.GONE);
         }
 
-        holder.responseCommentBodyTextView.setText(DiscussionTextUtils.parseHtml(comment.getRenderedBody()));
-        Linkify.addLinks(holder.responseCommentBodyTextView, Linkify.ALL);
+        DiscussionTextUtils.renderHtml(holder.responseCommentBodyTextView, comment.getRenderedBody());
 
         if (discussionThread.isClosed() && comment.getChildCount() == 0) {
             holder.addCommentLayout.setEnabled(false);
@@ -486,8 +482,6 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
             numberResponsesViewHolder = new NumberResponsesViewHolder(itemView);
             socialLayoutViewHolder = new DiscussionSocialLayoutViewHolder(itemView);
             discussionReportViewHolder = new DiscussionReportViewHolder(itemView);
-
-            threadBodyTextView.setMovementMethod(LinkMovementMethod.getInstance());
         }
     }
 
@@ -511,8 +505,6 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
             numberResponsesViewHolder = new NumberResponsesViewHolder(itemView);
             socialLayoutViewHolder = new DiscussionSocialLayoutViewHolder(itemView);
             discussionReportViewHolder = new DiscussionReportViewHolder(itemView);
-
-            responseCommentBodyTextView.setMovementMethod(LinkMovementMethod.getInstance());
         }
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DiscussionCommentsAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DiscussionCommentsAdapter.java
@@ -5,6 +5,8 @@ import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.v4.widget.TextViewCompat;
 import android.support.v7.widget.RecyclerView;
+import android.text.method.LinkMovementMethod;
+import android.text.util.Linkify;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -153,8 +155,8 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
         TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(
                 holder.discussionCommentCountReportTextView, iconDrawable, null, null, null);
 
-        String commentBody = discussionComment.getRawBody();
-        holder.discussionCommentBody.setText(commentBody);
+        holder.discussionCommentBody.setText(DiscussionTextUtils.parseHtml(discussionComment.getRenderedBody()));
+        Linkify.addLinks(holder.discussionCommentBody, Linkify.ALL);
     }
 
     @Override
@@ -206,6 +208,8 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
             discussionCommentBody = (TextView) itemView.findViewById(R.id.discussion_comment_body);
             discussionCommentCountReportTextView = (TextView) itemView.findViewById(R.id.discussion_comment_count_report_text_view);
             authorLayoutViewHolder = new AuthorLayoutViewHolder(itemView.findViewById(R.id.discussion_user_profile_row));
+
+            discussionCommentBody.setMovementMethod(LinkMovementMethod.getInstance());
         }
     }
 

--- a/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DiscussionCommentsAdapter.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/adapters/DiscussionCommentsAdapter.java
@@ -5,8 +5,6 @@ import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.v4.widget.TextViewCompat;
 import android.support.v7.widget.RecyclerView;
-import android.text.method.LinkMovementMethod;
-import android.text.util.Linkify;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -155,8 +153,7 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
         TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(
                 holder.discussionCommentCountReportTextView, iconDrawable, null, null, null);
 
-        holder.discussionCommentBody.setText(DiscussionTextUtils.parseHtml(discussionComment.getRenderedBody()));
-        Linkify.addLinks(holder.discussionCommentBody, Linkify.ALL);
+        DiscussionTextUtils.renderHtml(holder.discussionCommentBody, discussionComment.getRenderedBody());
     }
 
     @Override
@@ -208,8 +205,6 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
             discussionCommentBody = (TextView) itemView.findViewById(R.id.discussion_comment_body);
             discussionCommentCountReportTextView = (TextView) itemView.findViewById(R.id.discussion_comment_count_report_text_view);
             authorLayoutViewHolder = new AuthorLayoutViewHolder(itemView.findViewById(R.id.discussion_user_profile_row));
-
-            discussionCommentBody.setMovementMethod(LinkMovementMethod.getInstance());
         }
     }
 


### PR DESCRIPTION
### Description

[MA-2485](https://openedx.atlassian.net/browse/MA-2485)

Hyperlinks in discussion threads, responses and comments are now tappable and open in browser on tap.

### Testing

1. Open a sandbox's lms.
2. Add a thread with hyperlink in it.
3. Add a response to that thread with hyperlink in it.
4. Add a comment to that response with hyperlink in it.
5. All hyperlinks should appear blue & underlined and open in device's browser upon tap.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @1zaman 
- [x] Code review: @mdinino
