### PR TITLE
Make sure that Acceptance tests (androidTests):

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -218,6 +218,10 @@ dependencies {
     androidTestCompile ("org.mockito:mockito-core:1.10.19"){
         exclude group: 'org.hamcrest'
     }
+    androidTestCompile ('com.squareup.retrofit2:retrofit-mock:2.1.0') {
+        exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+    }
+
 }
 
 configurations {

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/FeatureTest.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/FeatureTest.java
@@ -29,9 +29,9 @@ public abstract class FeatureTest {
         environment.getLoginPrefs().clear();
         environment.getAnalyticsRegistry().resetIdentifyUser();
     }
+
     @After
-    public void removeMocks()
-    {
+    public void removeMocks() {
         RoboGuice.Util.reset();
     }
 }

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/FeatureTest.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/FeatureTest.java
@@ -2,10 +2,17 @@ package org.edx.mobile.test.feature;
 
 import android.support.test.runner.AndroidJUnit4;
 
+import com.google.inject.util.Modules;
+
 import org.edx.mobile.base.MainApplication;
+import org.edx.mobile.core.EdxDefaultModule;
 import org.edx.mobile.core.EdxEnvironment;
+import org.edx.mobile.test.util.MockOverrideModule;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
+
+import roboguice.RoboGuice;
 
 @RunWith(AndroidJUnit4.class)
 public abstract class FeatureTest {
@@ -15,8 +22,16 @@ public abstract class FeatureTest {
     public void setup() {
         // Ensure we are not logged in
         final MainApplication application = MainApplication.instance();
+        RoboGuice.overrideApplicationInjector(application,
+                Modules.override(new EdxDefaultModule(application.getApplicationContext()))
+                        .with(new MockOverrideModule()));
         environment = application.getInjector().getInstance(EdxEnvironment.class);
         environment.getLoginPrefs().clear();
         environment.getAnalyticsRegistry().resetIdentifyUser();
+    }
+    @After
+    public void removeMocks()
+    {
+        RoboGuice.Util.reset();
     }
 }

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/LaunchFeatureTest.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/LaunchFeatureTest.java
@@ -7,9 +7,6 @@ import org.edx.mobile.test.feature.data.TestValues;
 import org.edx.mobile.test.feature.interactor.AppInteractor;
 import org.junit.Test;
 
-
-
-
 public class LaunchFeatureTest extends FeatureTest {
 
     @Test
@@ -18,6 +15,7 @@ public class LaunchFeatureTest extends FeatureTest {
                 .launchApp()
                 .observeLandingScreen();
     }
+
     @Test
     public void whenAppLaunched_withValidUser_myCoursesScreenIsShown() throws Exception {
         final MainApplication application = MainApplication.instance();
@@ -34,7 +32,6 @@ public class LaunchFeatureTest extends FeatureTest {
         environment.getLoginPrefs().storeUserProfile(null); // Make sure that profile is null so we are going back to landing screen
         new AppInteractor()
                 .launchApp()
-                .observeLandingScreen(); // If profile is not set &
+                .observeLandingScreen();
     }
 }
-

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/LaunchFeatureTest.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/LaunchFeatureTest.java
@@ -7,6 +7,9 @@ import org.edx.mobile.test.feature.data.TestValues;
 import org.edx.mobile.test.feature.interactor.AppInteractor;
 import org.junit.Test;
 
+
+
+
 public class LaunchFeatureTest extends FeatureTest {
 
     @Test
@@ -15,7 +18,6 @@ public class LaunchFeatureTest extends FeatureTest {
                 .launchApp()
                 .observeLandingScreen();
     }
-
     @Test
     public void whenAppLaunched_withValidUser_myCoursesScreenIsShown() throws Exception {
         final MainApplication application = MainApplication.instance();
@@ -27,13 +29,12 @@ public class LaunchFeatureTest extends FeatureTest {
     }
 
     @Test
-    public void whenAppLaunched_withInvalidAuthToken_logInScreenIsShown() {
+    public void whenAppLaunched_withInvalidProfile_landingScreenIsShown() {
         environment.getLoginPrefs().storeAuthTokenResponse(TestValues.INVALID_AUTH_TOKEN_RESPONSE, LoginPrefs.AuthBackend.PASSWORD);
-        environment.getLoginPrefs().storeUserProfile(TestValues.DUMMY_PROFILE);
+        environment.getLoginPrefs().storeUserProfile(null); // Make sure that profile is null so we are going back to landing screen
         new AppInteractor()
                 .launchApp()
-                .observeLogInScreen()
-                .navigateBack()
-                .observeLandingScreen();
+                .observeLandingScreen(); // If profile is not set &
     }
 }
+

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/LogInFeatureTest.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/LogInFeatureTest.java
@@ -12,6 +12,7 @@ public class LogInFeatureTest extends FeatureTest {
                 .launchApp()
                 .observeLandingScreen()
                 .navigateToLogInScreen()
+                .observeLogInScreen()
                 .logIn(TestValues.ACTIVE_USER_CREDENTIALS)
                 .observeMyCoursesScreen();
     }

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/LogOutFeatureTest.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/LogOutFeatureTest.java
@@ -15,6 +15,6 @@ public class LogOutFeatureTest extends FeatureTest {
                 .logIn(TestValues.ACTIVE_USER_CREDENTIALS)
                 .openNavigationDrawer()
                 .logOut()
-                .observeLogInScreen();
+                .observeLandingScreen();
     }
 }

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/data/TestValues.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/data/TestValues.java
@@ -3,12 +3,95 @@ package org.edx.mobile.test.feature.data;
 import com.google.gson.Gson;
 
 import org.edx.mobile.authentication.AuthResponse;
+import org.edx.mobile.course.CourseDetail;
+import org.edx.mobile.model.Page;
+import org.edx.mobile.model.PaginationData;
+import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.model.api.ProfileModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import retrofit2.Call;
+
+import static java.util.Arrays.asList;
 
 public enum TestValues {
     ;
 
     public static final Credentials ACTIVE_USER_CREDENTIALS = new Credentials("honor@example.com", "edx");
     public static final ProfileModel DUMMY_PROFILE = new Gson().fromJson("{\"id\": 1, \"username\": \"user\", \"email\": \"email@example.com\", \"name\": \"name\", \"course_enrollments\": \"https://mobile-devi.sandbox.edx.org/api/mobile/v0.5/users/staff/course_enrollments/\"}", ProfileModel.class);
-    public static final AuthResponse INVALID_AUTH_TOKEN_RESPONSE = new Gson().fromJson("{\"access_token\": \"I am an invalid token\", \"token_type\": \"Bearer\", \"expires_in\": 2591999, \"scope\": \"\"}", AuthResponse.class);
+    public static final AuthResponse INVALID_AUTH_TOKEN_RESPONSE = new Gson().fromJson("{\"access_token\": \"I am an invalid token\", \"token_type\": \"Bearer\", \"expires_in\": 2591999, \"scope\": \"\",\"error\":\"true\"}", AuthResponse.class);
+    public static final AuthResponse VALID_AUTH_TOKEN_RESPONSE = new Gson().fromJson("{\"access_token\": \"validtoken\", \"token_type\": \"Bearer\", \"expires_in\": 2591999, \"scope\": \"\"}", AuthResponse.class);
+
+    private static final List<CourseDetail> clist =
+            new ArrayList<CourseDetail>(asList (
+                new Gson().fromJson(
+                        "{ \"course_id\": \"EDX/EDX101/NOW\"," +
+                                "\"name\": \"EdX Test Course 1\"," +
+                                "\"number\": \"EDX101\"," +
+                                "\"org\": \"EDX\"," +
+                                "\"short_description\": \"\"," +
+                                "\"effort\": null," +
+                                "\"media\": {" +
+                                "\"course_image\": {" +
+                                "\"uri\": \"/c4x/EDX/EDX101/asset/images_course_image.jpg\"" +
+                                "}," +
+                                "\"course_video\": {" +
+                                "\"uri\": null" +
+                                "}" +
+                                "}," +
+                                "\"start\": \"2015-01-01T00:00:00Z\"," +
+                                "\"start_type\": \"timestamp\"," +
+                                "\"start_display\": \"1 janvier 2015\"," +
+                                "\"end\": null," +
+                                "\"enrollment_start\": null," +
+                                "\"enrollment_end\": null," +
+                                "\"blocks_url\": \"https://edx.org/api/courses/v1/blocks/?course_id=EDX%2FEDX101%2FNOW\"" +
+                                "}",
+                        CourseDetail.class),
+                new Gson().fromJson(
+                        "{ \"course_id\": \"EDX/EDX102/NOW\"," +
+                                "\"name\": \"EdX Test Course 2\"," +
+                                "\"number\": \"EDX102\"," +
+                                "\"org\": \"EDX\"," +
+                                "\"short_description\": \"\"," +
+                                "\"effort\": null," +
+                                "\"media\": {" +
+                                "\"course_image\": {" +
+                                "\"uri\": \"/c4x/EDX/EDX102/asset/images_course_image.jpg\"" +
+                                "}," +
+                                "\"course_video\": {" +
+                                "\"uri\": null" +
+                                "}" +
+                                "}," +
+                                "\"start\": \"2016-01-01T00:00:00Z\"," +
+                                "\"start_type\": \"timestamp\"," +
+                                "\"start_display\": \"1 janvier 2016\"," +
+                                "\"end\": null," +
+                                "\"enrollment_start\": null," +
+                                "\"enrollment_end\": null," +
+                                "\"blocks_url\": \"https://edx.org/api/courses/v1/blocks/?course_id=EDX%2FEDX102%2FNOW\"" +
+                                "}",
+                        CourseDetail.class)
+            ));
+
+    public static final Page<CourseDetail> BASIC_COURSE_LIST = new Page<CourseDetail>(
+            new PaginationData(1,1,  null,null),
+            clist);
+
+    public static final List<EnrolledCoursesResponse> BASIC_USER_ENROLLED_COURSES =
+            new ArrayList<EnrolledCoursesResponse>(
+                    asList (new Gson().fromJson(" {\n" +
+                                    "        \"created\": \"2016-01-01T00:00:00Z\",\n" +
+                                    "        \"mode\": \"honor\",\n" +
+                                    "        \"is_active\": true,\n" +
+                                    "        \"course\": {\n" +
+                                    "            \"id\": \"EDX/EDX102/NOW\",\n" +
+                                    "            \"name\": \"EdX Test Course 2\"\n" +
+                                    "        },\n" +
+                                    "        \"user\": \"honor\"\n" +
+                                    "    }",
+                            EnrolledCoursesResponse.class))
+            );
 }

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/interactor/LogInScreenInteractor.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/interactor/LogInScreenInteractor.java
@@ -6,30 +6,38 @@ import android.support.test.espresso.ViewInteraction;
 import org.edx.mobile.R;
 import org.edx.mobile.base.MainApplication;
 import org.edx.mobile.test.feature.data.Credentials;
-import org.edx.mobile.util.Config;
-import org.edx.mobile.util.ResourceUtil;
+import org.edx.mobile.test.feature.matcher.TextInputLayoutMatcher;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.replaceText;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
-import static android.support.test.espresso.matcher.ViewMatchers.withHint;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withParent;
+import static android.support.test.espresso.matcher.ViewMatchers.withTagValue;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static org.edx.mobile.test.feature.matcher.ActionBarMatcher.isInActionBar;
+import static org.edx.mobile.test.feature.matcher.TextInputLayoutMatcher.inputLayoutWithHint;
 import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.Matchers.is;
 
 public class LogInScreenInteractor {
 
     public LogInScreenInteractor observeLogInScreen() {
         final MainApplication app = MainApplication.instance();
         final CharSequence title = app.getResources().getString(R.string.login_title);
-        onView(allOf(isInActionBar(), withText(title.toString()))).check(matches(isCompletelyDisplayed()));
-        onUsernameView().check(matches(isCompletelyDisplayed()));
-        onPasswordView().check(matches(isCompletelyDisplayed()));
-        onLogInButton().check(matches(isCompletelyDisplayed()));
+        onView(
+                allOf(
+                        isInActionBar(),
+                        withText(title.toString())))
+                .check(matches(isCompletelyDisplayed()));
+
+        onUsernameView().check(matches(isDisplayed()));
+        onPasswordView().check(matches(isDisplayed()));
+        onLogInButton().check(matches(isDisplayed()));
         return this;
     }
 
@@ -46,14 +54,15 @@ public class LogInScreenInteractor {
     }
 
     private ViewInteraction onUsernameView() {
-        return onView(withHint(R.string.email_username));
+        return onView(withParent(inputLayoutWithHint(is(MainApplication.instance().getResources().getString(R.string.email_username)))));
     }
 
     private ViewInteraction onPasswordView() {
-        return onView(withHint(R.string.password));
+        return onView(withParent(inputLayoutWithHint(is(MainApplication.instance().getResources().getString(R.string.password)))));
     }
 
     private ViewInteraction onLogInButton() {
-        return onView(withContentDescription(R.string.login_btn));
+        return onView(withContentDescription(MainApplication.instance().getResources().getString(R.string.login_btn)));
     }
+
 }

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/interactor/LogInScreenInteractor.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/interactor/LogInScreenInteractor.java
@@ -29,12 +29,7 @@ public class LogInScreenInteractor {
     public LogInScreenInteractor observeLogInScreen() {
         final MainApplication app = MainApplication.instance();
         final CharSequence title = app.getResources().getString(R.string.login_title);
-        onView(
-                allOf(
-                        isInActionBar(),
-                        withText(title.toString())))
-                .check(matches(isCompletelyDisplayed()));
-
+        onView(allOf(isInActionBar(),withText(title.toString()))).check(matches(isCompletelyDisplayed()));
         onUsernameView().check(matches(isDisplayed()));
         onPasswordView().check(matches(isDisplayed()));
         onLogInButton().check(matches(isDisplayed()));

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/interactor/NavigationDrawerInteractor.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/interactor/NavigationDrawerInteractor.java
@@ -15,8 +15,8 @@ public class NavigationDrawerInteractor {
         return new NavigationDrawerInteractor();
     }
 
-    public LogInScreenInteractor logOut() {
+    public LandingScreenInteractor logOut() {
         onView(withText(R.string.logout)).perform(click());
-        return new LogInScreenInteractor();
+        return new LandingScreenInteractor();
     }
 }

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/interactor/RegistrationScreenInteractor.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/interactor/RegistrationScreenInteractor.java
@@ -4,10 +4,10 @@ import android.support.test.espresso.ViewInteraction;
 
 import org.edx.mobile.R;
 import org.edx.mobile.base.MainApplication;
+import org.edx.mobile.module.registration.model.RegistrationOption;
 import org.edx.mobile.test.feature.data.Credentials;
 import org.edx.mobile.util.Config;
 import org.edx.mobile.util.ResourceUtil;
-import org.hamcrest.CoreMatchers;
 
 import static android.support.test.espresso.Espresso.onData;
 import static android.support.test.espresso.Espresso.onView;
@@ -16,6 +16,7 @@ import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard
 import static android.support.test.espresso.action.ViewActions.typeText;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withTagValue;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
@@ -37,25 +38,25 @@ public class RegistrationScreenInteractor {
         onUsernameView().perform(typeText(credentials.username), closeSoftKeyboard());
         onPasswordView().perform(typeText(credentials.password), closeSoftKeyboard());
         onCountryView().perform(click());
-        onData(allOf(is(instanceOf(String.class)))).atPosition(1).perform(click());
+        onData(allOf(is(instanceOf(RegistrationOption.class)))).atPosition(1).perform(click());
         onCreateAccountButton().perform(click());
         return new MyCoursesScreenInteractor();
     }
 
     private ViewInteraction onEmailView() {
-        return onView(withTagValue(is((Object) "email")));
+        return onView(isDescendantOfA(withTagValue(is((Object) "email"))));
     }
 
     private ViewInteraction onNameView() {
-        return onView(withTagValue(is((Object) "name")));
+        return onView(isDescendantOfA(withTagValue(is((Object) "name"))));
     }
 
     private ViewInteraction onUsernameView() {
-        return onView(withTagValue(is((Object) "username")));
+        return onView(isDescendantOfA(withTagValue(is((Object) "username"))));
     }
 
     private ViewInteraction onPasswordView() {
-        return onView(withTagValue(is((Object) "password")));
+        return onView(isDescendantOfA(withTagValue(is((Object) "password"))));
     }
 
     private ViewInteraction onCountryView() {

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/matcher/ActionBarMatcher.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/matcher/ActionBarMatcher.java
@@ -2,16 +2,21 @@ package org.edx.mobile.test.feature.matcher;
 
 import android.view.View;
 
+import org.edx.mobile.R;
 import org.hamcrest.Matcher;
 
 import static android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static org.hamcrest.Matchers.anyOf;
+
 
 public enum ActionBarMatcher {
     ;
 
     public static Matcher<View> isInActionBar() {
-        return isDescendantOfA(withId(android.support.design.R.id.action_bar_container));
+        return anyOf(isDescendantOfA(withId(android.support.design.R.id.action_bar_container)),
+                isDescendantOfA(withId(R.id.toolbar))); // Structures of views are not uniform. Action bar
+               // and labels are located in a slightly different hierarchy (login page, my course page)
     }
 }
 

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/matcher/ActionBarMatcher.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/matcher/ActionBarMatcher.java
@@ -9,14 +9,12 @@ import static android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static org.hamcrest.Matchers.anyOf;
 
-
 public enum ActionBarMatcher {
     ;
 
     public static Matcher<View> isInActionBar() {
         return anyOf(isDescendantOfA(withId(android.support.design.R.id.action_bar_container)),
                 isDescendantOfA(withId(R.id.toolbar))); // Structures of views are not uniform. Action bar
-               // and labels are located in a slightly different hierarchy (login page, my course page)
+        // and labels are located in a slightly different hierarchy (login page, my course page)
     }
 }
-

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/matcher/TextInputLayoutMatcher.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/feature/matcher/TextInputLayoutMatcher.java
@@ -1,0 +1,35 @@
+package org.edx.mobile.test.feature.matcher;
+
+import android.support.design.widget.TextInputLayout;
+import android.support.test.espresso.matcher.BoundedMatcher;
+import android.view.View;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+import static android.support.test.espresso.core.deps.guava.base.Preconditions.checkNotNull;
+
+
+/**
+ * Matcher for EditText items located within TextInputLayout
+ * This will allow to match the EditText component whenever it is
+ * nested in a TextInputLayout entity.
+ * https://code.google.com/p/android/issues/detail?id=191261
+ */
+
+public class TextInputLayoutMatcher {
+    public static Matcher<View> inputLayoutWithHint(final Matcher<String> stringMatcher) {
+        checkNotNull(stringMatcher);
+        return new BoundedMatcher<View, TextInputLayout>(TextInputLayout.class) {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("with hint: ");
+                stringMatcher.describeTo(description);
+            }
+            @Override
+            public boolean matchesSafely(TextInputLayout textView) {
+                return stringMatcher.matches(textView.getHint());
+            }
+        };
+    }
+}

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/util/MockOverrideModule.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/util/MockOverrideModule.java
@@ -43,7 +43,7 @@ public class MockOverrideModule extends AbstractModule {
 
         try {
             when(mockLoginAPI.logInUsingEmail(TestValues.ACTIVE_USER_CREDENTIALS.email,
-                            TestValues.ACTIVE_USER_CREDENTIALS.password))
+                    TestValues.ACTIVE_USER_CREDENTIALS.password))
                     .thenAnswer(new Answer<AuthResponse>() {
                         public AuthResponse answer(InvocationOnMock invocation) throws Throwable {
                             EdxEnvironment environment = MainApplication.instance().getInjector().getInstance(EdxEnvironment.class);
@@ -56,7 +56,7 @@ public class MockOverrideModule extends AbstractModule {
             when(mockLoginAPI.registerUsingEmail(any(Bundle.class)))
                     .thenAnswer(new Answer<AuthResponse>() {
                         public AuthResponse answer(InvocationOnMock invocation) throws Throwable {
-                            Bundle bundle = invocation.getArgumentAt(0,Bundle.class);
+                            Bundle bundle = invocation.getArgumentAt(0, Bundle.class);
                             EdxEnvironment environment = MainApplication.instance().getInjector().getInstance(EdxEnvironment.class);
                             environment.getLoginPrefs().storeAuthTokenResponse(TestValues.VALID_AUTH_TOKEN_RESPONSE, LoginPrefs.AuthBackend.PASSWORD);
                             ProfileModel profile = new ProfileModel();
@@ -73,7 +73,7 @@ public class MockOverrideModule extends AbstractModule {
             when(mockCourseAPI.getCourseList(anyInt()))
                     .thenReturn(Calls.response(TestValues.BASIC_COURSE_LIST));
 
-            when (mockUserAPI.getUserEnrolledCourses(anyString(),anyString(),anyBoolean())).thenReturn(TestValues.BASIC_USER_ENROLLED_COURSES);
+            when(mockCourseAPI.getEnrolledCourses()).thenReturn(Calls.response(TestValues.BASIC_USER_ENROLLED_COURSES));
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -81,9 +81,9 @@ public class MockOverrideModule extends AbstractModule {
 
     @Override
     protected void configure() {
-
         bind(LoginAPI.class).toInstance(mockLoginAPI);
         bind(CourseAPI.class).toInstance(mockCourseAPI);
         bind(UserAPI.class).toInstance(mockUserAPI);
     }
 }
+

--- a/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/util/MockOverrideModule.java
+++ b/OpenEdXMobile/src/androidTest/java/org/edx/mobile/test/util/MockOverrideModule.java
@@ -1,0 +1,89 @@
+package org.edx.mobile.test.util;
+
+import android.os.Bundle;
+
+import com.google.inject.AbstractModule;
+
+import org.edx.mobile.authentication.AuthResponse;
+import org.edx.mobile.authentication.LoginAPI;
+import org.edx.mobile.base.MainApplication;
+import org.edx.mobile.core.EdxEnvironment;
+import org.edx.mobile.course.CourseAPI;
+import org.edx.mobile.model.api.ProfileModel;
+import org.edx.mobile.module.prefs.LoginPrefs;
+import org.edx.mobile.test.feature.data.TestValues;
+import org.edx.mobile.user.UserAPI;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import retrofit2.mock.Calls;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Make sure that basic modules are mocked so we can remove dependency on a
+ * real edX install.
+ */
+
+public class MockOverrideModule extends AbstractModule {
+    private final LoginAPI mockLoginAPI;
+    private final CourseAPI mockCourseAPI;
+    private final UserAPI mockUserAPI;
+
+    public MockOverrideModule() {
+        super();
+        mockLoginAPI = mock(LoginAPI.class);
+        mockCourseAPI = mock(CourseAPI.class);
+        mockUserAPI = mock(UserAPI.class);
+
+        try {
+            when(mockLoginAPI.logInUsingEmail(TestValues.ACTIVE_USER_CREDENTIALS.email,
+                            TestValues.ACTIVE_USER_CREDENTIALS.password))
+                    .thenAnswer(new Answer<AuthResponse>() {
+                        public AuthResponse answer(InvocationOnMock invocation) throws Throwable {
+                            EdxEnvironment environment = MainApplication.instance().getInjector().getInstance(EdxEnvironment.class);
+                            environment.getLoginPrefs().storeAuthTokenResponse(TestValues.VALID_AUTH_TOKEN_RESPONSE, LoginPrefs.AuthBackend.PASSWORD);
+                            environment.getLoginPrefs().storeUserProfile(TestValues.DUMMY_PROFILE);
+                            return (AuthResponse) TestValues.VALID_AUTH_TOKEN_RESPONSE;
+                        }
+                    });
+
+            when(mockLoginAPI.registerUsingEmail(any(Bundle.class)))
+                    .thenAnswer(new Answer<AuthResponse>() {
+                        public AuthResponse answer(InvocationOnMock invocation) throws Throwable {
+                            Bundle bundle = invocation.getArgumentAt(0,Bundle.class);
+                            EdxEnvironment environment = MainApplication.instance().getInjector().getInstance(EdxEnvironment.class);
+                            environment.getLoginPrefs().storeAuthTokenResponse(TestValues.VALID_AUTH_TOKEN_RESPONSE, LoginPrefs.AuthBackend.PASSWORD);
+                            ProfileModel profile = new ProfileModel();
+                            profile.name = bundle.getString("name");
+                            profile.email = bundle.getString("email");
+                            profile.username = bundle.getString("username");
+                            profile.course_enrollments = bundle.getString("course_enrollments");
+                            profile.id = bundle.getLong("id");
+                            environment.getLoginPrefs().storeUserProfile(profile);
+                            return (AuthResponse) TestValues.VALID_AUTH_TOKEN_RESPONSE;
+                        }
+                    });
+
+            when(mockCourseAPI.getCourseList(anyInt()))
+                    .thenReturn(Calls.response(TestValues.BASIC_COURSE_LIST));
+
+            when (mockUserAPI.getUserEnrolledCourses(anyString(),anyString(),anyBoolean())).thenReturn(TestValues.BASIC_USER_ENROLLED_COURSES);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    protected void configure() {
+
+        bind(LoginAPI.class).toInstance(mockLoginAPI);
+        bind(CourseAPI.class).toInstance(mockCourseAPI);
+        bind(UserAPI.class).toInstance(mockUserAPI);
+    }
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -175,7 +175,7 @@ public abstract class MainApplication extends MultiDexApplication {
     }
 
     public Injector getInjector() {
-        return injector;
+        return RoboGuice.getInjector(this.getApplicationContext());
     }
 
     @NonNull


### PR DESCRIPTION
### Description

This PR aims to detach completely the tests from an running edX instance by mocking some of the basic APIs and making sure that all existing acceptance tests are still running correctly. This might be used as a partial solution to MA-2082 (https://openedx.atlassian.net/browse/MA-2082).

Changes are the following:

Gradle Updates:
-  Add a dependency needed for acceptance tests

Main application (OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java):
- Make sure that we get the right injector for the tests (so we can mock the base services)

Other:
- Add a mock class to mock LoginAPI and CourseAPI and mock data
- Modify some tests so they work according to the new UI layout (tests were likely to be oudated)


### Notes
I have noticed that some of the work of Mocking the API was already done in the unit tests. Did not find any sure way of merging the two approaches as use case are different but it could be the next step.

### Testing:
- Using android studio: run test in the the org.edx.mobile package.