### PR TITLE
WIP: Fix logout on expired token

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/http/OauthRefreshTokenAuthenticator.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/OauthRefreshTokenAuthenticator.java
@@ -36,6 +36,7 @@ public class OauthRefreshTokenAuthenticator implements Authenticator {
 
     private final Logger logger = new Logger(getClass().getName());
     private final static String TOKEN_EXPIRED_ERROR_MESSAGE = "token_expired";
+    private final static String TOKEN_NONEXISTENT_ERROR_MESSAGE = "token_nonexistent";
     private Context context;
 
     @Inject
@@ -53,9 +54,23 @@ public class OauthRefreshTokenAuthenticator implements Authenticator {
     public Request authenticate(Route route, final Response response) throws IOException {
         logger.warn(response.toString());
 
+        final AuthResponse meh = loginPrefs.getCurrentAuth();
+        logger.warn("#####################START########################");
+        logger.warn(meh.access_token);
+        logger.warn("##################################################");
+
+
         if (!isTokenExpired(response.peekBody(HttpStatus.OK).string())) {
-            return null;
+            if (doesTokenExist(response.peekBody(HttpStatus.OK).string())) {
+                final AuthResponse currentAuth = loginPrefs.getCurrentAuth();
+                return response.request().newBuilder()
+                        .header("Authorization", currentAuth.token_type + " " + currentAuth.access_token)
+                        .build();
+            } else {
+                return null;
+            }
         }
+
 
         final AuthResponse currentAuth = loginPrefs.getCurrentAuth();
         if (null == currentAuth || null == currentAuth.refresh_token) {
@@ -96,6 +111,19 @@ public class OauthRefreshTokenAuthenticator implements Authenticator {
             JSONObject jsonObj = new JSONObject(responseBody);
             String errorCode = jsonObj.getString("error_code");
             return errorCode.equals(TOKEN_EXPIRED_ERROR_MESSAGE);
+        } catch (JSONException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks the if the error_code in the response body is the token_expired error code.
+     */
+    private boolean doesTokenExist(String responseBody) {
+        try {
+            JSONObject jsonObj = new JSONObject(responseBody);
+            String errorCode = jsonObj.getString("error_code");
+            return errorCode.equals(TOKEN_NONEXISTENT_ERROR_MESSAGE);
         } catch (JSONException ex) {
             return false;
         }

--- a/VideoLocker/src/main/java/org/edx/mobile/http/OauthRefreshTokenAuthenticator.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/OauthRefreshTokenAuthenticator.java
@@ -54,14 +54,8 @@ public class OauthRefreshTokenAuthenticator implements Authenticator {
     public Request authenticate(Route route, final Response response) throws IOException {
         logger.warn(response.toString());
 
-        final AuthResponse meh = loginPrefs.getCurrentAuth();
-        logger.warn("#####################START########################");
-        logger.warn(meh.access_token);
-        logger.warn("##################################################");
-
-
         if (!isTokenExpired(response.peekBody(HttpStatus.OK).string())) {
-            if (doesTokenExist(response.peekBody(HttpStatus.OK).string())) {
+            if (doesTokenNonexistent(response.peekBody(HttpStatus.OK).string())) {
                 final AuthResponse currentAuth = loginPrefs.getCurrentAuth();
                 return response.request().newBuilder()
                         .header("Authorization", currentAuth.token_type + " " + currentAuth.access_token)
@@ -117,9 +111,9 @@ public class OauthRefreshTokenAuthenticator implements Authenticator {
     }
 
     /**
-     * Checks the if the error_code in the response body is the token_expired error code.
+     * Checks the if the error_code in the response body is the token_nonexistent error code.
      */
-    private boolean doesTokenExist(String responseBody) {
+    private boolean doesTokenNonexistent(String responseBody) {
         try {
             JSONObject jsonObj = new JSONObject(responseBody);
             String errorCode = jsonObj.getString("error_code");


### PR DESCRIPTION
### Description

[MA-2822](https://openedx.atlassian.net/browse/MA-2822)

What?
When opening the app with an expired token, the user is logged out. 

Why?
Two asynchronous calls are made on app open. One of these calls gets the refreshed token and works properly.  When a token is refreshed, the old one is invalidated. The other call, which also sent the expired token, receives a "token_nonexistent" error which forces logout. 

Options:
a. This PR has a less than ideal fix. If the token is non_existent then we should retry the request with updated access tokens. This will only retry 1 or 2 times (not implemented yet). 
b. Add an API call on app start to refresh the token if expired.
c. Make the two API calls on app opening synchronous.
d. Add some sort of lock when refreshing tokens so when other calls receive a 401, it is put on a queue to wait for the refresh flow to finish. Then reattempt the call with fresh tokens.
e. Add a version to the token, and if a token_nonexistent occurs, check the version. http://stackoverflow.com/questions/30506983/oauth2-how-to-solve-the-issue-with-expired-accesstoken-during-multiple-async-ap

D, but also the more complicated solution. 

e also looks more long term.

A is pretty much done and could be released right away.

Thoughts?

@bguertin @mdinino @miankhalid @1zaman 



