### PR TITLE
TextInputLayout’s hint made accessible in activated state

### DIFF
--- a/OpenEdXMobile/res/layout/activity_login.xml
+++ b/OpenEdXMobile/res/layout/activity_login.xml
@@ -58,7 +58,7 @@
                         android:paddingLeft="44dp"
                         android:paddingRight="44dp">
 
-                        <android.support.design.widget.TextInputLayout
+                        <org.edx.mobile.view.custom.EdxTextInputLayout
                             android:id="@+id/usernameWrapper"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
@@ -76,9 +76,9 @@
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"/>
 
-                        </android.support.design.widget.TextInputLayout>
+                        </org.edx.mobile.view.custom.EdxTextInputLayout>
 
-                        <android.support.design.widget.TextInputLayout
+                        <org.edx.mobile.view.custom.EdxTextInputLayout
                             android:id="@+id/passwordWrapper"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
@@ -97,7 +97,7 @@
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"/>
 
-                        </android.support.design.widget.TextInputLayout>
+                        </org.edx.mobile.view.custom.EdxTextInputLayout>
 
                         <TextView
                             android:id="@+id/forgot_password_tv"

--- a/OpenEdXMobile/res/layout/reset_password_dialog.xml
+++ b/OpenEdXMobile/res/layout/reset_password_dialog.xml
@@ -12,7 +12,7 @@
         android:paddingRight="@dimen/dialog_padding_material"
         android:paddingTop="@dimen/dialog_padding_top_material">
 
-        <android.support.design.widget.TextInputLayout
+        <org.edx.mobile.view.custom.EdxTextInputLayout
             android:id="@+id/email_input_layout"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -25,7 +25,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
-        </android.support.design.widget.TextInputLayout>
+        </org.edx.mobile.view.custom.EdxTextInputLayout>
 
         <include layout="@layout/loading_indicator" />
 

--- a/OpenEdXMobile/res/layout/view_register_edit_text.xml
+++ b/OpenEdXMobile/res/layout/view_register_edit_text.xml
@@ -6,7 +6,7 @@
     android:paddingBottom="@dimen/registration_field_vertical_padding"
     android:orientation="vertical">
 
-    <android.support.design.widget.TextInputLayout
+    <org.edx.mobile.view.custom.EdxTextInputLayout
         android:id="@+id/register_edit_text_til"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -16,7 +16,7 @@
             android:id="@+id/register_edit_text_tilEt"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
-    </android.support.design.widget.TextInputLayout>
+    </org.edx.mobile.view.custom.EdxTextInputLayout>
 
     <TextView
         android:id="@+id/input_instructions"

--- a/OpenEdXMobile/res/values/styles.xml
+++ b/OpenEdXMobile/res/values/styles.xml
@@ -521,4 +521,8 @@
     <style name="edX.Widget.SegmentedControlSegment.End" parent="edX.Widget.SegmentedControlSegment">
         <item name="android:background">@drawable/edx_segmented_control_right_background</item>
     </style>
+
+    <style name="edX.Widget.TextInputLayout.HintTextAppearance" parent="TextAppearance.AppCompat.Caption">
+        <item name="android:textColor">@color/edx_brand_primary_base</item>
+    </style>
 </resources>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/EdxTextInputLayout.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/EdxTextInputLayout.java
@@ -1,0 +1,30 @@
+package org.edx.mobile.view.custom;
+
+import android.content.Context;
+import android.support.design.widget.TextInputLayout;
+import android.util.AttributeSet;
+
+import org.edx.mobile.R;
+
+public class EdxTextInputLayout extends TextInputLayout {
+    private final int HINT_TEXT_APPEARANCE_STYLE = R.style.edX_Widget_TextInputLayout_HintTextAppearance;
+
+    public EdxTextInputLayout(Context context) {
+        super(context);
+        setCustomHintAppearance();
+    }
+
+    public EdxTextInputLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        setCustomHintAppearance();
+    }
+
+    public EdxTextInputLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        setCustomHintAppearance();
+    }
+
+    protected void setCustomHintAppearance() {
+        setHintTextAppearance(HINT_TEXT_APPEARANCE_STYLE);
+    }
+}


### PR DESCRIPTION
### Description

[MA-3111](https://openedx.atlassian.net/browse/MA-3111)

- EdxTextInputLayout (subclass of TextInputLayout) sets the hint’s text appearance by default to an accessible color.
- Usages of TextInputLayout replaced with EdxTextInputLayout throughout the project.

**Note**: More info on why I had to subclass and not go by any other way can be found here:
http://stackoverflow.com/questions/42138989/android-change-theme-of-textinputlayout-using-styles-xml