### PR TITLE
[Old] Android SD Card Download.

### DIFF
--- a/OpenEdXMobile/AndroidManifest.xml
+++ b/OpenEdXMobile/AndroidManifest.xml
@@ -256,6 +256,21 @@
             </intent-filter>
         </receiver>
 
+        <!-- Media status update receiver -->
+        <receiver android:name=".receivers.MediaStatusReceiver" android:enabled="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_UNMOUNTED" />
+                <action android:name="android.intent.action.MEDIA_REMOVED" />
+                <action android:name="android.intent.action.MEDIA_MOUNTED"/>
+                <data android:scheme="file" />
+            </intent-filter>
+        </receiver>
+
+        <!-- Setup for Code Coverage -->
+        <instrumentation
+            android:name="org.edx.mobile.instrumentation.EdxInstrumentation"
+            android:targetPackage="org.edx.mobile" />
+
         <!-- adb shell am broadcast -a org.edx.mobile.END_EMMA -->
         <receiver android:name="org.edx.mobile.instrumentation.EndEmmaBroadcast">
             <intent-filter>

--- a/OpenEdXMobile/AndroidManifest.xml
+++ b/OpenEdXMobile/AndroidManifest.xml
@@ -257,8 +257,8 @@
             </intent-filter>
         </receiver>
 
-        <!-- Media status update receiver -->
-        <receiver android:name=".receivers.MediaStatusReceiver" android:enabled="true">
+        <!-- Media status update receiver required for the SD Card storage feature -->
+        <receiver android:name=".receivers.MediaStatusReceiver" android:enabled="${sdCardEnabled}">
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_UNMOUNTED" />
                 <action android:name="android.intent.action.MEDIA_REMOVED" />

--- a/OpenEdXMobile/AndroidManifest.xml
+++ b/OpenEdXMobile/AndroidManifest.xml
@@ -267,10 +267,7 @@
             </intent-filter>
         </receiver>
 
-        <!-- Setup for Code Coverage -->
-        <instrumentation
-            android:name="org.edx.mobile.instrumentation.EdxInstrumentation"
-            android:targetPackage="org.edx.mobile" />
+
 
         <!-- adb shell am broadcast -a org.edx.mobile.END_EMMA -->
         <receiver android:name="org.edx.mobile.instrumentation.EndEmmaBroadcast">

--- a/OpenEdXMobile/AndroidManifest.xml
+++ b/OpenEdXMobile/AndroidManifest.xml
@@ -16,6 +16,7 @@
 
     <!-- Required by app for storing downloaded videos to the external storage -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <!-- Required by app for capturing image -->
     <uses-permission android:name="android.permission.CAMERA" />

