### PR TITLE
Crash fix and Profile Pictures put behind a feature flag

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionComment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionComment.java
@@ -171,7 +171,7 @@ public class DiscussionComment implements Serializable, IAuthorData, ProfileImag
     @Nullable
     @Override
     public ProfileImage getProfileImage() {
-        if (users == null) {
+        if (users == null || isAuthorAnonymous()) {
             return null;
         } else {
             return users.get(author).getProfile().getImage();

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionRequestFields.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionRequestFields.java
@@ -2,6 +2,11 @@ package org.edx.mobile.discussion;
 
 import android.support.annotation.NonNull;
 
+import org.edx.mobile.util.Config;
+
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Optional request fields in discussion responses and comments APIs.
  */
@@ -17,9 +22,26 @@ public enum DiscussionRequestFields {
     /**
      * Get the value of the query parameter.
      *
-     * @return The query parameter string
+     * @return The query parameter string.
      */
     public String getQueryParamValue() {
         return queryParamValue;
+    }
+
+    /**
+     * Generate the list of query param values to send for the requested_fields param.
+     *
+     * @param config The Config object to use for conditional param value additions.
+     * @return List of requested fields for query param.
+     */
+    public static List<String> getRequestedFieldsList(@NonNull Config config) {
+        final List<String> requestedFields;
+        if (config.isDiscussionProfilePicturesEnabled()) {
+            requestedFields = Collections.singletonList(
+                    DiscussionRequestFields.PROFILE_IMAGE.getQueryParamValue());
+        } else {
+            requestedFields = Collections.EMPTY_LIST;
+        }
+        return requestedFields;
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionThread.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/discussion/DiscussionThread.java
@@ -234,7 +234,7 @@ public class DiscussionThread implements Serializable, IAuthorData, ProfileImage
     @Nullable
     @Override
     public ProfileImage getProfileImage() {
-        if (users == null) {
+        if (users == null || isAuthorAnonymous()) {
             return null;
         } else {
             return users.get(author).getProfile().getImage();

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetCommentsListTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetCommentsListTask.java
@@ -7,9 +7,6 @@ import org.edx.mobile.discussion.DiscussionComment;
 import org.edx.mobile.discussion.DiscussionRequestFields;
 import org.edx.mobile.model.Page;
 
-import java.util.Collections;
-import java.util.List;
-
 public abstract class GetCommentsListTask extends Task<Page<DiscussionComment>> {
 
     private static final int PAGE_SIZE = 20;
@@ -25,9 +22,7 @@ public abstract class GetCommentsListTask extends Task<Page<DiscussionComment>> 
     }
 
     public Page<DiscussionComment> call() throws Exception {
-        List<String> requestedFields = Collections.singletonList(
-                DiscussionRequestFields.PROFILE_IMAGE.getQueryParamValue());
         return environment.getDiscussionAPI().getCommentsList(responseId, PAGE_SIZE, page,
-                requestedFields);
+                DiscussionRequestFields.getRequestedFieldsList(environment.getConfig()));
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetResponsesListTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetResponsesListTask.java
@@ -7,7 +7,6 @@ import org.edx.mobile.discussion.DiscussionComment;
 import org.edx.mobile.discussion.DiscussionRequestFields;
 import org.edx.mobile.model.Page;
 
-import java.util.Collections;
 import java.util.List;
 
 public abstract class GetResponsesListTask extends Task<Page<DiscussionComment>> {
@@ -28,8 +27,8 @@ public abstract class GetResponsesListTask extends Task<Page<DiscussionComment>>
     }
 
     public Page<DiscussionComment> call() throws Exception {
-        List<String> requestedFields = Collections.singletonList(
-                DiscussionRequestFields.PROFILE_IMAGE.getQueryParamValue());
+        final List<String> requestedFields = DiscussionRequestFields.getRequestedFieldsList(
+                environment.getConfig());
         if (isQuestionType) {
             return environment.getDiscussionAPI().getResponsesListForQuestion(threadId,
                     page, shouldGetEndorsed, requestedFields);

--- a/VideoLocker/src/main/java/org/edx/mobile/task/GetThreadListTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/GetThreadListTask.java
@@ -41,8 +41,8 @@ public abstract class GetThreadListTask extends Task<Page<DiscussionThread>> {
     }
 
     public Page<DiscussionThread> call() throws Exception {
-        List<String> requestedFields = Collections.singletonList(
-                DiscussionRequestFields.PROFILE_IMAGE.getQueryParamValue());
+        final List<String> requestedFields = DiscussionRequestFields.getRequestedFieldsList(
+                environment.getConfig());
         if (!topic.isFollowingType()) {
             return environment.getDiscussionAPI().getThreadList(courseId,
                     getAllTopicIds(), filter.getQueryParamValue(),

--- a/VideoLocker/src/main/java/org/edx/mobile/task/SearchThreadListTask.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/task/SearchThreadListTask.java
@@ -28,9 +28,7 @@ public abstract class SearchThreadListTask extends
     }
 
     public Page<DiscussionThread> call() throws Exception {
-        List<String> requestedFields = Collections.singletonList(
-                DiscussionRequestFields.PROFILE_IMAGE.getQueryParamValue());
         return environment.getDiscussionAPI().searchThreadList(courseId, text, page,
-                requestedFields);
+                DiscussionRequestFields.getRequestedFieldsList(environment.getConfig()));
     }
 }

--- a/VideoLocker/src/main/java/org/edx/mobile/util/Config.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/util/Config.java
@@ -61,6 +61,7 @@ public class Config {
     private static final String SERVER_SIDE_CHANGED_THREAD = "SERVER_SIDE_CHANGED_THREAD";
     private static final String END_TO_END_TEST = "END_TO_END_TEST";
     private static final String NEW_LOGISTRATION_ENABLED = "NEW_LOGISTRATION_ENABLED";
+    private static final String DISCUSSIONS_ENABLE_PROFILE_PICTURE_PARAM = "DISCUSSIONS_ENABLE_PROFILE_PICTURE_PARAM";
 
     public static class ZeroRatingConfig {
         @SerializedName("ENABLED")
@@ -417,6 +418,10 @@ public class Config {
 
     public boolean isNewLogistrationEnabled() {
         return getBoolean(NEW_LOGISTRATION_ENABLED, false);
+    }
+
+    public boolean isDiscussionProfilePicturesEnabled() {
+        return getBoolean(DISCUSSIONS_ENABLE_PROFILE_PICTURE_PARAM, false);
     }
 
     /**


### PR DESCRIPTION
### Description

[MA-2692](https://openedx.atlassian.net/browse/MA-2692) & [MA-2692](https://openedx.atlassian.net/browse/MA-2750)

This PR fixes 2 tightly coupled issues which are as follows:

1. Crash handling when author is null
   - Server sometimes returns null for an author's name i.e. if a post is
added anonymously, which causes our logic for getting a user's profile
image to throw NPE, which is what the 1st commit fixes.
2. Profile pictures put behind a feature flag
   - DISCUSSIONS_ENABLE_PROFILE_PICTURE_PARAM has been introduced to enable/
disable the profile pictures in Discussions.
   - Currently stage has some obsolete data which doesn't allow profile
pictures to work properly on it. So, the 2nd commit fixes the issue by putting
the feature behind a feature-flag.
   - If the flag is disabled we don't send the query param required for GET
request to send profile pictures in response.

### Notes
- The feature flag PR is still in review so while testing you'll have to checkout the respective branches for sandbox config and normal config.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @1zaman 
- [ ] Code review: @bguertin 
- [x] Code review: @mdinino 