### PR TITLE
Remove error notifications from NavigationFragment

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/ErrorHandlingCallback.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/ErrorHandlingCallback.java
@@ -195,7 +195,7 @@ public abstract class ErrorHandlingCallback<T> implements Callback<T> {
         if (progressCallback != null) {
             progressCallback.finishProcess();
         }
-        if (messageCallback != null) {
+        if (messageCallback != null && !call.isCanceled()) {
             messageCallback.onMessage(callTrigger.getMessageType(),
                     ErrorUtils.getErrorMessage(error, context));
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
@@ -188,9 +188,6 @@ public class CourseDiscussionCommentsFragment extends BaseFragment implements Di
 
     @Override
     public void reportComment(@NonNull DiscussionComment comment) {
-        if (setCommentFlaggedCall != null) {
-            setCommentFlaggedCall.cancel();
-        }
         setCommentFlaggedCall = discussionService.setCommentFlagged(
                 comment.getIdentifier(), new FlagBody(!comment.isAbuseFlagged()));
         setCommentFlaggedCall.enqueue(new ErrorHandlingCallback<DiscussionComment>(

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/NavigationFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/NavigationFragment.java
@@ -42,7 +42,6 @@ import org.edx.mobile.user.UserService;
 import org.edx.mobile.util.Config;
 import org.edx.mobile.util.EmailUtil;
 import org.edx.mobile.util.ResourceUtil;
-import org.edx.mobile.view.common.TaskProgressCallback;
 import org.edx.mobile.view.my_videos.MyVideosActivity;
 
 import java.util.HashMap;
@@ -94,7 +93,8 @@ public class NavigationFragment extends BaseFragment {
                     getActivity(),
                     profile.username,
                     CallTrigger.LOADING_UNCACHED,
-                    (TaskProgressCallback) null)); // Disable global loading indicator
+                    null, // Disable global loading indicator
+                    null)); // Disable global error message overlay
         }
         EventBus.getDefault().register(this);
     }


### PR DESCRIPTION
### Description

[MA-2967][]

Since the navigation drawer usually isn't being displayed, it doesn’t make sense to have it show error notifications to the user. Even when the drawer is open and on display, there's no appropriate area to show a data loading error that’s associated with it. Therefore, this pull request removes the Snackbar error notification logic from calls made by `NavigationFragment`.

Note that the drawer was also added automatically to many Activities where it wasn’t even used, and was always blocked from opening, and where cases showing an error was completely inappropriate. This was because the default layout of the `BaseSingleFragmentActivity` included the drawer’s layout, and subclasses that didn’t support it (which were the majority) blocked it on a case-by-case basis.

### Reviewers

If you've been tagged for review, please "Start a review" with the GitHub GUI.

- Code review: @miankhalid, @BenjiLee

[MA-2967]: https://openedx.atlassian.net/browse/MA-2967