### PR TITLE
Registration Screen Title Change and Navigation Button fix

### DIFF
--- a/OpenEdXMobile/res/layout/activity_single_fragment_base.xml
+++ b/OpenEdXMobile/res/layout/activity_single_fragment_base.xml
@@ -9,7 +9,7 @@
     android:splitMotionEvents="false">
 
     <android.support.design.widget.CoordinatorLayout
-        android:id="@+id/coorinator_layout"
+        android:id="@+id/coordinator_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fitsSystemWindows="true">

--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -496,7 +496,7 @@
     <!-- Text shown while waiting for registration request -->
     <string name="creating_account_text">Creating account...</string>
     <!-- Registration screen title -->
-    <string name="register_title">Sign up for {platform_name}</string>
+    <string name="register_title">Register</string>
     <!-- Text for successful registration with social token  -->
     <string name="sign_up_with_facebook_ok">You’ve successfully signed in with Facebook.</string>
     <string name="sign_up_with_google_ok">You’ve successfully signed in with Google.</string>

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/interactor/RegistrationScreenInteractor.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/interactor/RegistrationScreenInteractor.java
@@ -26,10 +26,7 @@ import static org.hamcrest.Matchers.instanceOf;
 
 public class RegistrationScreenInteractor {
     public RegistrationScreenInteractor observeRegistrationScreen() {
-        final MainApplication app = MainApplication.instance();
-        final CharSequence title = ResourceUtil.getFormattedString(app.getResources(),
-                R.string.register_title, "platform_name",
-                app.getInjector().getInstance(Config.class).getPlatformName());
+        final CharSequence title = "Register";
         onView(allOf(isInActionBar(), withText(title.toString()))).check(matches(isCompletelyDisplayed()));
         return this;
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
@@ -109,21 +109,15 @@ public abstract class BaseFragmentActivity extends BaseAppActivity
     protected void onResume() {
         super.onResume();
         EventBus.getDefault().registerSticky(this);
-        try {
-            DrawerLayout mDrawerLayout = (DrawerLayout)
-                    findViewById(R.id.drawer_layout);
-            if (mDrawerLayout != null) {
-
-                Fragment frag = getSupportFragmentManager()
-                        .findFragmentByTag("NavigationFragment");
-                if (frag == null) {
-                    getSupportFragmentManager().beginTransaction()
-                            .replace(R.id.slider_menu,
-                                    new NavigationFragment(), "NavigationFragment").commit();
-                }
+        DrawerLayout mDrawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
+        if (mDrawerLayout != null) {
+            Fragment frag = getSupportFragmentManager().findFragmentByTag("NavigationFragment");
+            if (frag == null) {
+                getSupportFragmentManager().beginTransaction().replace(
+                        R.id.slider_menu,
+                        new NavigationFragment(),
+                        "NavigationFragment").commit();
             }
-        } catch (Exception ex) {
-            logger.error(ex);
         }
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
@@ -87,22 +87,18 @@ public abstract class BaseFragmentActivity extends BaseAppActivity
     protected void onCreate(Bundle arg0) {
         super.onCreate(arg0);
         updateActionBarShadow();
-
-        logger.debug("created");
-    }
-
-    @Override
-    protected void onStart() {
-        super.onStart();
-        isActivityStarted = true;
-
-        // enabling action bar app icon.
         ActionBar bar = getSupportActionBar();
         if (bar != null) {
             bar.setDisplayShowHomeEnabled(true);
             bar.setDisplayHomeAsUpEnabled(true);
             bar.setIcon(android.R.color.transparent);
         }
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        isActivityStarted = true;
     }
 
     @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseSingleFragmentActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseSingleFragmentActivity.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v7.app.ActionBar;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.widget.ProgressBar;
@@ -38,6 +39,13 @@ public abstract class BaseSingleFragmentActivity extends BaseFragmentActivity im
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_single_fragment_base);
         setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
+
+        ActionBar bar = getSupportActionBar();
+        if (bar != null) {
+            bar.setDisplayShowHomeEnabled(true);
+            bar.setDisplayHomeAsUpEnabled(true);
+            bar.setIcon(android.R.color.transparent);
+        }
     }
 
     @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
+import android.support.v7.app.ActionBar;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.view.View;
@@ -52,6 +53,14 @@ public abstract class FindCoursesBaseActivity extends BaseFragmentActivity imple
         super.onCreate(savedInstanceState);
 
         setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
+
+        ActionBar bar = getSupportActionBar();
+        if (bar != null) {
+            bar.setDisplayShowHomeEnabled(true);
+            bar.setDisplayHomeAsUpEnabled(true);
+            bar.setIcon(android.R.color.transparent);
+        }
+
 
         webview = (WebView) findViewById(R.id.webview);
         offlineBar = findViewById(R.id.offline_bar);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseBaseActivity.java
@@ -3,6 +3,7 @@ package org.edx.mobile.view;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.widget.DrawerLayout;
+import android.support.v7.app.ActionBar;
 import android.support.v7.widget.Toolbar;
 import android.view.Gravity;
 import android.view.Menu;
@@ -69,6 +70,14 @@ public abstract  class CourseBaseActivity  extends BaseFragmentActivity implemen
     protected void onCreate(Bundle arg0) {
         super.onCreate(arg0);
         setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
+
+        ActionBar bar = getSupportActionBar();
+        if (bar != null) {
+            bar.setDisplayShowHomeEnabled(true);
+            bar.setDisplayHomeAsUpEnabled(true);
+            bar.setIcon(android.R.color.transparent);
+        }
+
         Bundle bundle = arg0;
         if ( bundle == null ) {
             if ( getIntent() != null )

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/LoginActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/LoginActivity.java
@@ -7,11 +7,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
 import android.support.v7.app.ActionBar;
-import android.view.Menu;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
-import android.view.animation.Animation;
 
 import com.google.inject.Inject;
 
@@ -33,7 +30,6 @@ import org.edx.mobile.util.Config;
 import org.edx.mobile.util.IntentFactory;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.util.ResourceUtil;
-import org.edx.mobile.util.ViewAnimationUtil;
 import org.edx.mobile.view.dialog.ResetPasswordActivity;
 import org.edx.mobile.view.dialog.SimpleAlertDialog;
 import org.edx.mobile.view.login.LoginPresenter;
@@ -122,6 +118,16 @@ public class LoginActivity extends PresenterActivity<LoginPresenter, LoginPresen
         }
 
         return new LoginPresenter.LoginViewInterface() {
+            @Override
+            public void disableToolbarNavigation() {
+                ActionBar actionBar = getSupportActionBar();
+                if (actionBar != null) {
+                    actionBar.setHomeButtonEnabled(false);
+                    actionBar.setDisplayHomeAsUpEnabled(false);
+                    actionBar.setDisplayShowHomeEnabled(false);
+                }
+            }
+
             @Override
             public void setSocialLoginButtons(boolean googleEnabled, boolean facebookEnabled) {
                 if (!facebookEnabled && !googleEnabled) {
@@ -265,18 +271,6 @@ public class LoginActivity extends PresenterActivity<LoginPresenter, LoginPresen
         super.showErrorDialog(header, message);
     }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        if (!environment.getConfig().isRegistrationEnabled()) {
-            ActionBar actionBar = getSupportActionBar();
-            if (actionBar != null) {
-                actionBar.setHomeButtonEnabled(false);
-                actionBar.setDisplayHomeAsUpEnabled(false);
-                actionBar.setDisplayShowHomeEnabled(false);
-            }
-        }
-    }
 
     /**
      * Starts fetching profile of the user after login by Facebook or Google.

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/LoginActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/LoginActivity.java
@@ -266,7 +266,8 @@ public class LoginActivity extends PresenterActivity<LoginPresenter, LoginPresen
     }
 
     @Override
-    public boolean createOptionsMenu(Menu menu) {
+    protected void onResume() {
+        super.onResume();
         if (!environment.getConfig().isRegistrationEnabled()) {
             ActionBar actionBar = getSupportActionBar();
             if (actionBar != null) {
@@ -275,7 +276,6 @@ public class LoginActivity extends PresenterActivity<LoginPresenter, LoginPresen
                 actionBar.setDisplayShowHomeEnabled(false);
             }
         }
-        return false;
     }
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListActivity.java
@@ -26,7 +26,7 @@ import roboguice.inject.InjectView;
 public class MyCoursesListActivity extends BaseSingleFragmentActivity {
 
     @NonNull
-    @InjectView(R.id.coorinator_layout)
+    @InjectView(R.id.coordinator_layout)
     private CoordinatorLayout coordinatorLayout;
 
     @Inject

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -73,7 +73,7 @@ public class RegisterActivity extends BaseFragmentActivity
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_register);
 
-        setTitle(ResourceUtil.getFormattedString(getResources(), R.string.register_title, "platform_name", environment.getConfig().getPlatformName()));
+        setTitle(R.string.register_title);
 
         environment.getSegment().trackScreenView(ISegment.Screens.LAUNCH_ACTIVITY);
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/login/LoginPresenter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/login/LoginPresenter.java
@@ -25,11 +25,17 @@ public class LoginPresenter extends ViewHoldingPresenter<LoginPresenter.LoginVie
         } else {
             view.setSocialLoginButtons(config.getGoogleConfig().isEnabled(), config.getFacebookConfig().isEnabled());
         }
+
+        if (!config.isRegistrationEnabled()) {
+            view.disableToolbarNavigation();
+        }
     }
 
     public interface LoginViewInterface {
 
         void setSocialLoginButtons(boolean googleEnabled, boolean facebookEnabled);
+
+        void disableToolbarNavigation();
 
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/my_videos/MyVideosActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/my_videos/MyVideosActivity.java
@@ -3,6 +3,7 @@ package org.edx.mobile.view.my_videos;
 import android.os.Bundle;
 import android.support.design.widget.TabLayout;
 import android.support.v4.view.ViewPager;
+import android.support.v7.app.ActionBar;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.view.WindowManager;
@@ -22,6 +23,13 @@ public class MyVideosActivity extends BaseVideosDownloadStateActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_myvideos_tab);
         setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
+
+        ActionBar bar = getSupportActionBar();
+        if (bar != null) {
+            bar.setDisplayShowHomeEnabled(true);
+            bar.setDisplayHomeAsUpEnabled(true);
+            bar.setIcon(android.R.color.transparent);
+        }
 
         // configure slider layout. This should be called only once and
         // hence is shifted to onCreate() function


### PR DESCRIPTION
### Description

[MA-2906](https://openedx.atlassian.net/browse/MA-2906)
[MA-2914](https://openedx.atlassian.net/browse/MA-2914)/[MA-3002](https://openedx.atlassian.net/browse/MA-3002)

Registration Screen now only says Register. 

When registration is disabled, back navigation button was reappearing onResume. Now it doesn't.

Notes: Both of these things are things that I missed in the original tickets.

### Testing
- Set `REGISTRATION_ENABLED` to False. Go to the sign in screen, put it in the background and return to it. Back navigation button should stay hidden.
- Registration screen's title should only say "Register"

### Reviewers

If you've been tagged for review, please "Start a review" with the GitHub GUI.

- Code review: @miankhalid , @1zaman 

