### PR TITLE
Hide keyboard on spinner opening

### DIFF
--- a/VideoLocker/res/layout/fragment_add_post.xml
+++ b/VideoLocker/res/layout/fragment_add_post.xml
@@ -52,7 +52,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/widget_margin">
 
-                <android.support.v7.widget.AppCompatSpinner
+                <org.edx.mobile.view.custom.KeyboardDismissingSpinner
                     android:id="@+id/topics_spinner"
                     style="@style/edX.Widget.Spinner"
                     android:layout_width="match_parent"

--- a/VideoLocker/src/main/java/org/edx/mobile/util/SoftKeyboardUtil.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/SoftKeyboardUtil.java
@@ -23,6 +23,19 @@ public class SoftKeyboardUtil {
     }
 
     /**
+     * Hides the soft keyboard.
+     *
+     * @param view The view object's reference from which we'll get the window token.
+     */
+    public static void hide(@NonNull final View view) {
+        final InputMethodManager iManager = (InputMethodManager) view.getContext().
+                getSystemService(Context.INPUT_METHOD_SERVICE);
+        if (iManager != null) {
+            iManager.hideSoftInputFromWindow(view.getWindowToken(), 0);
+        }
+    }
+
+    /**
      * Hides the soft keyboard by clearing view's focus.
      *
      * @param view The view whose focus needs to be cleared.

--- a/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddPostFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/DiscussionAddPostFragment.java
@@ -5,6 +5,7 @@ import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.annotation.StringRes;
 import android.support.v4.view.ViewCompat;
+import android.support.v7.widget.AppCompatSpinner;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.LayoutInflater;
@@ -14,7 +15,6 @@ import android.widget.AdapterView;
 import android.widget.EditText;
 import android.widget.ProgressBar;
 import android.widget.RadioGroup;
-import android.widget.Spinner;
 import android.widget.TextView;
 
 import com.google.inject.Inject;
@@ -61,7 +61,7 @@ public class DiscussionAddPostFragment extends BaseFragment {
     private RadioGroup discussionQuestionSegmentedGroup;
 
     @InjectView(R.id.topics_spinner)
-    private Spinner topicsSpinner;
+    private AppCompatSpinner topicsSpinner;
 
     @InjectView(R.id.title_edit_text)
     private EditText titleEditText;
@@ -121,7 +121,7 @@ public class DiscussionAddPostFragment extends BaseFragment {
         discussionQuestionSegmentedGroup.check(R.id.discussion_radio_button);
 
         getTopicList();
-
+        
         topicsSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {

--- a/VideoLocker/src/main/java/org/edx/mobile/view/custom/KeyboardDismissingSpinner.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/custom/KeyboardDismissingSpinner.java
@@ -1,0 +1,32 @@
+package org.edx.mobile.view.custom;
+
+import android.content.Context;
+import android.support.v7.widget.AppCompatSpinner;
+import android.util.AttributeSet;
+
+import org.edx.mobile.util.SoftKeyboardUtil;
+
+/**
+ * Subclass of {@link AppCompatSpinner} that dismisses an open keyboard (if visible) on tap.
+ */
+public class KeyboardDismissingSpinner extends AppCompatSpinner {
+
+    public KeyboardDismissingSpinner(Context context) {
+        super(context);
+    }
+
+    public KeyboardDismissingSpinner(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public KeyboardDismissingSpinner(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public boolean performClick() {
+        // Dismiss the keyboard if its being displayed
+        SoftKeyboardUtil.hide(this);
+        return super.performClick();
+    }
+}


### PR DESCRIPTION
### Description

[MA-2458](https://openedx.atlassian.net/browse/MA-2458)

Topics spinner while creating a new discussion post causes the spinner
popup to appear over the already displayed keyboard. Which causes
irregular behaviour upon orientation change as well.
This PR solves this issue by always dismissing keyboard whenever
spinner is tapped.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @1zaman 
- [x] Code review: @mdinino 