### PR TITLE
Estute/create make file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,11 @@ before_script:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH, DESCRIBE=$DESCRIBE"
   - chmod +x gradlew
-  # Beging spinning up an emulator in the background
+  # Begin spinning up an emulator in the background
   - make emulator
 
 script:
+  - make quality
   - make test
   # Check if emulator has finished booting
   - android-wait-for-emulator
@@ -45,6 +46,7 @@ script:
   - make e2e
 
 after_script:
+  - make artifacts
   - mv OpenEdXMobile/screenshots artifacts/
   - curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
   - ~/bin/artifacts upload artifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,32 +34,17 @@ before_script:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH, DESCRIBE=$DESCRIBE"
   - chmod +x gradlew
-  # ARM architecture is used instead of x86 (which is 10x faster) of the lack of support from CI due
-  # to complications of creating a virtual machine within a virtual machine. This may be solved
-  # eventually and would significantly speed some things up.
-  # Create the AVD for screenshot tests
-  - android create avd --force --name screenshotDevice --target android-21 --abi armeabi-v7a --device "Nexus 4" --skin 768x1280 --sdcard 250M
-  - echo "runtime.scalefactor=auto" >> $HOME/.android/avd/screenshotDevice.avd/config.ini
-  # Boot up the emulator in the background
-  - emulator -avd screenshotDevice -no-audio -no-window &
+  # Beging spinning up an emulator in the background
+  - make emulator
 
 script:
-# --debug or --info info flag can be suffixed to following command for more detailed logs of tests
-# It comes in handy to see stacktraces from test failures, which otherwise aren't printed
-# P.S. --debug flag prints too many logs that are mostly not needed, which make it exceed the
-#      4mb limit enforced by travis (so use it with caution)
-  - ./gradlew lintProdDebug
-  - ./gradlew copyLintBuildArtifacts
-  - ./gradlew testProdDebugUnitTestCoverage
-  - ./gradlew copyUnitTestBuildArtifacts
-
+  - make test
+  # Check if emulator has finished booting
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
-  # Run screenshot tests and compare them against screenshots in PR
-  - ./gradlew verifyMode screenshotTests -PdisablePreDex
+  - make e2e
 
 after_script:
-  - ./gradlew recordMode pullScreenshots -PdisablePreDex
   - mv OpenEdXMobile/screenshots artifacts/
   - curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
   - ~/bin/artifacts upload artifacts

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /usr/bin/env bash
-.PHONY: help requirements clean emulator test emulatorTest
+.PHONY: help requirements clean emulator test e2e
 
 help :
 	@echo ''

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,56 @@
+SHELL := /usr/bin/env bash
+.PHONY: help requirements clean emulator test emulatorTest
+
+help :
+	@echo ''
+	@echo 'Makefile for the edX Android application'
+	@echo 'Usage:'
+	@echo '    make help            show this information'
+	@echo '    make clean           remove artifacts from previous usage'
+	@echo '    make requirements    install python requirements'
+	@echo '    make emulator        create and initialize an android emulator'
+	@echo '    make test            run all local tests (linting, unit tests)'
+	@echo '    make e2e             run all emulator tests (e2e, screenshot tests)'
+	@echo 'Requirements:'
+	@echo '    You must have the `tools` directory in the Android SDK available'
+	@echo '    in your path'
+	@echo ''
+
+clean :
+	@echo 'Cleaning the workspace and any previously created AVDs'
+	./gradlew clean
+	rm -Rf $$HOME/.android/avd/screenshotDevice.avd
+	rm $$HOME/.android/avd/screenshotDevice.ini
+
+requirements :
+	@echo 'Installing python requirements'
+	@pip install --user -r requirements.txt --exists-action w
+
+emulator :
+	@echo 'Creating and initializing an Android emulator for testing the app'
+	# ARM architecture is used instead of x86 (which is 10x faster) of the lack
+	# of support from CI due to complications of creating a virtual machine
+	# within a virtual machine. This may be solved eventually and would
+	# significantly speed some things up.
+	@android create avd --force --name screenshotDevice --target android-21 \
+    --abi armeabi-v7a --device "Nexus 4" --skin 768x1280 --sdcard 250M
+	@echo "runtime.scalefactor=auto" >> \
+    $$HOME/.android/avd/screenshotDevice.avd/config.ini
+	# Boot up the emulator in the background. This can take a fair amount of
+	# time.
+	@emulator -avd screenshotDevice -no-audio -no-window &
+
+# `--debug` or `--info` info flags can be suffixed to the commands in the
+# following targets for more detailed logs of tests. It comes in handy to see
+# stacktraces from test failures, which otherwise aren't printed. P.S. --debug
+# flag prints too many logs that are mostly not needed, which make it exceed
+# the 4mb limit enforced by travis (so use it with caution)
+test:
+	@./gradlew lintProdDebug
+	@./gradlew copyLintBuildArtifacts
+	@./gradlew testProdDebugUnitTestCoverage
+	@./gradlew copyUnitTestBuildArtifacts
+
+e2e :
+	@./gradlew verifyMode screenshotTests -PdisablePreDex
+	@./gradlew recordMode pullScreenshots -PdisablePreDex

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /usr/bin/env bash
-.PHONY: help requirements clean emulator test e2e
+.PHONY: help requirements clean emulator quality test validate e2e artifacts
 
 help :
 	@echo ''
