### PR TITLE
Analytic naming change

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
@@ -378,9 +378,9 @@ public interface Analytics {
         String PROFILE_VIEW = "Profile View";
         String PROFILE_EDIT = "Profile Edit";
         String PROFILE_CROP_PHOTO = "Crop Photo";
-        String PROFILE_CHOOSE_BIRTH_YEAR = "Choose Form Value Birth Year";
+        String PROFILE_CHOOSE_BIRTH_YEAR = "Choose Form Value Birth year";
         String PROFILE_CHOOSE_LOCATION = "Choose Form Value Location";
-        String PROFILE_CHOOSE_LANGUAGE = "Choose Form Value Primary Language";
+        String PROFILE_CHOOSE_LANGUAGE = "Choose Form Value Primary language";
         String PROFILE_EDIT_TEXT_VALUE = "Edit Text Form Value";
     }
 


### PR DESCRIPTION
@miankhalid @saeedbashir 

Looks like iOS uses lowercase. It pulls the text after "Choose Form Value" from the profiles.json file.

https://github.com/edx/edx-app-ios/blob/master/Source/en.lproj/profiles.json#L19
https://github.com/edx/edx-app-ios/blob/master/Source/en.lproj/profiles.json#L41

iOS is already emitting this event, Android is not. I figured we should change it on Android to match iOS for consistency. Thoughts?

