### PR TITLE
Db upgrade fix when a video is downloading

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/DbHelper.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/DbHelper.java
@@ -145,7 +145,8 @@ class DbHelper extends SQLiteOpenHelper {
                                 final String previousDirPath = TextUtils.join(
                                         "/", Arrays.<CharSequence>asList(previousAppDirPath,
                                                 username)) + "/";
-                                if (!filePath.startsWith(previousDirPath)) {
+                                // filePath is null when a video is downloading
+                                if (filePath == null || !filePath.startsWith(previousDirPath)) {
                                     db.delete(DbStructure.Table.DOWNLOADS,
                                             DbStructure.Column.ID + "= ?", new String[]{id});
                                     continue;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/DbOperationBase.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/DbOperationBase.java
@@ -34,7 +34,7 @@ abstract class DbOperationBase<T> implements IDbOperation<T> {
             if (callback != null) {
                 callback.sendException(ex);
                 logger.debug("sending error...");
-                logger.error(ex);
+                logger.error(ex, true);
             }
         }
         
@@ -48,10 +48,4 @@ abstract class DbOperationBase<T> implements IDbOperation<T> {
      * @return
      */
     public abstract T execute(SQLiteDatabase db);
-
-    /**
-     * Returns the default value of the data type.
-     * @return The data type
-     */
-    public abstract T getDefaultValue();
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/IDbOperation.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/IDbOperation.java
@@ -20,6 +20,12 @@ interface IDbOperation<T> {
     T requestExecute(SQLiteDatabase db);
     
     /**
+     * Returns the default value of the data type.
+     * @return The data type
+     */
+    T getDefaultValue();
+    
+    /**
      * Sets a callback for database operation success and failure.
      * @param callback
      */

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 14 12:48:05 EDT 2016
+#Tue Oct 25 01:08:15 PKT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
### Description

[MA-2943](https://openedx.atlassian.net/browse/MA-2943)

The crash was caused due to database not having the filePath key's value in it, reason being the video is downloading.

### Reviewers

If you've been tagged for review, please "Start a review" with the GitHub GUI.

- Code review: @1zaman, @BenjiLee 

