### PR TITLE
Added optional config for setting app shortcut name

### DIFF
--- a/OpenEdXMobile/AndroidManifest.xml
+++ b/OpenEdXMobile/AndroidManifest.xml
@@ -41,7 +41,7 @@
 
         <activity
             android:name="org.edx.mobile.view.SplashActivity"
-            android:label="@string/app_name"
+            android:label="@string/app_shortcut_name"
             android:screenOrientation="portrait"
             android:theme="@android:style/Theme.NoDisplay">
             <intent-filter>

--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -279,6 +279,12 @@ android {
         def platformName = config.get('PLATFORM_NAME')
         resValue "string", "platform_name", platformName
 
+        def appShortcutName = config.get('APP_SHORTCUT_NAME')
+        if (appShortcutName == null) {
+            appShortcutName = platformName
+        }
+        resValue "string", "shortcut_name", appShortcutName
+
         def phoneticPlatformName = config.get('PHONETIC_PLATFORM_NAME')
         if (phoneticPlatformName == null) {
             phoneticPlatformName = platformName

--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">@string/platform_name</string>
+    <string name="app_shortcut_name">@string/shortcut_name</string>
     <string name="phonetic_app_name">@string/phonetic_platform_name</string>
 
     <!-- Certificates -->


### PR DESCRIPTION
### Description

[MA-2915](https://openedx.atlassian.net/browse/MA-2915)

Adds option to set a shortcut name for the app. If not set, defaults to platform name.

Uses new config setting "APP_SHORTCUT_NAME"

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @mdinino @bguertin @miankhalid @1zaman 