@@ -9,8 +9,11 @@ help :
 	@echo '    make clean           remove artifacts from previous usage'
 	@echo '    make requirements    install python requirements'
 	@echo '    make emulator        create and initialize an android emulator'
-	@echo '    make test            run all local tests (linting, unit tests)'
+	@echo '    make quality         check coding style'
+	@echo '    make test            run unit tests'
+	@echo '    make validate        run all local tests (linting, unit tests)'
 	@echo '    make e2e             run all emulator tests (e2e, screenshot tests)'
+	@echo '    make artifacts       gather artifacts from testing (reports, screenhsots)'
 	@echo 'Requirements:'
 	@echo '    You must have the `tools` directory in the Android SDK available'
 	@echo '    in your path'
@@ -24,7 +27,7 @@ clean :
 
 requirements :
 	@echo 'Installing python requirements'
-	@pip install --user -r requirements.txt --exists-action w
+	@pip install -r requirements.txt --exists-action w
 
 emulator :
 	@echo 'Creating and initializing an Android emulator for testing the app'
@@ -45,12 +48,18 @@ emulator :
 # stacktraces from test failures, which otherwise aren't printed. P.S. --debug
 # flag prints too many logs that are mostly not needed, which make it exceed
 # the 4mb limit enforced by travis (so use it with caution)
-test:
+quality:
 	@./gradlew lintProdDebug
-	@./gradlew copyLintBuildArtifacts
+
+test:
 	@./gradlew testProdDebugUnitTestCoverage
-	@./gradlew copyUnitTestBuildArtifacts
+
+validate: quality test
 
 e2e :
 	@./gradlew verifyMode screenshotTests -PdisablePreDex
+
+artifacts:
+	@./gradlew copyLintBuildArtifacts
+	@./gradlew copyUnitTestBuildArtifacts
 	@./gradlew recordMode pullScreenshots -PdisablePreDex

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+codecov
+pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-codecov
-pillow
+codecov==2.0.5
+Pillow==3.4.2


### PR DESCRIPTION
### Description
[TE-1768](https://openedx.atlassian.net/browse/TE-1768)
Separate travis commands into a build script

### Notes
I know this may seem a bit redundant, what with gradle and all, but in order to be able to run on both Jenkins and Travis, the set up and repo-specific gradle commands for the app must be CI-agnostic.

### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit shows 0 violations
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Analytics
- [ ] Performance
- [ ] Database migrations are backwards-compatible

### Reviewers
@BenjiLee 
@jzoldak @benpatterson for OEP-8 compliance
