### PR TITLE
Partial revert of PR 794

### DIFF
--- a/OpenEdXMobile/res/layout/activity_register.xml
+++ b/OpenEdXMobile/res/layout/activity_register.xml
@@ -113,7 +113,6 @@
 
         </LinearLayout>
     </ScrollView>
-
     <TextView
         android:id="@+id/flying_message"
         style="@style/flying_message"

--- a/OpenEdXMobile/res/layout/activity_single_fragment_base.xml
+++ b/OpenEdXMobile/res/layout/activity_single_fragment_base.xml
@@ -30,11 +30,20 @@
                     android:layout_height="match_parent"
                     android:orientation="vertical">
 
-                    <View
-                        android:id="@+id/offline_bar"
-                        style="@style/offline_bar"
-                        android:layout_alignParentTop="true"
-                        android:visibility="gone" />
+                <LinearLayout
+                    android:id="@+id/error_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone">
+
+                    <include layout="@layout/panel_error_message_with_title"/>
+                </LinearLayout>
+
+                <View
+                    android:id="@+id/offline_bar"
+                    style="@style/offline_bar"
+                    android:layout_alignParentTop="true"
+                    android:visibility="gone" />
 
                     <RelativeLayout
                         android:id="@+id/my_groups_list_container"

--- a/OpenEdXMobile/res/layout/panel_error_message_with_title.xml
+++ b/OpenEdXMobile/res/layout/panel_error_message_with_title.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_error_dialog"
+    android:orientation="vertical"
+    android:paddingLeft="20dp"
+    android:paddingRight="20dp"
+    android:paddingTop="10dp">
+
+    <TextView
+        android:id="@+id/error_header"
+        style="@style/semibold_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/error_heading"
+        android:textColor="@color/grey_text_mycourse"
+        android:textSize="14sp" />
+
+    <TextView
+        android:id="@+id/error_message"
+        style="@style/regular_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/error_message"
+        android:textColor="@color/edx_error_text"
+        android:textSize="16sp" />
+</LinearLayout>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
@@ -18,6 +18,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.google.inject.Inject;
@@ -478,6 +479,31 @@ public abstract class BaseFragmentActivity extends BaseAppActivity
                 });
             }
         }
+    }
+
+    public boolean showErrorMessage(String header, String message) {
+        return showErrorMessage(header, message, true);
+    }
+
+    public boolean showErrorMessage(String header, String message, boolean isPersistent) {
+        LinearLayout error_layout = (LinearLayout) findViewById(R.id.error_layout);
+        if (error_layout == null) {
+            logger.warn("Error Layout not available, so couldn't show flying message");
+            return false;
+        }
+        TextView errorHeader = (TextView) findViewById(R.id.error_header);
+        TextView errorMessageView = (TextView) findViewById(R.id.error_message);
+        if (header == null || header.isEmpty()) {
+            errorHeader.setVisibility(View.GONE);
+        } else {
+            errorHeader.setVisibility(View.VISIBLE);
+            errorHeader.setText(header);
+        }
+        if (message != null) {
+            errorMessageView.setText(message);
+        }
+        ViewAnimationUtil.showMessageBar(error_layout, isPersistent);
+        return true;
     }
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseSingleFragmentActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseSingleFragmentActivity.java
@@ -5,7 +5,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
-import android.support.v4.widget.DrawerLayout;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.widget.ProgressBar;
@@ -122,7 +121,7 @@ public abstract class BaseSingleFragmentActivity extends BaseFragmentActivity im
         //TODO - -we need to define different UI message view for different message type?
         switch (messageType) {
             case FLYIN_ERROR:
-                this.showErrorDialog(null, message);
+                this.showErrorMessage("", message);
                 break;
             case FLYIN_WARNING:
             case FLYIN_INFO:

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/social/SocialLoginDelegate.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/social/SocialLoginDelegate.java
@@ -4,8 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.view.View;
 
 import com.google.inject.Inject;
@@ -265,7 +263,7 @@ public class SocialLoginDelegate {
 
         void onUserLoginSuccess(ProfileModel profile);
 
-        void showErrorDialog(@Nullable String title, @NonNull String message);
+        void showErrorDialog(String header, String message);
     }
 
     public interface SocialUserInfoCallback {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
@@ -334,7 +334,7 @@ public abstract  class CourseBaseActivity  extends BaseFragmentActivity implemen
     }
 
     public void onMessage(@NonNull MessageType messageType, @NonNull String message){
-        showErrorDialog(null, message);
+        showErrorMessage("", message);
     }
 }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/LoginActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/LoginActivity.java
@@ -8,8 +8,10 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
 import android.support.v7.app.ActionBar;
 import android.view.Menu;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.view.animation.Animation;
 
 import com.google.inject.Inject;
 
@@ -31,6 +33,7 @@ import org.edx.mobile.util.Config;
 import org.edx.mobile.util.IntentFactory;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.util.ResourceUtil;
+import org.edx.mobile.util.ViewAnimationUtil;
 import org.edx.mobile.view.dialog.ResetPasswordActivity;
 import org.edx.mobile.view.dialog.SimpleAlertDialog;
 import org.edx.mobile.view.login.LoginPresenter;
@@ -254,6 +257,12 @@ public class LoginActivity extends PresenterActivity<LoginPresenter, LoginPresen
         SimpleAlertDialog noNetworkFragment = SimpleAlertDialog.newInstance(args);
         noNetworkFragment.setStyle(DialogFragment.STYLE_NO_TITLE, 0);
         noNetworkFragment.show(getSupportFragmentManager(), "dialog");
+    }
+
+    // make sure that on the login activity, all errors show up as a dialog as opposed to a flying snackbar
+    @Override
+    public void showErrorDialog(String header, String message) {
+        super.showErrorDialog(header, message);
     }
 
     @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -376,6 +376,12 @@ public class RegisterActivity extends BaseFragmentActivity
         }
     }
 
+    // make sure that on the login activity, all errors show up as a dialog as opposed to a flying snackbar
+    @Override
+    public void showErrorDialog(String header, String message) {
+        super.showErrorDialog(header, message);
+    }
+
     @Override
     public boolean createOptionsMenu(Menu menu) {
         // Register screen doesn't have any menu


### PR DESCRIPTION
### Description

[MA-2893](https://openedx.atlassian.net/browse/MA-2893)

Partially reverted https://github.com/edx/edx-app-android/pull/794. The sign in and register screens use the alert dialog, but the other screens are using the flying snackbar again.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @BenjiLee 
- [x] Code review: @1zaman 
- [ ] Code review: @miankhalid 
- [ ] FYI @andy-armstrong 

