### PR TITLE
Hide action buttons for own thread, response & comment

### DIFF
--- a/OpenEdXMobile/res/layout/discussion_response_action_bar_layout.xml
+++ b/OpenEdXMobile/res/layout/discussion_response_action_bar_layout.xml
@@ -2,6 +2,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/discussion_actions_bar"
     style="@style/discussion_responses_nested_card_layout"
     android:layout_height="@dimen/discussion_responses_secondary_actions_bar_height"
     tools:showIn="@layout/row_discussion_responses_response">
@@ -71,4 +72,8 @@
             style="@style/discussion_responses_small_text"
             android:text="@string/discussion_responses_report_label" />
     </LinearLayout>
+
+    <View
+        style="@style/light_gray_separator"
+        android:layout_gravity="top" />
 </FrameLayout>

--- a/OpenEdXMobile/res/layout/row_discussion_comments_comment.xml
+++ b/OpenEdXMobile/res/layout/row_discussion_comments_comment.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -8,10 +7,10 @@
     android:layout_marginLeft="@dimen/discussion_responses_standard_margin"
     android:layout_marginRight="@dimen/discussion_responses_standard_margin"
     app:cardCornerRadius="@dimen/edx_box_radius"
-    app:cardPreventCornerOverlap="false"
-    app:cardUseCompatPadding="true"
     app:cardElevation="1dp"
-    app:cardMaxElevation="1dp">
+    app:cardMaxElevation="1dp"
+    app:cardPreventCornerOverlap="false"
+    app:cardUseCompatPadding="true">
 
     <LinearLayout
         android:id="@+id/row_discussion_comment_layout"
@@ -28,13 +27,21 @@
             style="@style/discussion_regular_text"
             tools:text="This is the text of a comment. This is the text of a comment. This is the text of a comment. This is the text of a comment. This is the text of a comment." />
 
-        <TextView
-            android:id="@+id/discussion_comment_count_report_text_view"
-            style="@style/discussion_responses_small_text"
+        <!-- This container layout is only defined to add bottom padding to the parent view, when
+             the enclosed TextView's visibility is set to GONE. -->
+        <FrameLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:layout_gravity="end"
-            android:background="?android:selectableItemBackground"
-            android:clickable="true"
-            android:padding="@dimen/discussion_responses_box_padding"
-            tools:text="@string/discussion_responses_report_label" />
+            android:minHeight="@dimen/discussion_responses_box_padding">
+
+            <TextView
+                android:id="@+id/discussion_comment_count_report_text_view"
+                style="@style/discussion_responses_small_text"
+                android:background="?android:selectableItemBackground"
+                android:clickable="true"
+                android:padding="@dimen/discussion_responses_box_padding"
+                tools:text="@string/discussion_responses_report_label" />
+        </FrameLayout>
     </LinearLayout>
 </android.support.v7.widget.CardView>

--- a/OpenEdXMobile/res/layout/row_discussion_responses_response.xml
+++ b/OpenEdXMobile/res/layout/row_discussion_responses_response.xml
@@ -40,8 +40,6 @@
 
         </LinearLayout>
 
-        <View style="@style/light_gray_separator" />
-
         <include layout="@layout/discussion_response_action_bar_layout" />
 
         <RelativeLayout

--- a/OpenEdXMobile/res/layout/row_discussion_responses_thread.xml
+++ b/OpenEdXMobile/res/layout/row_discussion_responses_thread.xml
@@ -57,8 +57,6 @@
 
     </LinearLayout>
 
-    <View style="@style/light_gray_separator" />
-
     <include layout="@layout/discussion_response_action_bar_layout" />
 
 </LinearLayout>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/DiscussionCommentsAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/DiscussionCommentsAdapter.java
