### PR TITLE
Addressed unwanted logout when opening app

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/http/OauthRefreshTokenAuthenticator.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/http/OauthRefreshTokenAuthenticator.java
@@ -36,6 +36,8 @@ public class OauthRefreshTokenAuthenticator implements Authenticator {
 
     private final Logger logger = new Logger(getClass().getName());
     private final static String TOKEN_EXPIRED_ERROR_MESSAGE = "token_expired";
+    private final static String TOKEN_NONEXISTENT_ERROR_MESSAGE = "token_nonexistent";
+    private final static String TOKEN_INVALID_GRANT_ERROR_MESSAGE = "invalid_grant";
     private Context context;
 
     @Inject
@@ -43,6 +45,7 @@ public class OauthRefreshTokenAuthenticator implements Authenticator {
 
     @Inject
     LoginPrefs loginPrefs;
+
 
     public OauthRefreshTokenAuthenticator(Context context) {
         this.context = context;
@@ -53,14 +56,26 @@ public class OauthRefreshTokenAuthenticator implements Authenticator {
     public Request authenticate(Route route, final Response response) throws IOException {
         logger.warn(response.toString());
 
-        if (!isTokenExpired(response.peekBody(200).string())) {
-            return null;
-        }
-
         final AuthResponse currentAuth = loginPrefs.getCurrentAuth();
         if (null == currentAuth || null == currentAuth.refresh_token) {
             return null;
         }
+        String response_body = response.peekBody(200).string();
+
+        switch (getErrorCode(response_body)) {
+            case TOKEN_EXPIRED_ERROR_MESSAGE:
+                break;
+            case TOKEN_NONEXISTENT_ERROR_MESSAGE:
+            case TOKEN_INVALID_GRANT_ERROR_MESSAGE:
+                if (!response.request().headers().get("Authorization").split(" ")[1].equals(currentAuth.access_token)) {
+                    return response.request().newBuilder()
+                            .header("Authorization", currentAuth.token_type + " " + currentAuth.access_token)
+                            .build();
+                }
+            default:
+                return null;
+        }
+
         final AuthResponse refreshedAuth;
         try {
             refreshedAuth = refreshAccessToken(currentAuth);
@@ -88,16 +103,12 @@ public class OauthRefreshTokenAuthenticator implements Authenticator {
         return refreshTokenResponse;
     }
 
-    /**
-     * Checks the if the error_code in the response body is the token_expired error code.
-     */
-    private boolean isTokenExpired(String responseBody) {
+    private String getErrorCode(String responseBody) {
         try {
             JSONObject jsonObj = new JSONObject(responseBody);
-            String errorCode = jsonObj.getString("error_code");
-            return errorCode.equals(TOKEN_EXPIRED_ERROR_MESSAGE);
+            return jsonObj.getString("error_code");
         } catch (JSONException ex) {
-            return false;
+            return null;
         }
     }
 }


### PR DESCRIPTION
### Description

[MA-2822](https://openedx.atlassian.net/browse/MA-2822)

Quick fix for bug that forces logout when opening app. Checks for the two cases described below and reattempts the request if the access_token used in the original request does not match the current access_token which had been refreshed.

Case 1: When opening app with an expired token, there are 2 asynchronous calls. When one call successfully refreshes the access_token, the old one is deleted. The other call, which had sent the deleted access_token, will return a 401 nonexistent token error which causes a logout. 

Case 2: When opening app with an expired token, there are 2 asynchronous calls. Only 1 refresh is permitted per refresh token. When both calls are returned 401s, both calls attempt a refresh. Only one succeeds and the other is returns a 401 invalid grant error which causes a logout.

One solution was to lock the refresh flow so that all requests are queued up during the process rather than having the two cases above occur. The actual implementation did not come to mind easily so this PR is a hotfix that we can release sooner than later. **This fix will be it's own release (2.6.3)** 

### Testing
Mobile-dev is currently set to have access tokens that expire in 5 seconds. You can test that the app doesn't log out on app close without waiting too long.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @bguertin 
- [x] Code review: @mdinino 
- [ ] Code review: @miankhalid 
- [ ] Code review: @1zaman 

