### PR TITLE
Respect Closed Captioning in Android system’s settings

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
@@ -80,7 +80,7 @@ public class LoginPrefs {
     @Nullable
     public String getSubtitleLanguage() {
         final String lang = pref.getString(PrefManager.Key.TRANSCRIPT_LANGUAGE);
-        if (android.text.TextUtils.isEmpty(lang) || lang.equalsIgnoreCase("none")) {
+        if (android.text.TextUtils.isEmpty(lang)) {
             return null;
         }
         return lang;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
@@ -1718,22 +1718,24 @@ public class PlayerFragment extends BaseFragment implements IPlayerListener, Ser
         if (srtList != null && srtList.size() > 0) {
             String languageSubtitle = getSubtitleLanguage();
 
-            if (languageSubtitle == null) {
-                // Check if captioning is enabled in accessibility settings and set the captioning language implicitly
-                final CaptioningManager cManager = (CaptioningManager) getContext().getSystemService(Context.CAPTIONING_SERVICE);
-                if (cManager.isEnabled()) {
-                    final String defaultCcLanguage;
-                    {
-                        final Locale cManagerLocale = cManager.getLocale();
-                        if (cManagerLocale != null) {
-                            defaultCcLanguage = cManagerLocale.getLanguage();
-                        } else {
-                            defaultCcLanguage = Locale.getDefault().getLanguage();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                if (languageSubtitle == null) {
+                    // Check if captioning is enabled in accessibility settings and set the captioning language implicitly
+                    final CaptioningManager cManager = (CaptioningManager) getContext().getSystemService(Context.CAPTIONING_SERVICE);
+                    if (cManager.isEnabled()) {
+                        final String defaultCcLanguage;
+                        {
+                            final Locale cManagerLocale = cManager.getLocale();
+                            if (cManagerLocale != null) {
+                                defaultCcLanguage = cManagerLocale.getLanguage();
+                            } else {
+                                defaultCcLanguage = Locale.getDefault().getLanguage();
+                            }
                         }
-                    }
-                    if (srtList.containsKey(defaultCcLanguage)) {
-                        languageSubtitle = defaultCcLanguage;
-                        setSubtitleLanguage(languageSubtitle);
+                        if (srtList.containsKey(defaultCcLanguage)) {
+                            languageSubtitle = defaultCcLanguage;
+                            setSubtitleLanguage(languageSubtitle);
+                        }
                     }
                 }
             }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CCLanguageDialogFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CCLanguageDialogFragment.java
@@ -85,8 +85,9 @@ public class CCLanguageDialogFragment extends RoboDialogFragment {
 
 
             TextView tvNone = (TextView) v.findViewById(R.id.tv_cc_cancel);
+            final String tvNoneTxt = getString(R.string.lbl_cc_cancel);
             if(langSelected!=null){
-                if(langSelected.equalsIgnoreCase("none")){
+                if(langSelected.equalsIgnoreCase(tvNoneTxt)){
                     tvNone.setBackgroundResource(R.color.cyan_text_navigation_20);
                 }else{
                     tvNone.setBackgroundResource(R.drawable.white_bottom_rounded_selector);


### PR DESCRIPTION
### Description

[MA-2669](https://openedx.atlassian.net/browse/MA-2669)

Check in the device's accessibility settings if `Captions` are enabled. If they are enabled:
1 - and captions language is also set, then query that language's captions for a video.
2 - otherwise get the device's default locale and query that language's captions for a video.

p.s. Previously we were considering the `NONE` option as a `null` internally and doing hardcoded string comparisons on it, which has been fixed too in this PR.