@@ -5,6 +5,7 @@ import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.v4.widget.TextViewCompat;
 import android.support.v7.widget.RecyclerView;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -18,6 +19,7 @@ import org.edx.mobile.R;
 import org.edx.mobile.discussion.DiscussionComment;
 import org.edx.mobile.discussion.DiscussionTextUtils;
 import org.edx.mobile.discussion.DiscussionThread;
+import org.edx.mobile.module.prefs.LoginPrefs;
 import org.edx.mobile.util.Config;
 import org.edx.mobile.view.view_holders.AuthorLayoutViewHolder;
 
@@ -30,6 +32,9 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
 
     @Inject
     private Config config;
+
+    @Inject
+    private LoginPrefs loginPrefs;
 
     @NonNull
     private final Context context;
@@ -111,6 +116,7 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
         final ResponseOrCommentViewHolder holder = (ResponseOrCommentViewHolder) viewHolder;
         final DiscussionComment discussionComment;
         final IconDrawable iconDrawable;
+
         if (position == 0) {
             discussionComment = response;
 
@@ -123,7 +129,6 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
                     .colorRes(context, R.color.edx_brand_gray_base);
             holder.discussionCommentCountReportTextView.setOnClickListener(null);
             holder.discussionCommentCountReportTextView.setClickable(false);
-
         } else {
             holder.authorLayoutViewHolder.answerTextView.setVisibility(View.GONE);
             discussionComment = discussionComments.get(position - 1);
@@ -131,14 +136,20 @@ public class DiscussionCommentsAdapter extends RecyclerView.Adapter implements I
             iconDrawable = new IconDrawable(context, FontAwesomeIcons.fa_flag)
                     .sizeRes(context, R.dimen.edx_small)
                     .colorRes(context, discussionComment.isAbuseFlagged() ? R.color.edx_brand_primary_base : R.color.edx_brand_gray_base);
-            holder.discussionCommentCountReportTextView.setText(discussionComment.isAbuseFlagged() ? context.getString(R.string.discussion_responses_reported_label) : context.getString(R.string.discussion_responses_report_label));
-            holder.discussionCommentCountReportTextView.setTextColor(context.getResources().getColor(R.color.edx_brand_gray_base));
 
-            holder.discussionCommentCountReportTextView.setOnClickListener(new View.OnClickListener() {
-                public void onClick(final View v) {
-                    listener.reportComment(discussionComment);
-                }
-            });
+            if (TextUtils.equals(loginPrefs.getUsername(), discussionComment.getAuthor())) {
+                holder.discussionCommentCountReportTextView.setVisibility(View.GONE);
+            } else {
+                holder.discussionCommentCountReportTextView.setVisibility(View.VISIBLE);
+                holder.discussionCommentCountReportTextView.setText(discussionComment.isAbuseFlagged() ? context.getString(R.string.discussion_responses_reported_label) : context.getString(R.string.discussion_responses_report_label));
+                holder.discussionCommentCountReportTextView.setTextColor(context.getResources().getColor(R.color.edx_brand_gray_base));
+
+                holder.discussionCommentCountReportTextView.setOnClickListener(new View.OnClickListener() {
+                    public void onClick(final View v) {
+                        listener.reportComment(discussionComment);
+                    }
+                });
+            }
         }
 
         holder.authorLayoutViewHolder.populateViewHolder(config, discussionComment,


### PR DESCRIPTION
### Description

[MA-2818](https://openedx.atlassian.net/browse/MA-2818)

Hide follow, report and vote buttons when a thread, response or comment is posted by oneself.

Here's how it looks:

Thread & Response | Comment
---- | ----
![responsesscreen](https://cloud.githubusercontent.com/assets/1710804/20384540/0727fc14-acd6-11e6-87e2-acfcdae68d89.png) | ![commentsscreen](https://cloud.githubusercontent.com/assets/1710804/20384541/0820f210-acd6-11e6-91fc-55e39db2992d.png)

### Reviewers

If you've been tagged for review, please "Start a review" with the GitHub GUI.

- Code review: @1zaman , @BenjiLee 

