### PR TITLE
Fix remote registration field errors not showing

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -314,6 +314,7 @@ public class RegisterActivity extends BaseFragmentActivity
             for (RegisterResponseFieldError e : errors) {
                 buffer.append(e.getUserMessage() + " ");
             }
+            fieldView.handleError(buffer.toString());
             showErrorPopup();
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -291,6 +291,7 @@ public class RegisterActivity extends BaseFragmentActivity
                         }
                     }
                     if (fieldErrorShown) {
+                        showErrorPopup();
                         // We are showing an error message on a visible form field.
                         return; // Return here to avoid showing the generic error pop-up.
                     }


### PR DESCRIPTION
### Description

[MA-2944][]


#815 added a popup dialog in addition to the field errors. However, it caused a regression in that it failed to display field-specific errors returned by the server (thus only displaying field errors upon the initial local validation). It also introduced the issue that it displayed a new dialog on the stack for each separate field error. This pull request addressed both of these issues.

### Reviewers

If you've been tagged for review, please "Start a review" with the GitHub GUI.

- Code review: @miankhalid, @BenjiLee

[MA-2944]: https://openedx.atlassian.net/browse/MA-2944