--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -337,6 +337,7 @@ android {
 
         manifestPlaceholders = [supportsRtl:"false",
                                 firebaseEnabled: firebaseEnabled?: false,
+                                sdCardEnabled: config.get('SD_CARD_DOWNLOAD')?:false,
                                 branchKey: branchKey]
 
         javaCompileOptions {

--- a/OpenEdXMobile/res/layout/fragment_settings.xml
+++ b/OpenEdXMobile/res/layout/fragment_settings.xml
@@ -59,7 +59,6 @@
         </LinearLayout>
 
         <LinearLayout
-            android:id="@+id/sd_card_setting"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/white"
@@ -73,27 +72,23 @@
                 android:orientation="vertical">
 
                 <TextView
-                    android:id="@+id/download_location_text"
                     style="@style/regular_text"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginEnd="8dp"
-                    android:layout_marginRight="8dp"
-                    android:text="@string/setting_download_location_top"
+                    android:layout_marginEnd="@dimen/edx_half_margin"
+                    android:text="@string/settings_download_to_sdcard_title"
                     android:textColor="@color/grey_6"
-                    android:textSize="13sp"
+                    android:textSize="@dimen/edx_small"
                     tools:targetApi="17" />
 
                 <TextView
-                    android:id="@+id/download_location_text2"
                     style="@style/regular_text"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginEnd="8dp"
-                    android:layout_marginRight="8dp"
-                    android:text="@string/setting_download_location_detail"
+                    android:layout_marginEnd="@dimen/edx_half_margin"
+                    android:text="@string/settings_download_to_sdcard_subtitle"
                     android:textColor="@color/grey_4"
-                    android:textSize="11sp"
+                    android:textSize="@dimen/edx_xx_small"
                     tools:targetApi="17" />
             </LinearLayout>
 

--- a/OpenEdXMobile/res/layout/fragment_settings.xml
+++ b/OpenEdXMobile/res/layout/fragment_settings.xml
@@ -58,5 +58,50 @@
                 android:checked="true" />
         </LinearLayout>
 
+        <LinearLayout
+            android:id="@+id/sd_card_setting"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/white"
+            android:orientation="horizontal"
+            android:padding="@dimen/edx_margin">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/download_location_text"
+                    style="@style/regular_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:text="@string/setting_download_location_top"
+                    android:textColor="@color/grey_6"
+                    android:textSize="13sp"
+                    tools:targetApi="17" />
+
+                <TextView
+                    android:id="@+id/download_location_text2"
+                    style="@style/regular_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:text="@string/setting_download_location_detail"
+                    android:textColor="@color/grey_4"
+                    android:textSize="11sp"
+                    tools:targetApi="17" />
+            </LinearLayout>
+
+            <Switch
+                android:id="@+id/download_location_switch"
+                style="@style/edX.Widget.Switch"
+                android:checked="true" />
+        </LinearLayout>
     </LinearLayout>
+
 </ScrollView>

--- a/OpenEdXMobile/res/layout/fragment_settings.xml
+++ b/OpenEdXMobile/res/layout/fragment_settings.xml
@@ -59,6 +59,7 @@
         </LinearLayout>
 
         <LinearLayout
+            android:id="@+id/sd_card_setting_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/white"

--- a/OpenEdXMobile/res/values-es/strings.xml
+++ b/OpenEdXMobile/res/values-es/strings.xml
@@ -37,6 +37,10 @@
   <string name="settings_wifi_top">Descargar solo por Wi-Fi</string>
   <!--Label explaining what wifi only means in detail-->
   <string name="settings_wifi_bottom">Sólo descargar contenido cuando el Wifi está encendido</string>
+  <!-- Label for the Download to sd-card setting -->
+  <string name="settings_download_to_sdcard_title">Download Video to SD Card</string>
+  <!-- Label explaining the download location setting in detail -->
+  <string name="settings_download_to_sdcard_subtitle">Videos will be downloaded to the SD Card if available</string>
   <!--Certificate Page-->
   <!--Description of button that will open the certificate sharing menu-->
   <string name="share_certificate_button">Comparta su certificado</string>

--- a/OpenEdXMobile/res/values/dimens.xml
+++ b/OpenEdXMobile/res/values/dimens.xml
@@ -219,6 +219,7 @@
     <dimen name="edx_line">3px</dimen>
     <dimen name="edx_box_radius">5dp</dimen>
     <dimen name="edx_margin">15dp</dimen>
+    <dimen name="edx_half_margin">8dp</dimen>
     <dimen name="edx_double_margin">30dp</dimen>
     <dimen name="edx_quadruple_margin">60dp</dimen>
     <dimen name="widget_margin_half">5dp</dimen>

--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -53,6 +53,11 @@
     <!-- Label explaining what wifi only means in detail -->
     <string name="settings_wifi_bottom">Only download content when Wi-Fi is turned on</string>
 
+    <!-- Label for the Download location switch -->
+    <string name="setting_download_location_top">Download Video to SD Card</string>
+    <!-- Label explaining the download location setting in detail -->
+    <string name="setting_download_location_detail">Videos will be downloaded to the SD Card if available</string>
+
     <!-- Certificate Page -->
     <!-- Description of button that will open the certificate sharing menu -->
     <string name="share_certificate_button">Share your certificate</string>

--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -53,10 +53,10 @@
     <!-- Label explaining what wifi only means in detail -->
     <string name="settings_wifi_bottom">Only download content when Wi-Fi is turned on</string>
 
-    <!-- Label for the Download location switch -->
-    <string name="setting_download_location_top">Download Video to SD Card</string>
+    <!-- Label for the Download to sd-card setting -->
+    <string name="settings_download_to_sdcard_title">Download Video to SD Card</string>
     <!-- Label explaining the download location setting in detail -->
-    <string name="setting_download_location_detail">Videos will be downloaded to the SD Card if available</string>
+    <string name="settings_download_to_sdcard_subtitle">Videos will be downloaded to the SD Card if available</string>
 
     <!-- Certificate Page -->
     <!-- Description of button that will open the certificate sharing menu -->

--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -54,9 +54,9 @@
     <string name="settings_wifi_bottom">Only download content when Wi-Fi is turned on</string>
 
     <!-- Label for the Download to sd-card setting -->
-    <string name="settings_download_to_sdcard_title">Download Video to SD Card</string>
+    <string name="settings_download_to_sdcard_title" tools:ignore="MissingTranslation">Download Video to SD Card</string>
     <!-- Label explaining the download location setting in detail -->
-    <string name="settings_download_to_sdcard_subtitle">Videos will be downloaded to the SD Card if available</string>
+    <string name="settings_download_to_sdcard_subtitle" tools:ignore="MissingTranslation">Videos will be downloaded to the SD Card if available</string>
 
     <!-- Certificate Page -->
     <!-- Description of button that will open the certificate sharing menu -->

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/db/DownloadEntry.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/db/DownloadEntry.java
@@ -220,7 +220,7 @@ public class DownloadEntry implements SectionItemInterface, VideoModel {
     @Override
     public void setDownloadInfo(NativeDownloadModel download) {
         dmId = download.dmid;
-        downloaded = DownloadedState.DOWNLOADING;
+        downloaded = DownloadedState.values()[(int)download.downloaded];
         filepath = download.filepath;
         size = download.size;
         // duration can't be updated here

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/db/DownloadEntry.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/db/DownloadEntry.java
@@ -220,7 +220,7 @@ public class DownloadEntry implements SectionItemInterface, VideoModel {
     @Override
     public void setDownloadInfo(NativeDownloadModel download) {
         dmId = download.dmid;
-        downloaded = DownloadedState.values()[(int)download.downloaded];
+        downloaded = DownloadedState.DOWNLOADING;
         filepath = download.filepath;
         size = download.size;
         // duration can't be updated here

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
@@ -246,20 +246,6 @@ public class PrefManager {
         }
     }
 
-    public static class UserPrefManager extends PrefManager {
-        public UserPrefManager(Context context) {
-            super(context, Pref.USER_PREF);
-        }
-
-        public boolean isVideosCacheRestored() {
-            return getBoolean(Key.VIDEOS_CACHE_RESTORED, false);
-        }
-
-        public void setIsVideosCacheRestored(boolean restored) {
-            super.put(Key.VIDEOS_CACHE_RESTORED, restored);
-        }
-    }
-
     /**
      * Contains preference name constants. These must be unique.
      */

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
@@ -29,6 +29,9 @@ public class PrefManager {
         this.prefName = prefName;
     }
 
+    public boolean contains(String key){
+        return context.getSharedPreferences(prefName, Context.MODE_PRIVATE).contains(key);
+    }
     /**
      * Puts given key-value pair to the Shared Preferences.
      *
@@ -243,6 +246,20 @@ public class PrefManager {
         }
     }
 
+    public static class UserPrefManager extends PrefManager {
+        public UserPrefManager(Context context) {
+            super(context, Pref.USER_PREF);
+        }
+
+        public boolean isVideosCacheRestored() {
+            return getBoolean(Key.VIDEOS_CACHE_RESTORED, false);
+        }
+
+        public void setIsVideosCacheRestored(boolean restored) {
+            super.put(Key.VIDEOS_CACHE_RESTORED, restored);
+        }
+    }
+
     /**
      * Contains preference name constants. These must be unique.
      */
@@ -253,6 +270,7 @@ public class PrefManager {
         public static final String FEATURES = "features";
         public static final String APP_INFO = "pref_app_info";
         public static final String USER_PREF = "pref_user";
+        public static final String SD_CARD = "pref_sd_card";
 
         public static String[] getAll() {
             return new String[]{LOGIN, WIFI, VIDEOS, FEATURES, APP_INFO, USER_PREF};
@@ -291,6 +309,7 @@ public class PrefManager {
         public static final String AppNotificationPushHash = "AppNotificationPushHash";
         public static final String AppUpgradeNeedSyncWithParse = "AppUpgradeNeedSyncWithParse";
         public static final String AppSettingNeedSyncWithParse = "AppSettingNeedSyncWithParse";
+        public static final String DOWNLOAD_TO_SDCARD = "download_to_sdcard";
 
         // Preference to save user app rating
         public static final String APP_RATING = "APP_RATING";

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/UserPrefs.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/UserPrefs.java
@@ -54,7 +54,20 @@ public class UserPrefs {
      */
     @Nullable
     public File getDownloadDirectory() {
-        final File externalAppDir = FileUtil.getExternalAppDir(context);
+        final PrefManager prefManger = new PrefManager(context, PrefManager.Pref.SD_CARD);
+        File externalAppDir = null;
+        if (prefManger.getBoolean(PrefManager.Key.DOWNLOAD_TO_SDCARD, false)) {
+            // This directory is confirmed to be removable storage
+            externalAppDir = FileUtil.getRemovableStorageAppDir(context);
+        }
+
+        // If the SD Card setting was set, but failed to get a removable storage path
+        if (externalAppDir == null) {
+            // This method can return emulated storage, which is internal storage
+            // made to look like external or hardware external storage depending on the
+            // device.
+            externalAppDir = FileUtil.getExternalAppDir(context);
+        }
         final ProfileModel profile = getProfile();
         if (externalAppDir != null && profile != null) {
             File videosDir = new File(externalAppDir, AppConstants.Directories.VIDEOS);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/UserPrefs.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/UserPrefs.java
@@ -47,7 +47,8 @@ public class UserPrefs {
     }
 
     /**
-     * Returns user storage directory under /Android/data/ folder for the currently logged in user.
+     * Returns user storage directory under /Android/data/ folder for the currently logged in user
+     * or if the sd-card download is enabled the sd-card data location will be used.
      * This is the folder where all video downloads should be kept.
      *
      * @return
@@ -55,22 +56,18 @@ public class UserPrefs {
     @Nullable
     public File getDownloadDirectory() {
         final PrefManager prefManger = new PrefManager(context, PrefManager.Pref.SD_CARD);
-        File externalAppDir = null;
+        File downloadDir = null;
         if (prefManger.getBoolean(PrefManager.Key.DOWNLOAD_TO_SDCARD, false)) {
-            // This directory is confirmed to be removable storage
-            externalAppDir = FileUtil.getRemovableStorageAppDir(context);
+            downloadDir = FileUtil.getRemovableStorageAppDir(context);
         }
 
-        // If the SD Card setting was set, but failed to get a removable storage path
-        if (externalAppDir == null) {
-            // This method can return emulated storage, which is internal storage
-            // made to look like external or hardware external storage depending on the
-            // device.
-            externalAppDir = FileUtil.getExternalAppDir(context);
+        // If no removable storage found, set app internal storage directory as download directory
+        if (downloadDir == null) {
+            downloadDir = FileUtil.getExternalAppDir(context);
         }
         final ProfileModel profile = getProfile();
-        if (externalAppDir != null && profile != null) {
-            File videosDir = new File(externalAppDir, AppConstants.Directories.VIDEOS);
+        if (downloadDir != null && profile != null) {
+            File videosDir = new File(downloadDir, AppConstants.Directories.VIDEOS);
             File usersVidsDir = new File(videosDir, Sha1Util.SHA1(profile.username));
             usersVidsDir.mkdirs();
             try {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/UserPrefs.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/UserPrefs.java
@@ -59,12 +59,11 @@ public class UserPrefs {
         File downloadDir = null;
         if (prefManger.getBoolean(PrefManager.Key.DOWNLOAD_TO_SDCARD, false)) {
             downloadDir = FileUtil.getRemovableStorageAppDir(context);
-        }
-
-        // If no removable storage found, set app internal storage directory as download directory
-        if (downloadDir == null) {
+        } else {
+            // If no removable storage found, set app internal storage directory as download directory
             downloadDir = FileUtil.getExternalAppDir(context);
         }
+
         final ProfileModel profile = getProfile();
         if (downloadDir != null && profile != null) {
             File videosDir = new File(downloadDir, AppConstants.Directories.VIDEOS);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/UserPrefs.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/UserPrefs.java
@@ -8,6 +8,7 @@ import android.support.annotation.Nullable;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
+import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.api.ProfileModel;
 import org.edx.mobile.util.AppConstants;
@@ -25,6 +26,9 @@ public class UserPrefs {
 
     @NonNull
     private final LoginPrefs loginPrefs;
+
+    @Inject
+    protected IEdxEnvironment environment;
 
     @Inject
     public UserPrefs(Context context, @NonNull LoginPrefs loginPrefs) {
@@ -46,6 +50,14 @@ public class UserPrefs {
         return onlyWifi;
     }
 
+    public boolean isSDCardDownloadEnabled(){
+        if (!environment.getConfig().isSDCardDownloadEnabled()){
+            return false;
+        }
+        final PrefManager prefManger = new PrefManager(context, PrefManager.Pref.SD_CARD);
+        return prefManger.getBoolean(PrefManager.Key.DOWNLOAD_TO_SDCARD, false);
+    }
+
     /**
      * Returns user storage directory under /Android/data/ folder for the currently logged in user
      * or if the sd-card download is enabled the sd-card data location will be used.
@@ -55,12 +67,12 @@ public class UserPrefs {
      */
     @Nullable
     public File getDownloadDirectory() {
-        final PrefManager prefManger = new PrefManager(context, PrefManager.Pref.SD_CARD);
         File downloadDir = null;
-        if (prefManger.getBoolean(PrefManager.Key.DOWNLOAD_TO_SDCARD, false)) {
+        if (isSDCardDownloadEnabled()) {
             downloadDir = FileUtil.getRemovableStorageAppDir(context);
         } else {
-            // If no removable storage found, set app internal storage directory as download directory
+            // If no removable storage found, set app internal storage directory
+            // as download directory
             downloadDir = FileUtil.getExternalAppDir(context);
         }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/storage/Storage.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/storage/Storage.java
@@ -201,7 +201,7 @@ public class Storage implements IStorage {
 
     /**
      * Deletes the physical file identified by given absolute file path.
-     * Returns true if delete succeeds or if file does NOT exist, false otherwise.
+     * Returns true if delete succeeds or if file does NOT exisHe t, false otherwise.
      * DownloadManager actually deletes the physical file when remove method is called.
      * So, this method might not be required for removing downloads.
      * @param filepath The file to delete

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/receivers/MediaStatusReceiver.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/receivers/MediaStatusReceiver.java
@@ -1,0 +1,142 @@
+package org.edx.mobile.receivers;
+
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Environment;
+import android.util.Log;
+import android.widget.Switch;
+
+import com.google.inject.Inject;
+
+import org.edx.mobile.base.MainApplication;
+import org.edx.mobile.model.VideoModel;
+import org.edx.mobile.model.course.VideoBlockModel;
+import org.edx.mobile.model.db.DownloadEntry;
+import org.edx.mobile.model.download.NativeDownloadModel;
+import org.edx.mobile.module.db.DataCallback;
+import org.edx.mobile.module.db.IDatabase;
+import org.edx.mobile.module.db.impl.DatabaseFactory;
+import org.edx.mobile.module.prefs.LoginPrefs;
+import org.edx.mobile.module.prefs.PrefManager;
+import org.edx.mobile.util.Sha1Util;
+
+
+import java.io.File;
+import java.util.List;
+
+
+/**
+ * Class containing the Broadcast receiver to detect the status of Removable media
+ */
+public class MediaStatusReceiver extends BroadcastReceiver{
+
+    @Inject
+    private IDatabase db;
+    @Inject
+    private LoginPrefs loginPrefs;
+
+    public MediaStatusReceiver() {
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Log.i("TEST RECEIVER", "Media UPDATE!!!");
+        db = DatabaseFactory.getInstance( DatabaseFactory.TYPE_DATABASE_NATIVE, context);
+
+        loginPrefs = MainApplication.getEnvironment(context).getLoginPrefs();
+        String username = loginPrefs.getUsername();
+        String username_sha = (username != null) ? Sha1Util.SHA1(username) : null;
+        final String action_path = intent.getDataString().replace("file://", "");
+
+        switch (intent.getAction()) {
+            case Intent.ACTION_MEDIA_REMOVED:
+            case Intent.ACTION_MEDIA_UNMOUNTED:
+                final PrefManager prefManager =
+                        new PrefManager(context, PrefManager.Pref.SD_CARD);
+                prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, false);
+                Log.i("TEST RECEIVER", "CARD REMOVED");
+                db.getAllVideos(username_sha, new DataCallback<List<VideoModel>>() {
+                    @Override
+                    public void onResult(List<VideoModel> result) {
+                        for (VideoModel videoModel : result) {
+                            String current_path = videoModel.getFilePath();
+
+                            if (current_path.contains(action_path) &&
+                                    Environment.isExternalStorageRemovable(new File(current_path))) {
+                                NativeDownloadModel dm = new NativeDownloadModel();
+                                dm.dmid = videoModel.getDmId();
+                                dm.filepath = videoModel.getFilePath();
+                                dm.size = videoModel.getSize();
+                                dm.downloaded = DownloadEntry.DownloadedState.ONLINE.ordinal();
+                                videoModel.setDownloadInfo(dm);
+                                db.updateDownloadingVideoInfoByVideoId(videoModel, new DataCallback<Integer>() {
+                                    @Override
+                                    public void onResult(Integer result) {
+                                        Log.i("TEST RECEIVER", "Video updated as online!!!");
+
+                                    }
+
+                                    @Override
+                                    public void onFail(Exception ex) {
+
+                                    }
+                                });
+                            }
+                        }
+                        Log.i("TEST RECEIVER", "Data Result for All videos!!!");
+                    }
+
+                    @Override
+                    public void onFail(Exception ex) {
+                        Log.i("TEST RECEIVER", "FAIL !!! Data Result for All videos!!!");
+
+                    }
+                });
+                break;
+        case Intent.ACTION_MEDIA_MOUNTED:
+            db.getAllVideos(username_sha, new DataCallback<List<VideoModel>>() {
+                @Override
+                public void onResult(List<VideoModel> result) {
+                    for (VideoModel videoModel : result) {
+                        String current_path = videoModel.getFilePath();
+
+                        if (current_path.contains(action_path) &&
+                                Environment.isExternalStorageRemovable(new File(current_path))) {
+
+                            NativeDownloadModel dm = new NativeDownloadModel();
+                            dm.dmid = videoModel.getDmId();
+                            dm.filepath = videoModel.getFilePath();
+                            dm.size = videoModel.getSize();
+                            dm.downloaded = DownloadEntry.DownloadedState.DOWNLOADED.ordinal();
+                            videoModel.setDownloadInfo(dm);
+                            db.updateDownloadingVideoInfoByVideoId(videoModel, new DataCallback<Integer>() {
+                                @Override
+                                public void onResult(Integer result) {
+                                    Log.i("TEST RECEIVER", "Video updated as Downloaded!!!!");
+                                }
+
+                                @Override
+                                public void onFail(Exception ex) {
+
+                                }
+                            });
+                        }
+                    }
+                    Log.i("TEST RECEIVER", "Data Result for All videos!!!");
+                }
+
+                @Override
+                public void onFail(Exception ex) {
+                    Log.i("TEST RECEIVER", "FAIL !!! Data Result for All videos!!!");
+
+                }
+            });
+            Log.i("TEST RECEIVER", "CARD MOUNTED");
+            break;
+        }
+    }
+
+//    private class AllVideosCallback implements DataCallback<List>
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/receivers/MediaStatusReceiver.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/receivers/MediaStatusReceiver.java
@@ -1,26 +1,21 @@
 package org.edx.mobile.receivers;
 
-
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Environment;
 import android.util.Log;
-import android.widget.Switch;
 
 import com.google.inject.Inject;
 
-import org.edx.mobile.base.MainApplication;
 import org.edx.mobile.model.VideoModel;
-import org.edx.mobile.model.course.VideoBlockModel;
 import org.edx.mobile.model.db.DownloadEntry;
 import org.edx.mobile.model.download.NativeDownloadModel;
 import org.edx.mobile.module.db.DataCallback;
 import org.edx.mobile.module.db.IDatabase;
-import org.edx.mobile.module.db.impl.DatabaseFactory;
 import org.edx.mobile.module.prefs.LoginPrefs;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.util.Sha1Util;
+
+import roboguice.receiver.RoboBroadcastReceiver;
 
 
 import java.io.File;
@@ -28,10 +23,9 @@ import java.util.List;
 
 
 /**
- * Class containing the Broadcast receiver to detect the status of Removable media
+ * BroadcastReceiver to receive the removable storage (such as SD-card) status events.
  */
-public class MediaStatusReceiver extends BroadcastReceiver{
-
+public class MediaStatusReceiver extends RoboBroadcastReceiver {
     @Inject
     private IDatabase db;
     @Inject
@@ -41,14 +35,10 @@ public class MediaStatusReceiver extends BroadcastReceiver{
     }
 
     @Override
-    public void onReceive(Context context, Intent intent) {
-        Log.i("TEST RECEIVER", "Media UPDATE!!!");
-        db = DatabaseFactory.getInstance( DatabaseFactory.TYPE_DATABASE_NATIVE, context);
-
-        loginPrefs = MainApplication.getEnvironment(context).getLoginPrefs();
+    public void handleReceive(Context context, Intent intent) {
         String username = loginPrefs.getUsername();
-        String username_sha = (username != null) ? Sha1Util.SHA1(username) : null;
-        final String action_path = intent.getDataString().replace("file://", "");
+        String hashedUsername = (username != null) ? Sha1Util.SHA1(username) : null;
+        final String sdCardPath = intent.getDataString().replace("file://", "");
 
         switch (intent.getAction()) {
             case Intent.ACTION_MEDIA_REMOVED:
@@ -56,87 +46,70 @@ public class MediaStatusReceiver extends BroadcastReceiver{
                 final PrefManager prefManager =
                         new PrefManager(context, PrefManager.Pref.SD_CARD);
                 prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, false);
-                Log.i("TEST RECEIVER", "CARD REMOVED");
-                db.getAllVideos(username_sha, new DataCallback<List<VideoModel>>() {
+                db.getAllVideos(hashedUsername, new DataCallback<List<VideoModel>>() {
                     @Override
                     public void onResult(List<VideoModel> result) {
                         for (VideoModel videoModel : result) {
-                            String current_path = videoModel.getFilePath();
-
-                            if (current_path.contains(action_path) &&
-                                    Environment.isExternalStorageRemovable(new File(current_path))) {
-                                NativeDownloadModel dm = new NativeDownloadModel();
-                                dm.dmid = videoModel.getDmId();
-                                dm.filepath = videoModel.getFilePath();
-                                dm.size = videoModel.getSize();
-                                dm.downloaded = DownloadEntry.DownloadedState.ONLINE.ordinal();
-                                videoModel.setDownloadInfo(dm);
-                                db.updateDownloadingVideoInfoByVideoId(videoModel, new DataCallback<Integer>() {
-                                    @Override
-                                    public void onResult(Integer result) {
-                                        Log.i("TEST RECEIVER", "Video updated as online!!!");
-
-                                    }
-
-                                    @Override
-                                    public void onFail(Exception ex) {
-
-                                    }
-                                });
-                            }
+                            String videoPath = videoModel.getFilePath();
+                            updateVideoDownloadState(
+                                    videoModel,
+                                    DownloadEntry.DownloadedState.ONLINE.ordinal(),
+                                    sdCardPath,
+                                    videoPath
+                            );
                         }
-                        Log.i("TEST RECEIVER", "Data Result for All videos!!!");
                     }
-
                     @Override
                     public void onFail(Exception ex) {
-                        Log.i("TEST RECEIVER", "FAIL !!! Data Result for All videos!!!");
-
+                        //TODO Proper error handling here?
+                        Log.e(this.getClass().getSimpleName(),
+                                "Unable to get to get list of Videos"
+                        );
                     }
                 });
                 break;
-        case Intent.ACTION_MEDIA_MOUNTED:
-            db.getAllVideos(username_sha, new DataCallback<List<VideoModel>>() {
-                @Override
-                public void onResult(List<VideoModel> result) {
-                    for (VideoModel videoModel : result) {
-                        String current_path = videoModel.getFilePath();
-
-                        if (current_path.contains(action_path) &&
-                                Environment.isExternalStorageRemovable(new File(current_path))) {
-
-                            NativeDownloadModel dm = new NativeDownloadModel();
-                            dm.dmid = videoModel.getDmId();
-                            dm.filepath = videoModel.getFilePath();
-                            dm.size = videoModel.getSize();
-                            dm.downloaded = DownloadEntry.DownloadedState.DOWNLOADED.ordinal();
-                            videoModel.setDownloadInfo(dm);
-                            db.updateDownloadingVideoInfoByVideoId(videoModel, new DataCallback<Integer>() {
-                                @Override
-                                public void onResult(Integer result) {
-                                    Log.i("TEST RECEIVER", "Video updated as Downloaded!!!!");
-                                }
-
-                                @Override
-                                public void onFail(Exception ex) {
-
-                                }
-                            });
+            case Intent.ACTION_MEDIA_MOUNTED:
+                db.getAllVideos(hashedUsername, new DataCallback<List<VideoModel>>() {
+                    @Override
+                    public void onResult(List<VideoModel> result) {
+                        for (VideoModel videoModel : result) {
+                            String videoPath = videoModel.getFilePath();
+                            File file = new File(videoPath);
+                            if (file.exists()) {
+                                updateVideoDownloadState(
+                                        videoModel,
+                                        DownloadEntry.DownloadedState.DOWNLOADED.ordinal(),
+                                        sdCardPath,
+                                        videoPath
+                                );
+                            }
                         }
                     }
-                    Log.i("TEST RECEIVER", "Data Result for All videos!!!");
-                }
-
-                @Override
-                public void onFail(Exception ex) {
-                    Log.i("TEST RECEIVER", "FAIL !!! Data Result for All videos!!!");
-
-                }
-            });
-            Log.i("TEST RECEIVER", "CARD MOUNTED");
-            break;
+                    @Override
+                    public void onFail(Exception ex) {
+                        Log.e(this.getClass().getSimpleName(),
+                                "Unable to get to get list of Videos"
+                        );
+                    }
+                });
+                break;
         }
     }
 
+    public void updateVideoDownloadState(VideoModel videoModel,
+                                         int downloadState,
+                                         String sdCardPath,
+                                         String videoPath) {
+        if (videoPath.contains(sdCardPath)) {
+            // TODO: Check that the video files are still available.
+            NativeDownloadModel dm = new NativeDownloadModel();
+            dm.dmid = videoModel.getDmId();
+            dm.filepath = videoModel.getFilePath();
+            dm.size = videoModel.getSize();
+            dm.downloaded = downloadState;
+            videoModel.setDownloadInfo(dm);
+            db.updateDownloadingVideoInfoByVideoId(videoModel, null);
+        }
+    }
 //    private class AllVideosCallback implements DataCallback<List>
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/receivers/MediaStatusReceiver.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/receivers/MediaStatusReceiver.java
@@ -38,62 +38,79 @@ public class MediaStatusReceiver extends RoboBroadcastReceiver {
     public void handleReceive(Context context, Intent intent) {
         String username = loginPrefs.getUsername();
         String hashedUsername = (username != null) ? Sha1Util.SHA1(username) : null;
+
+        // TODO: Is this Path a good method for Identifying the path in the DB
+        // should we updated the model to have an SD Card Flag?
         final String sdCardPath = intent.getDataString().replace("file://", "");
 
-        switch (intent.getAction()) {
-            case Intent.ACTION_MEDIA_REMOVED:
-            case Intent.ACTION_MEDIA_UNMOUNTED:
-                final PrefManager prefManager =
-                        new PrefManager(context, PrefManager.Pref.SD_CARD);
-                prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, false);
-                db.getAllVideos(hashedUsername, new DataCallback<List<VideoModel>>() {
-                    @Override
-                    public void onResult(List<VideoModel> result) {
-                        for (VideoModel videoModel : result) {
-                            String videoPath = videoModel.getFilePath();
-                            updateVideoDownloadState(
-                                    videoModel,
-                                    DownloadEntry.DownloadedState.ONLINE.ordinal(),
-                                    sdCardPath,
-                                    videoPath
-                            );
-                        }
-                    }
-                    @Override
-                    public void onFail(Exception ex) {
-                        //TODO Proper error handling here?
-                        Log.e(this.getClass().getSimpleName(),
-                                "Unable to get to get list of Videos"
-                        );
-                    }
-                });
-                break;
-            case Intent.ACTION_MEDIA_MOUNTED:
-                db.getAllVideos(hashedUsername, new DataCallback<List<VideoModel>>() {
-                    @Override
-                    public void onResult(List<VideoModel> result) {
-                        for (VideoModel videoModel : result) {
-                            String videoPath = videoModel.getFilePath();
-                            File file = new File(videoPath);
-                            if (file.exists()) {
-                                updateVideoDownloadState(
-                                        videoModel,
-                                        DownloadEntry.DownloadedState.DOWNLOADED.ordinal(),
-                                        sdCardPath,
-                                        videoPath
-                                );
-                            }
-                        }
-                    }
-                    @Override
-                    public void onFail(Exception ex) {
-                        Log.e(this.getClass().getSimpleName(),
-                                "Unable to get to get list of Videos"
-                        );
-                    }
-                });
-                break;
+        String action = intent.getAction();
+        if(action != null) {
+            switch (action) {
+                case Intent.ACTION_MEDIA_REMOVED:
+                case Intent.ACTION_MEDIA_UNMOUNTED:
+                    handleSDCardUnmounted(context, hashedUsername, sdCardPath);
+                    break;
+                case Intent.ACTION_MEDIA_MOUNTED:
+                    handleSDCardMounted(hashedUsername, sdCardPath);
+                    break;
+            }
         }
+    }
+
+    private void handleSDCardUnmounted(Context context,
+                                       String hashedUsername,
+                                       final String sdCardPath){
+        final PrefManager prefManager =
+                new PrefManager(context, PrefManager.Pref.SD_CARD);
+        prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, false);
+        db.getAllVideos(hashedUsername, new DataCallback<List<VideoModel>>() {
+            @Override
+            public void onResult(List<VideoModel> result) {
+                for (VideoModel videoModel : result) {
+                    String videoPath = videoModel.getFilePath();
+                    updateVideoDownloadState(
+                            videoModel,
+                            DownloadEntry.DownloadedState.ONLINE.ordinal(),
+                            sdCardPath,
+                            videoPath
+                    );
+                }
+            }
+
+            @Override
+            public void onFail(Exception ex) {
+                Log.e(this.getClass().getSimpleName(),
+                        "Unable to get to get list of Videos"
+                );
+            }
+        });
+    }
+
+    private void handleSDCardMounted(String hashedUsername, final String sdCardPath){
+        db.getAllVideos(hashedUsername, new DataCallback<List<VideoModel>>() {
+            @Override
+            public void onResult(List<VideoModel> result) {
+                for (VideoModel videoModel : result) {
+                    String videoPath = videoModel.getFilePath();
+                    File file = new File(videoPath);
+                    if (file.exists()) {
+                        updateVideoDownloadState(
+                                videoModel,
+                                DownloadEntry.DownloadedState.DOWNLOADED.ordinal(),
+                                sdCardPath,
+                                videoPath
+                        );
+                    }
+                }
+            }
+
+            @Override
+            public void onFail(Exception ex) {
+                Log.e(this.getClass().getSimpleName(),
+                        "Unable to get to get list of Videos"
+                );
+            }
+        });
     }
 
     public void updateVideoDownloadState(VideoModel videoModel,
@@ -101,14 +118,16 @@ public class MediaStatusReceiver extends RoboBroadcastReceiver {
                                          String sdCardPath,
                                          String videoPath) {
         if (videoPath.contains(sdCardPath)) {
-            // TODO: Check that the video files are still available.
-            NativeDownloadModel dm = new NativeDownloadModel();
-            dm.dmid = videoModel.getDmId();
-            dm.filepath = videoModel.getFilePath();
-            dm.size = videoModel.getSize();
-            dm.downloaded = downloadState;
-            videoModel.setDownloadInfo(dm);
-            db.updateDownloadingVideoInfoByVideoId(videoModel, null);
+            File testFileExists = new File(videoPath);
+            if (testFileExists.exists()) {
+                NativeDownloadModel dm = new NativeDownloadModel();
+                dm.dmid = videoModel.getDmId();
+                dm.filepath = videoModel.getFilePath();
+                dm.size = videoModel.getSize();
+                dm.downloaded = downloadState;
+                videoModel.setDownloadInfo(dm);
+                db.updateDownloadingVideoInfoByVideoId(videoModel, null);
+            }
         }
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/receivers/MediaStatusReceiver.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/receivers/MediaStatusReceiver.java
@@ -111,5 +111,4 @@ public class MediaStatusReceiver extends RoboBroadcastReceiver {
             db.updateDownloadingVideoInfoByVideoId(videoModel, null);
         }
     }
-//    private class AllVideosCallback implements DataCallback<List>
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/receivers/MediaStatusReceiver.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/receivers/MediaStatusReceiver.java
@@ -48,7 +48,7 @@ public class MediaStatusReceiver extends RoboBroadcastReceiver {
             switch (action) {
                 case Intent.ACTION_MEDIA_REMOVED:
                 case Intent.ACTION_MEDIA_UNMOUNTED:
-                    handleSDCardUnmounted(context, hashedUsername, sdCardPath);
+                    handleSDCardUnmounted(hashedUsername, sdCardPath);
                     break;
                 case Intent.ACTION_MEDIA_MOUNTED:
                     handleSDCardMounted(hashedUsername, sdCardPath);
@@ -57,12 +57,7 @@ public class MediaStatusReceiver extends RoboBroadcastReceiver {
         }
     }
 
-    private void handleSDCardUnmounted(Context context,
-                                       String hashedUsername,
-                                       final String sdCardPath){
-        final PrefManager prefManager =
-                new PrefManager(context, PrefManager.Pref.SD_CARD);
-        prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, false);
+    private void handleSDCardUnmounted(String hashedUsername, final String sdCardPath){
         db.getAllVideos(hashedUsername, new DataCallback<List<VideoModel>>() {
             @Override
             public void onResult(List<VideoModel> result) {
@@ -76,7 +71,6 @@ public class MediaStatusReceiver extends RoboBroadcastReceiver {
                     );
                 }
             }
-
             @Override
             public void onFail(Exception ex) {
                 Log.e(this.getClass().getSimpleName(),

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/services/VideoDownloadHelper.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/services/VideoDownloadHelper.java
@@ -101,8 +101,7 @@ public class VideoDownloadHelper {
                 downloadCount++;
             }
         }
-        if (downloadSize > MemoryUtil
-                .getAvailableExternalMemory(activity)) {
+        if (downloadSize > MemoryUtil.getAvailableExternalMemory(activity)) {
             ((BaseFragmentActivity) activity).showInfoMessage(activity.getString(R.string.file_size_exceeded));
             callback.updateListUI();
             EventBus.getDefault().post(new BulkVideosDownloadCancelledEvent());

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
@@ -74,6 +74,7 @@ public class Config {
     private static final String COURSE_DATES_ENABLED = "COURSE_DATES_ENABLED";
     private static final String WHATS_NEW_ENABLED = "WHATS_NEW_ENABLED";
     private static final String COURSE_VIDEOS_ENABLED = "COURSE_VIDEOS_ENABLED";
+    private static final String SD_CARD_DOWNLOAD = "SD_CARD_DOWNLOAD";
 
     public static class ZeroRatingConfig {
         @SerializedName("ENABLED")
@@ -609,6 +610,10 @@ public class Config {
 
     public boolean isCourseVideosEnabled() {
         return getBoolean(COURSE_VIDEOS_ENABLED, true);
+    }
+
+    public boolean isSDCardDownloadEnabled(){
+        return getBoolean(SD_CARD_DOWNLOAD, false);
     }
 
     @NonNull

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/FileUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/FileUtil.java
@@ -1,6 +1,8 @@
 package org.edx.mobile.util;
 
 import android.content.Context;
+import android.os.Build;
+import android.os.Environment;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.RawRes;
@@ -22,6 +24,38 @@ public class FileUtil {
     }
 
     /**
+     * Utility method to determine is Removable storage (SD Cards) are available.
+     * @param context The current context
+     * @return True if there is removable storage available on the device.
+     */
+    public static boolean isRemovableStorageAvailable(@NonNull Context context){
+        int currentapiVersion = android.os.Build.VERSION.SDK_INT;
+        if (currentapiVersion >= Build.VERSION_CODES.LOLLIPOP) {
+            File[] fileList = context.getExternalFilesDirs("Android");
+            for (File extFile : fileList){
+                if (extFile != null && Environment.isExternalStorageRemovable(extFile)){
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Nullable
+    public static File getRemovableStorageAppDir(@NonNull Context context) {
+        int currentapiVersion = android.os.Build.VERSION.SDK_INT;
+        if (currentapiVersion >= Build.VERSION_CODES.LOLLIPOP) {
+            File[] fileList = context.getExternalFilesDirs("Android");
+            for (File extFile : fileList){
+                if (extFile != null && Environment.isExternalStorageRemovable(extFile)){
+                    return extFile;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
      * Utility function for getting the app's external storage directory.
      *
      * @param context The current context.
@@ -31,6 +65,12 @@ public class FileUtil {
     public static File getExternalAppDir(@NonNull Context context) {
         File externalFilesDir = context.getExternalFilesDir(null);
         return (externalFilesDir != null ? externalFilesDir.getParentFile() : null);
+    }
+
+    @Nullable
+    public static File getInternalAppDir(@NonNull Context context) {
+        File internalFileDir = context.getFilesDir();
+        return (internalFileDir != null ? internalFileDir.getParentFile() : null);
     }
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/FileUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/FileUtil.java
@@ -1,5 +1,6 @@
 package org.edx.mobile.util;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
 import android.os.Environment;
@@ -24,28 +25,21 @@ public class FileUtil {
     }
 
     /**
-     * Utility method to determine is Removable storage (SD Cards) are available.
+     * Utility method to determine if any removable storage (such as an SD card) is available.
      * @param context The current context
      * @return True if there is removable storage available on the device.
      */
+    @TargetApi(21)
     public static boolean isRemovableStorageAvailable(@NonNull Context context){
-        int currentapiVersion = android.os.Build.VERSION.SDK_INT;
-        if (currentapiVersion >= Build.VERSION_CODES.LOLLIPOP) {
-            File[] fileList = context.getExternalFilesDirs("Android");
-            for (File extFile : fileList){
-                if (extFile != null && Environment.isExternalStorageRemovable(extFile)){
-                    return true;
-                }
-            }
-        }
-        return false;
+        return getRemovableStorageAppDir(context) != null;
     }
 
     @Nullable
+    @TargetApi(21)
     public static File getRemovableStorageAppDir(@NonNull Context context) {
         int currentapiVersion = android.os.Build.VERSION.SDK_INT;
         if (currentapiVersion >= Build.VERSION_CODES.LOLLIPOP) {
-            File[] fileList = context.getExternalFilesDirs("Android");
+            File[] fileList = context.getExternalFilesDirs(null);
             for (File extFile : fileList){
                 if (extFile != null && Environment.isExternalStorageRemovable(extFile)){
                     return extFile;
@@ -65,12 +59,6 @@ public class FileUtil {
     public static File getExternalAppDir(@NonNull Context context) {
         File externalFilesDir = context.getExternalFilesDir(null);
         return (externalFilesDir != null ? externalFilesDir.getParentFile() : null);
-    }
-
-    @Nullable
-    public static File getInternalAppDir(@NonNull Context context) {
-        File internalFileDir = context.getFilesDir();
-        return (internalFileDir != null ? internalFileDir.getParentFile() : null);
     }
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/SettingsFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/SettingsFragment.java
@@ -16,8 +16,10 @@ import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.module.analytics.Analytics;
 import org.edx.mobile.module.prefs.PrefManager;
+import org.edx.mobile.util.FileUtil;
 import org.edx.mobile.view.dialog.IDialogCallback;
 import org.edx.mobile.view.dialog.NetworkCheckDialogFragment;
+
 
 public class SettingsFragment extends BaseFragment {
 
@@ -32,6 +34,7 @@ public class SettingsFragment extends BaseFragment {
     ExtensionRegistry extensionRegistry;
 
     private Switch wifiSwitch;
+    private Switch mSDCardSwitch;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -45,7 +48,10 @@ public class SettingsFragment extends BaseFragment {
 
         final View layout = inflater.inflate(R.layout.fragment_settings, container, false);
         wifiSwitch = (Switch) layout.findViewById(R.id.wifi_setting);
+        mSDCardSwitch = (Switch) layout.findViewById(R.id.download_location_switch);
+
         updateWifiSwitch();
+        updateSDCardSwitch();
         final LinearLayout settingsLayout = (LinearLayout) layout.findViewById(R.id.settings_layout);
         for (SettingsExtension extension : extensionRegistry.forType(SettingsExtension.class)) {
             extension.onCreateSettingsView(settingsLayout);
@@ -71,6 +77,33 @@ public class SettingsFragment extends BaseFragment {
                 }
             }
         });
+    }
+
+
+
+    private void updateSDCardSwitch(){
+        final PrefManager prefManager =
+                new PrefManager(getActivity().getBaseContext(), PrefManager.Pref.SD_CARD);
+        if (FileUtil.isRemovableStorageAvailable(getContext())) {
+            mSDCardSwitch.setEnabled(true);
+
+            mSDCardSwitch.setOnCheckedChangeListener(null);
+            mSDCardSwitch.setChecked(prefManager.getBoolean(PrefManager.Key.DOWNLOAD_TO_SDCARD, true));
+            if ( !prefManager.contains(PrefManager.Key.DOWNLOAD_TO_SDCARD)){
+                // Initialize the preference
+                prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, true);
+            }
+            mSDCardSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
+                    prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, isChecked);
+                }
+            });
+        } else {
+            prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, false);
+            mSDCardSwitch.setEnabled(false);
+        }
+
     }
 
     protected void showWifiDialog() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/SettingsFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/SettingsFragment.java
@@ -34,7 +34,7 @@ public class SettingsFragment extends BaseFragment {
     ExtensionRegistry extensionRegistry;
 
     private Switch wifiSwitch;
-    private Switch mSDCardSwitch;
+    private Switch sdCardSwitch;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -48,7 +48,7 @@ public class SettingsFragment extends BaseFragment {
 
         final View layout = inflater.inflate(R.layout.fragment_settings, container, false);
         wifiSwitch = (Switch) layout.findViewById(R.id.wifi_setting);
-        mSDCardSwitch = (Switch) layout.findViewById(R.id.download_location_switch);
+        sdCardSwitch = (Switch) layout.findViewById(R.id.download_location_switch);
 
         updateWifiSwitch();
         updateSDCardSwitch();
@@ -79,21 +79,15 @@ public class SettingsFragment extends BaseFragment {
         });
     }
 
-
-
-    private void updateSDCardSwitch(){
+    private void updateSDCardSwitch() {
         final PrefManager prefManager =
                 new PrefManager(getActivity().getBaseContext(), PrefManager.Pref.SD_CARD);
         if (FileUtil.isRemovableStorageAvailable(getContext())) {
-            mSDCardSwitch.setEnabled(true);
+            sdCardSwitch.setEnabled(true);
 
-            mSDCardSwitch.setOnCheckedChangeListener(null);
-            mSDCardSwitch.setChecked(prefManager.getBoolean(PrefManager.Key.DOWNLOAD_TO_SDCARD, true));
-            if ( !prefManager.contains(PrefManager.Key.DOWNLOAD_TO_SDCARD)){
-                // Initialize the preference
-                prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, true);
-            }
-            mSDCardSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            sdCardSwitch.setOnCheckedChangeListener(null);
+            sdCardSwitch.setChecked(prefManager.getBoolean(PrefManager.Key.DOWNLOAD_TO_SDCARD, true));
+            sdCardSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                 @Override
                 public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
                     prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, isChecked);
@@ -101,9 +95,8 @@ public class SettingsFragment extends BaseFragment {
             });
         } else {
             prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, false);
-            mSDCardSwitch.setEnabled(false);
+            sdCardSwitch.setEnabled(false);
         }
-
     }
 
     protected void showWifiDialog() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/SettingsFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/SettingsFragment.java
@@ -89,21 +89,14 @@ public class SettingsFragment extends BaseFragment {
         if (!environment.getConfig().isSDCardDownloadEnabled()){
             sdCardSettinglayout.setVisibility(View.GONE);
         } else {
-            if (FileUtil.isRemovableStorageAvailable(getContext())) {
-                sdCardSwitch.setEnabled(true);
-
-                sdCardSwitch.setOnCheckedChangeListener(null);
-                sdCardSwitch.setChecked(prefManager.getBoolean(PrefManager.Key.DOWNLOAD_TO_SDCARD, true));
-                sdCardSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-                    @Override
-                    public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
-                        prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, isChecked);
-                    }
-                });
-            } else {
-                prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, false);
-                sdCardSwitch.setEnabled(false);
-            }
+            sdCardSwitch.setOnCheckedChangeListener(null);
+            sdCardSwitch.setChecked(prefManager.getBoolean(PrefManager.Key.DOWNLOAD_TO_SDCARD, true));
+            sdCardSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
+                    prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, isChecked);
+                }
+            });
         }
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/SettingsFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/SettingsFragment.java
@@ -16,6 +16,7 @@ import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.module.analytics.Analytics;
 import org.edx.mobile.module.prefs.PrefManager;
+import org.edx.mobile.module.prefs.UserPrefs;
 import org.edx.mobile.util.FileUtil;
 import org.edx.mobile.view.dialog.IDialogCallback;
 import org.edx.mobile.view.dialog.NetworkCheckDialogFragment;
@@ -35,6 +36,7 @@ public class SettingsFragment extends BaseFragment {
 
     private Switch wifiSwitch;
     private Switch sdCardSwitch;
+    private LinearLayout sdCardSettinglayout;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -49,6 +51,7 @@ public class SettingsFragment extends BaseFragment {
         final View layout = inflater.inflate(R.layout.fragment_settings, container, false);
         wifiSwitch = (Switch) layout.findViewById(R.id.wifi_setting);
         sdCardSwitch = (Switch) layout.findViewById(R.id.download_location_switch);
+        sdCardSettinglayout = (LinearLayout) layout.findViewById(R.id.sd_card_setting_layout);
 
         updateWifiSwitch();
         updateSDCardSwitch();
@@ -82,20 +85,25 @@ public class SettingsFragment extends BaseFragment {
     private void updateSDCardSwitch() {
         final PrefManager prefManager =
                 new PrefManager(getActivity().getBaseContext(), PrefManager.Pref.SD_CARD);
-        if (FileUtil.isRemovableStorageAvailable(getContext())) {
-            sdCardSwitch.setEnabled(true);
 
-            sdCardSwitch.setOnCheckedChangeListener(null);
-            sdCardSwitch.setChecked(prefManager.getBoolean(PrefManager.Key.DOWNLOAD_TO_SDCARD, true));
-            sdCardSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-                @Override
-                public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
-                    prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, isChecked);
-                }
-            });
+        if (!environment.getConfig().isSDCardDownloadEnabled()){
+            sdCardSettinglayout.setVisibility(View.GONE);
         } else {
-            prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, false);
-            sdCardSwitch.setEnabled(false);
+            if (FileUtil.isRemovableStorageAvailable(getContext())) {
+                sdCardSwitch.setEnabled(true);
+
+                sdCardSwitch.setOnCheckedChangeListener(null);
+                sdCardSwitch.setChecked(prefManager.getBoolean(PrefManager.Key.DOWNLOAD_TO_SDCARD, true));
+                sdCardSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                    @Override
+                    public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
+                        prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, isChecked);
+                    }
+                });
+            } else {
+                prefManager.put(PrefManager.Key.DOWNLOAD_TO_SDCARD, false);
+                sdCardSwitch.setEnabled(false);
+            }
         }
     }
 


### PR DESCRIPTION
### Description

Current Story: [LEARNER-6166](https://openedx.atlassian.net/browse/LEARNER-6166)
Old Story: [LEARNER-785](https://openedx.atlassian.net/browse/LEARNER-785)

This PR would add limited SD Card Support
### Acceptance Criteria

1. If user has downloaded(or currently downloading) some video from course outline screen and then user eject the sd-card and come back to app, course outline screen should update its video downloading status accordingly.
2. After step 1 if user mount the same card again and videos are present in sd-card on required paths, they should appear as downloaded in app.
3. All the screens which needs to be updated on ejecting/mounting of sd-card, should be updated accordingly. (Settings, Course outline, video playback screen)

