### PR TITLE
Hide post creation button while topic is loading

### DIFF
--- a/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
+++ b/VideoLocker/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
@@ -127,8 +127,8 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
         super.onViewCreated(view, savedInstanceState);
 
         if (discussionTopic == null) {
-            // Disable the button for adding new posts until the topic is loaded.
-            createNewPostLayout.setEnabled(false);
+            // Hide the button for adding new posts until the topic is loaded.
+            createNewPostLayout.setVisibility(View.GONE);
             // Either we are coming from a deep link or courseware's inline discussion
             fetchDiscussionTopic();
         } else {
@@ -239,8 +239,8 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
                                 populatePostListRunnable.run();
                             }
 
-                            // Now that we have the topic date, we can allow the user to add new posts.
-                            createNewPostLayout.setEnabled(true);
+                            // Now that we have the topic data, we can allow the user to add new posts.
+                            createNewPostLayout.setVisibility(View.VISIBLE);
                         }
                     }
                 });


### PR DESCRIPTION
### Description

[MA-2540](https://openedx.atlassian.net/browse/MA-2540)

Previously we disabled the button which turned out to be a bad UX, so,
now we hide it until we've receive the topic data.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @1zaman 
- [x] Code review: @mdinino 