### PR TITLE
Don't truncate course name on detail page

### DIFF
--- a/OpenEdXMobile/res/layout/fragment_course_dashboard.xml
+++ b/OpenEdXMobile/res/layout/fragment_course_dashboard.xml
@@ -18,24 +18,25 @@
                 android:id="@+id/header_image_view"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:scaleType="fitXY"
                 android:contentDescription="@null"
+                android:scaleType="fitXY"
                 tools:src="@drawable/placeholder_course_card_image" />
 
             <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="70dp"
+                android:layout_height="wrap_content"
                 android:layout_gravity="bottom"
                 android:background="@color/transparent_white_85"
+                android:minHeight="@dimen/course_detail_card_height"
                 android:orientation="horizontal">
 
                 <LinearLayout
                     android:layout_width="0dp"
-                    android:layout_height="match_parent"
+                    android:layout_height="wrap_content"
                     android:layout_gravity="bottom"
                     android:layout_weight="1"
                     android:orientation="vertical"
-                    android:padding="10dp">
+                    android:padding="@dimen/widget_margin">
 
                     <TextView
                         android:id="@+id/course_detail_name"
@@ -52,12 +53,12 @@
 
                 <ImageButton
                     android:id="@+id/course_detail_share"
-                    android:layout_width="36dp"
-                    android:layout_height="36dp"
+                    android:layout_width="@dimen/course_detail_share_icon_size"
+                    android:layout_height="@dimen/course_detail_share_icon_size"
                     android:layout_gravity="bottom|right"
                     android:background="@null"
                     android:contentDescription="@string/share_course_button"
-                    android:padding="10dp"
+                    android:padding="@dimen/widget_margin"
                     android:scaleType="fitCenter"
                     android:src="@drawable/abc_ic_menu_share_mtrl_alpha"
                     android:tint="@color/black"
@@ -66,31 +67,30 @@
 
             <ImageView
                 android:id="@+id/header_play_icon"
-                android:layout_width="60dp"
-                android:layout_height="60dp"
+                android:layout_width="@dimen/course_card_play_icon_size"
+                android:layout_height="@dimen/course_card_play_icon_size"
                 android:layout_gravity="center"
                 android:clickable="false"
+                android:contentDescription="@string/go_to_video"
                 android:focusable="false"
                 android:focusableInTouchMode="false"
-                android:contentDescription="@string/go_to_video"
                 android:scaleType="fitXY"
                 android:src="@drawable/ic_media_play_inactive"
                 android:tint="@color/black"
-                android:visibility="invisible" />
+                android:visibility="invisible"
+                tools:visibility="visible" />
 
         </FrameLayout>
 
         <View style="@style/gray_hairline_separator" />
 
-
         <LinearLayout
             android:id="@+id/dashboard_detail"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
             android:divider="@drawable/edx_divider"
-            android:showDividers="middle|end">
-        </LinearLayout>
+            android:orientation="vertical"
+            android:showDividers="middle|end" />
 
     </LinearLayout>
 

--- a/OpenEdXMobile/res/values/dimens.xml
+++ b/OpenEdXMobile/res/values/dimens.xml
@@ -43,7 +43,9 @@
 
     <!-- Course Card -->
     <dimen name="course_card_height">190dp</dimen>
+    <dimen name="course_card_play_icon_size">60dp</dimen>
     <dimen name="course_detail_card_height">70dp</dimen>
+    <dimen name="course_detail_share_icon_size">36dp</dimen>
 
     <!-- Course Dashboard-->
     <dimen name="dashboard_nav_element_height">85dp</dimen>

--- a/OpenEdXMobile/res/values/text_styles.xml
+++ b/OpenEdXMobile/res/values/text_styles.xml
@@ -268,7 +268,7 @@
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginBottom">3dp</item>
-        <item name="android:textSize">@dimen/edx_x_large</item>
+        <item name="android:textSize">@dimen/edx_large</item>
         <item name="android:singleLine">true</item>
         <item name="android:ellipsize">end</item>
     </style>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/CourseEntry.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/CourseEntry.java
@@ -1,17 +1,15 @@
 package org.edx.mobile.model.api;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.google.inject.Inject;
-
 import org.edx.mobile.social.SocialMember;
-import org.edx.mobile.util.Config;
+import org.edx.mobile.util.UnicodeCharacters;
 import org.edx.mobile.util.UrlUtil;
 import org.edx.mobile.util.images.CourseCardUtils;
 
 import java.io.Serializable;
-import java.net.URISyntaxException;
 import java.util.List;
 
 @SuppressWarnings("serial")
@@ -24,7 +22,7 @@ public class CourseEntry implements Serializable {
     private String end; // completion date
     private String start_display;
     private StartType start_type;
-    private String name;
+    @NonNull private String name;
     private String org;
     private String video_outline;
     private String course_about;
@@ -37,7 +35,7 @@ public class CourseEntry implements Serializable {
     private String discussion_url;
     private SocialURLModel social_urls;
     private CoursewareAccess courseware_access;
-    
+
     public LatestUpdateModel getLatest_updates() {
         return latest_updates;
     }
@@ -88,11 +86,12 @@ public class CourseEntry implements Serializable {
         this.start_type = start_type;
     }
 
+    @NonNull
     public String getName() {
-        return name;
+        return name.replaceAll("-", String.valueOf(UnicodeCharacters.NON_BREAKING_HYPHEN));
     }
 
-    public void setName(String name) {
+    public void setName(@NonNull String name) {
         this.name = name;
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/UnicodeCharacters.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/UnicodeCharacters.java
@@ -1,0 +1,16 @@
+package org.edx.mobile.util;
+
+/**
+ * A collection of Unicode characters that may be ambiguous when rendered directly as literals.
+ */
+public class UnicodeCharacters {
+    // Make this class non-instantiable
+    private UnicodeCharacters() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * A variant of hyphen that doesn't allow line-breaking when read by a word processor.
+     */
+    public static final char NON_BREAKING_HYPHEN = '\u2011';
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDashboardFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDashboardFragment.java
@@ -70,6 +70,9 @@ public class CourseDashboardFragment extends BaseFragment {
             parent = (LinearLayout) view.findViewById(R.id.dashboard_detail);
             shareButton = (ImageButton) view.findViewById(R.id.course_detail_share); //invisible by default
 
+            // Full course name should appear on the course's dashboard screen.
+            courseTextName.setEllipsize(null);
+            courseTextName.setSingleLine(false);
         } else {
             view = inflater.inflate(R.layout.fragment_course_dashboard_disabled, container, false);
             errorText = (TextView) view.findViewById(R.id.error_msg);


### PR DESCRIPTION
### Description

[MA-2529](https://openedx.atlassian.net/browse/MA-2529)

- Truncation removed for course name on the course dashboard screen.
- Dimensions in the layout standardised.
- Autoformat done on the layout.

### Notes
**I didn't refactor the whole layout (actually didn't look deeply into it if there were some optimization I could do) but I did standardize the hardcoded dimensions and autoformat the layout.**

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @1zaman 
- [x] Code review: @mdinino 
