### PR TITLE
Fix to fix multiple dialogs on registration screen

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -316,7 +316,6 @@ public class RegisterActivity extends BaseFragmentActivity
                 buffer.append(e.getUserMessage() + " ");
             }
             fieldView.handleError(buffer.toString());
-            showErrorPopup();
         }
     }
 


### PR DESCRIPTION
### Description

[MA-2944][]

#867 attempted to fix a regression due to which the registration screen displayed a new dialog on the stack for each separate field error. However, while it did change the flow to show one dialog for the aggregate of the field errors, it didn't remove the initial flow of individual error dialogs, thus further exacerbating the issue by having one more dialog displayed on top of whatever where already being done. This pull request fixes this issue by removing the initial problematic flow.

### Reviewers

- Code review: @BenjiLee, @miankhalid

[MA-2944]: https://openedx.atlassian.net/browse/MA-2944