### PR TITLE
MA-2455 MA-2904 Fixed colors for discussions button

### DIFF
--- a/OpenEdXMobile/res/drawable/edx_brand_single_state_button.xml
+++ b/OpenEdXMobile/res/drawable/edx_brand_single_state_button.xml
@@ -2,13 +2,6 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <selector xmlns:android="http://schemas.android.com/apk/res/android">
-            <item android:state_enabled="false">
-                <shape android:shape="rectangle">
-                    <solid android:color="@color/edx_brand_primary_back" />
-                    <corners android:radius="@dimen/edx_box_radius" />
-                    <stroke android:color="@color/edx_brand_gray_back" android:width="@dimen/edx_hairline" />
-                </shape>
-            </item>
             <item>
                 <shape android:shape="rectangle">
                     <solid android:color="@color/edx_brand_primary_base" />

--- a/OpenEdXMobile/res/layout/fragment_add_post.xml
+++ b/OpenEdXMobile/res/layout/fragment_add_post.xml
@@ -80,7 +80,7 @@
                 android:layout_height="wrap_content"
                 android:hint="@string/discussion_post_title"
                 android:inputType="text"
-                android:singleLine="true" />
+                android:maxLines="1" />
 
             <EditText
                 android:id="@+id/body_edit_text"

--- a/OpenEdXMobile/res/values/styles.xml
+++ b/OpenEdXMobile/res/values/styles.xml
@@ -369,7 +369,7 @@
     </style>
 
     <style name="edX.Widget.SignInButton" parent="regular_white_text">
-        <!-- When this style is used, it is always wrapped by edX.Widget.CreationButtonLayout -->
+        <!-- When this style is used, it is always wrapped by edX.Widget.SignInButtonLayout -->
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_gravity">center</item>
@@ -385,7 +385,7 @@
         <item name="android:paddingLeft">@dimen/widget_margin</item>
         <item name="android:paddingRight">@dimen/widget_margin</item>
         <item name="android:minHeight">@dimen/edx_button_height</item>
-        <item name="android:background">@drawable/edx_brand_button</item>
+        <item name="android:background">@drawable/edx_brand_single_state_button</item>
     </style>
 
     <style name="edX.Widget.CreationButton">
@@ -393,7 +393,7 @@
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_gravity">center</item>
-        <item name="android:textColor">@color/edx_brand_button_text</item>
+        <item name="android:textColor">@color/white</item>
         <item name="android:textSize">@dimen/edx_small</item>
         <item name="android:duplicateParentState">true</item>
     </style>


### PR DESCRIPTION
### Description

[MA-2455](https://openedx.atlassian.net/browse/MA-2455)
[MA-2904](https://openedx.atlassian.net/browse/MA-2904)

Addressing feedback from QA.

The Discussions post to add a post/response/comment changed color. This PR addresses the change.

@lizcohen I'm trying to follow the discussions UI patterns in https://openedx.atlassian.net/wiki/display/MA/Mobile+Discussions+UI+fixes and I noticed that the original (below) text and button color are not a11y friendly for contrast ratio. 

Original/Updated
<img src="https://cloud.githubusercontent.com/assets/7101723/18836231/08b8fb64-83cd-11e6-910c-d62dcfb99d2b.png" width="250" /> <img src="https://cloud.githubusercontent.com/assets/7101723/18838045/fb1eb4f6-83d3-11e6-8fc1-290573eccba7.png" width="250" />

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @bguertin @miankhalid @mdinino 
- [ ] UX review: @lizcohen
