### PR TITLE
Update build tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ before_script:
   - echo "runtime.scalefactor=auto" >> $HOME/.android/avd/screenshotDevice.avd/config.ini
   # Boot up the emulator in the background
   - emulator -avd screenshotDevice -no-audio -no-window &
+  - android list sdk --all
 
 script:
 # --debug or --info info flag can be suffixed to following command for more detailed logs of tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ android:
     - tools
 
     # The BuildTools version used
-    - build-tools-23.0.3
+    - build-tools-25.0.0
 
     # The SDK version used to compile the project
     - android-23

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 dist: precise # For 7.5GB of memory since the emulator requires a big chunk.
 env:
   matrix:
-    - ANDROID_TARGET=android-23
+    - ANDROID_TARGET=android-21
   global:
     - ADB_INSTALL_TIMEOUT=12
 android:
@@ -17,7 +17,7 @@ android:
     - build-tools-25.0.0
 
     # The SDK version used to compile the project
-    - android-23
+    - android-25
 
     # Additional components
     - extra-google-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ android:
     # use the latest revision of Android SDK Tools
     - platform-tools
     - tools
+    - tools # see https://github.com/travis-ci/travis-ci/issues/6040#issuecomment-219367943)
+
 
     # The BuildTools version used
     - build-tools-25.0.0

--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -231,7 +231,7 @@ android {
         }
     }
 
-    compileSdkVersion 23
+    compileSdkVersion 25
     buildToolsVersion BUILD_TOOLS_VERSION
 
     useLibrary 'org.apache.http.legacy'

--- a/android-iconify-fontawesome/build.gradle
+++ b/android-iconify-fontawesome/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.2'
 
         repositories {
             jcenter()

--- a/android-iconify-fontawesome/build.gradle
+++ b/android-iconify-fontawesome/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 25
     buildToolsVersion BUILD_TOOLS_VERSION
 
     defaultConfig {

--- a/android-iconify/build.gradle
+++ b/android-iconify/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.2'
 
         repositories {
             jcenter()

--- a/android-iconify/build.gradle
+++ b/android-iconify/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 25
     buildToolsVersion BUILD_TOOLS_VERSION
 
     defaultConfig {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()  //  This is the Maven Central repo
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 project.ext {
-    BUILD_TOOLS_VERSION = "23.0.3"
+    BUILD_TOOLS_VERSION = "25.0.0"
 
     // dummy keystore configuration if not already defined
     if ( !project.properties.containsKey("RELEASE_STORE_FILE")) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 14 12:48:05 EDT 2016
+#Tue Oct 25 06:30:22 PKT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
### Description

https://openedx.atlassian.net/browse/MA-2745

Android Studio 2.2.2 recommends updating the Gradle plugin to version 2.2.2, and Gradle to version 2.14.1, to take advantage of all the latest features (e.g. Instant Run), improvements, and security fixes. Therefore, this pull request updates Gradle and it's plugin to their recommended
versions. The build tools have also been updated to version 25, to take advantage of the latest tools and bugfixes.
### Reviewers

If you've been tagged for review, please "Start a review" with the GitHub GUI.
- Code review: @miankhalid
