### PR TITLE
Fix generics usage in database query method

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/IDatabaseBaseImpl.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/IDatabaseBaseImpl.java
@@ -51,12 +51,12 @@ class IDatabaseBaseImpl implements Runnable {
      * @param op
      * @return
      */
-    private synchronized <T extends Object> T execute(IDbOperation<?> op) {
+    private synchronized <T> T execute(IDbOperation<T> op) {
         // perform this database operation
         synchronized (helper) {
             T result;
             try {
-                result = (T) op.requestExecute(helper.getDatabase());
+                result = op.requestExecute(helper.getDatabase());
             } catch (SQLiteException e) {
                 /* Catch any SQLite exceptions thrown by the operation, or by the database creation
                  * or upgrade process invoked by the helper, deliver the exception to the callback,
@@ -64,7 +64,7 @@ class IDatabaseBaseImpl implements Runnable {
                  */
                 op.getCallback().sendException(e);
                 logger.error(e, true);
-                result = (T) op.getDefaultValue();
+                result = op.getDefaultValue();
             }
 
             return result;
@@ -80,7 +80,7 @@ class IDatabaseBaseImpl implements Runnable {
      *
      * @param operation
      */
-    public synchronized <T extends Object> T enqueue(IDbOperation<?> operation) {
+    public synchronized <T> T enqueue(IDbOperation<T> operation) {
         // execute right away if this operation doesn't have a callback to send back the result
         if (operation.getCallback() == null) {
             return execute(operation);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/IDatabaseImpl.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/IDatabaseImpl.java
@@ -653,7 +653,11 @@ public class IDatabaseImpl extends IDatabaseBaseImpl implements IDatabase {
                 dataCallback.sendException(ex);
             }
         });
-        return enqueue(op);
+        List<Integer> ordinals = enqueue(op);
+        if (ordinals != null && !ordinals.isEmpty()) {
+            return WatchedState.values()[ordinals.get(0)];
+        }
+        return WatchedState.UNWATCHED;
     }
 
     @Override
@@ -713,7 +717,11 @@ public class IDatabaseImpl extends IDatabaseBaseImpl implements IDatabase {
                 dataCallback.sendException(ex);
             }
         });
-        return enqueue(op);
+        List<Integer> ordinals = enqueue(op);
+        if (ordinals != null && !ordinals.isEmpty()) {
+            return DownloadedState.values()[ordinals.get(0)];
+        }
+        return DownloadedState.ONLINE;
     }
 
     @Override


### PR DESCRIPTION
### Description

The `execute()` and `enqueue()` methods in `IDatabaseBaseImpl` were not using matching generic types properly to ensure that that operation type matched the actual return type. Instead, the operation type was defined as a wildcard. This was actually covering over a few bugs in the implementation, where there were different types being returned, due to it missing a few conversion steps. However, these bugs weren't exposed since they were only there for the synchronous return type, which was returned as `null` when it was invoked asynchronously by providing a callback, and all the usages were providing callbacks.

This pull request fixes this issue by ensuring the matching of the generic types of the operation and the returned value, and fixing the improper usages in the implementations by adding the missing conversion logic.
### Reviewers

If you've been tagged for review, please "Start a review" with the GitHub GUI.
- Code review: @BenjiLee, @miankhalid
