### PR TITLE
Fixed bug where 2 actionbars were loading for Certificates screen

### DIFF
--- a/OpenEdXMobile/AndroidManifest.xml
+++ b/OpenEdXMobile/AndroidManifest.xml
@@ -207,7 +207,9 @@
         <activity
             android:name="org.edx.mobile.view.CertificateActivity"
             android:label="@string/tab_label_certificate"
-            android:screenOrientation="portrait" />
+            android:screenOrientation="portrait"
+            android:theme="@style/AppTheme.NoActionBar.TranslucentStatusBar"/>
+
         <activity
             android:name="org.edx.mobile.view.SettingsActivity"
             android:label="@string/app_name"


### PR DESCRIPTION
### Description

Issue reported in Fabric for Android 2.7.3 rollout.

```
Fatal Exception: java.lang.RuntimeException: Unable to start activity ComponentInfo{org.edx.mobile/org.edx.mobile.view.CertificateActivity}: java.lang.IllegalStateException: This Activity already has an action bar supplied by the window decor. Do not request Window.FEATURE_SUPPORT_ACTION_BAR and set windowActionBar to false in your theme to use a Toolbar instead.
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2326)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2387)
       at android.app.ActivityThread.access$800(ActivityThread.java:147)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1281)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:135)
       at android.app.ActivityThread.main(ActivityThread.java:5264)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:900)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:695)
Caused by java.lang.IllegalStateException: This Activity already has an action bar supplied by the window decor. Do not request Window.FEATURE_SUPPORT_ACTION_BAR and set windowActionBar to false in your theme to use a Toolbar instead.
       at android.support.v7.app.AppCompatDelegateImplV7.setSupportActionBar(AppCompatDelegateImplV7.java:197)
       at android.support.v7.app.AppCompatActivity.setSupportActionBar(AppCompatActivity.java:126)
       at org.edx.mobile.base.BaseSingleFragmentActivity.onCreate(BaseSingleFragmentActivity.java:40)
       at android.app.Activity.performCreate(Activity.java:5975)
       at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1105)
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2269)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2387)
       at android.app.ActivityThread.access$800(ActivityThread.java:147)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1281)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:135)
       at android.app.ActivityThread.main(ActivityThread.java:5264)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:900)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:695)
```
