### PR TITLE
Allow DOM storage API for webview

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/FindCoursesBaseActivity.java
@@ -65,6 +65,8 @@ public abstract class FindCoursesBaseActivity extends BaseFragmentActivity imple
         offlineBar = findViewById(R.id.offline_bar);
         progressWheel = (ProgressBar) findViewById(R.id.loading_indicator);
 
+        webview.getSettings().setDomStorageEnabled(true);
+
         setupWebView();
         enableEnrollCallback();
 


### PR DESCRIPTION
### Description

[MA-3070](https://openedx.atlassian.net/browse/MA-3070)

Enabled DOM storage for the Find Courses webview. ECOM recently made this change which broke the webview on Android. 

Before/After:
<img src="https://cloud.githubusercontent.com/assets/7101723/21620107/c253be74-d1c0-11e6-8408-d2bface3f96a.png" width="200"> <img src="https://cloud.githubusercontent.com/assets/7101723/21620138/ec8dfd1c-d1c0-11e6-85c9-02bbe89b2a8f.png" width="200">


