### PR TITLE
Added hard-coded Chinese language exceptions

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/LocaleUtils.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/LocaleUtils.java
@@ -16,10 +16,23 @@ public class LocaleUtils {
 
     public static String getLanguageNameFromCode(@NonNull String languageCode) throws InvalidLocaleException {
         final String lowercaseLanguage = languageCode.toLowerCase(Locale.ROOT);
-        if (!isValidBcp47Alpha(lowercaseLanguage, 2, 3)) {
-            throw new InvalidLocaleException("Invalid language: " + languageCode);
+
+        switch (lowercaseLanguage) {
+            /* Chinese languages are special cases. The server uses different codes when compared
+            to Android's locale library. Additionally, zh_CN and zh_TW are not languageCodes that
+            Android's locale recognizes as exceptions. */
+            case "zh_cn":
+            case "zh_hans":
+                return Locale.SIMPLIFIED_CHINESE.getDisplayLanguage();
+            case "zh_tw":
+            case "zh_hant":
+                return Locale.TRADITIONAL_CHINESE.getDisplayLanguage();
+            default:
+                if (!isValidBcp47Alpha(lowercaseLanguage, 2, 3)) {
+                    throw new InvalidLocaleException("Invalid language: " + languageCode);
+                }
+                return new Locale(languageCode).getDisplayLanguage();
         }
-        return new Locale(languageCode).getDisplayLanguage();
     }
 
 
@@ -36,7 +49,6 @@ public class LocaleUtils {
                 return false;
             }
         }
-
         return true;
     }
 }


### PR DESCRIPTION
### Description

[MA-2931](https://openedx.atlassian.net/browse/MA-2931)

edx-platform uses different language codes from Android's locale library. These exceptions have been hardcoded in.

Before/After:
<img src="https://cloud.githubusercontent.com/assets/7101723/21725837/0d8d523a-d408-11e6-94b8-c19da022a7f2.png" width="200"><img src="https://cloud.githubusercontent.com/assets/7101723/21725806/e5730362-d407-11e6-8f9f-722c0d36ad05.png" width="200">
<img src="https://cloud.githubusercontent.com/assets/7101723/21725838/0ed3b4fe-d408-11e6-8cac-85fb82f863e0.png" width="200"><img src="https://cloud.githubusercontent.com/assets/7101723/21725807/e67fc7cc-d407-11e6-8ff0-0ab83f9da67e.png" width="200">


Updated After (Using Android's locale displayname instead of hardcoded. This means that we only get "Chinese" instead of with "Traditional" or "Simplified"
<img src="https://cloud.githubusercontent.com/assets/7101723/21772924/34f745c4-d65b-11e6-9a15-cd62214064b5.png" width="200">