### PR TITLE
Show error message to user in case of un-supported version.

### DIFF
--- a/OpenEdXMobile/res/values/errors.xml
+++ b/OpenEdXMobile/res/values/errors.xml
@@ -70,8 +70,6 @@
     <string name="app_version_deprecated" translatable="false">@string/app_version_outdated</string>
     <!-- Snackbar notification shown when the current version of the app is outdated -->
     <string name="app_version_outdated">A new version of the app is available.</string>
-    <!-- Snackbar action button label for opening an app store to upgrade the app to the latest version -->
-    <string name="app_version_update_button">Update</string>
     <!-- Toast notification for when the user presses the update action button from the Snackbar
          notifications while no supported app store or browser is installed on the device with which
          the app could be updated -->
@@ -93,5 +91,11 @@
 
     <!-- Error message shown when a user can't perform an action on e.g. add a post/response/comment in forums -->
     <string name="action_not_completed">Your action could not be completed.</string>
+
+    <!-- Error dialog message shown when the user try to log in in app with un-supported version  -->
+    <string name="app_version_unsupported_login_msg">Your version of the app is no longer supported. Update to the latest version to log in.</string>
+
+    <!-- Error dialog message shown when the user try to register in app with un-supported version -->
+    <string name="app_version_unsupported_register_msg">Your version of the app is no longer supported. Update to the latest version to register.</string>
 
 </resources>

--- a/OpenEdXMobile/res/values/labels.xml
+++ b/OpenEdXMobile/res/values/labels.xml
@@ -38,4 +38,6 @@
     <string name="label_maybe_later">Maybe Later</string>
     <!-- Alert dialog rate the app button -->
     <string name="label_rate_the_app">Rate The App</string>
+    <!-- Alert dialog and snackbar button for opening an app store to update the app to the latest version -->
+    <string name="label_update">Update</string>
 </resources>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/authentication/LoginAPI.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/authentication/LoginAPI.java
@@ -8,10 +8,9 @@ import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
-import org.edx.mobile.exception.AuthException;
-import org.edx.mobile.http.constants.ApiConstants;
-import org.edx.mobile.http.HttpStatusException;
 import org.edx.mobile.http.HttpStatus;
+import org.edx.mobile.http.HttpStatusException;
+import org.edx.mobile.http.constants.ApiConstants;
 import org.edx.mobile.model.api.FormFieldMessageBody;
 import org.edx.mobile.model.api.ProfileModel;
 import org.edx.mobile.module.analytics.AnalyticsRegistry;
@@ -82,14 +81,10 @@ public class LoginAPI {
     public AuthResponse logInUsingEmail(@NonNull String email, @NonNull String password) throws Exception {
         final Response<AuthResponse> response = getAccessToken(email, password);
         if (!response.isSuccessful()) {
-            throw new AuthException(response.message());
+            throw new HttpStatusException(response);
         }
-        final AuthResponse data = response.body();
-        if (!data.isSuccess()) {
-            throw new AuthException(data.error);
-        }
-        finishLogIn(data, LoginPrefs.AuthBackend.PASSWORD, email.trim());
-        return data;
+        finishLogIn(response.body(), LoginPrefs.AuthBackend.PASSWORD, email.trim());
+        return response.body();
     }
 
     @NonNull

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
@@ -564,6 +564,15 @@ public abstract class BaseFragmentActivity extends BaseAppActivity
         AlertDialogFragment.newInstance(title, message, onPositiveClick).show(getSupportFragmentManager(), null);
     }
 
+    public void showAlertDialog(@Nullable String title, @NonNull String message,
+                                @NonNull String  positiveButtonText,
+                                @Nullable DialogInterface.OnClickListener onPositiveClick,
+                                @Nullable String  negativeButtonText,
+                                @Nullable DialogInterface.OnClickListener onNegativeClick) {
+        AlertDialogFragment.newInstance(title, message, positiveButtonText, onPositiveClick, negativeButtonText, onNegativeClick)
+                .show(getSupportFragmentManager(), null);
+    }
+
     @Override
     public boolean tryToSetUIInteraction(boolean enable) {
         return false;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/images/ErrorUtils.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/images/ErrorUtils.java
@@ -35,6 +35,9 @@ public enum ErrorUtils {
                 case HttpStatus.INTERNAL_SERVER_ERROR:
                     errorMessage = context.getString(R.string.action_not_completed);
                     break;
+                case HttpStatus.UPGRADE_REQUIRED:
+                    errorMessage = context.getString(R.string.app_version_unsupported);
+                    break;
             }
         }
         if (null == errorMessage) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListActivity.java
@@ -124,7 +124,7 @@ public class MyCoursesListActivity extends BaseSingleFragmentActivity {
                     newVersionAvailableEvent.getNotificationString(this),
                     Snackbar.LENGTH_INDEFINITE);
             if (AppStoreUtils.canUpdate(this)) {
-                snackbar.setAction(R.string.app_version_update_button,
+                snackbar.setAction(R.string.label_update,
                         AppStoreUtils.OPEN_APP_IN_APP_STORE_CLICK_LISTENER);
             }
             snackbar.setCallback(new Snackbar.Callback() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -26,6 +26,8 @@ import org.edx.mobile.R;
 import org.edx.mobile.authentication.AuthResponse;
 import org.edx.mobile.authentication.LoginAPI;
 import org.edx.mobile.base.BaseFragmentActivity;
+import org.edx.mobile.http.HttpStatus;
+import org.edx.mobile.http.HttpStatusException;
 import org.edx.mobile.model.api.FormFieldMessageBody;
 import org.edx.mobile.model.api.ProfileModel;
 import org.edx.mobile.model.api.RegisterResponseFieldError;
@@ -41,6 +43,7 @@ import org.edx.mobile.social.SocialFactory;
 import org.edx.mobile.social.SocialLoginDelegate;
 import org.edx.mobile.task.RegisterTask;
 import org.edx.mobile.task.Task;
+import org.edx.mobile.util.AppStoreUtils;
 import org.edx.mobile.util.IntentFactory;
 import org.edx.mobile.util.ResourceUtil;
 import org.edx.mobile.util.images.ErrorUtils;
@@ -311,7 +314,21 @@ public class RegisterActivity extends BaseFragmentActivity
                         return; // Return here to avoid falling back to the generic error handler.
                     }
                 }
-                RegisterActivity.this.showAlertDialog(null, ErrorUtils.getErrorMessage(ex, RegisterActivity.this));
+                // If app version is un-supported
+                if (ex instanceof HttpStatusException &&
+                        ((HttpStatusException) ex).getStatusCode() == HttpStatus.UPGRADE_REQUIRED) {
+                    RegisterActivity.this.showAlertDialog(null,
+                            getString(R.string.app_version_unsupported_register_msg),
+                            getString(R.string.label_update),
+                            new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    AppStoreUtils.openAppInAppStore(RegisterActivity.this);
+                                }
+                            }, getString(android.R.string.cancel), null);
+                } else {
+                    RegisterActivity.this.showAlertDialog(null, ErrorUtils.getErrorMessage(ex, RegisterActivity.this));
+                }
             }
         };
         task.execute();

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/AlertDialogFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/AlertDialogFragment.java
@@ -3,9 +3,10 @@ package org.edx.mobile.view.dialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.app.DialogFragment;
 import android.support.v7.app.AlertDialog;
 
 import org.edx.mobile.R;
@@ -13,84 +14,137 @@ import org.edx.mobile.R;
 import roboguice.fragment.RoboDialogFragment;
 
 /**
- * Note: This is a very simple implementation that only shows an {@link AlertDialog} with a given
- * message and an OK button without any listener.
- *
- * In the future, more customizability might be added as need.
+ * Wrapper class to create a basic fragment dialog.
  */
-
 public class AlertDialogFragment extends RoboDialogFragment {
-    protected static final String ARG_TITLE = "title";
-    protected static final String ARG_MESSAGE = "message";
+    protected static final String ARG_TITLE = "ARG_TITLE";
+    protected static final String ARG_MESSAGE = "ARG_MESSAGE";
+    protected static final String ARG_POSITIVE_ATTR = "ARG_POSITIVE_ATTR";
+    protected static final String ARG_NEGATIVE_ATTR = "ARG_NEGATIVE_ATTR";
 
-    public interface ButtonAttributes {
-        @NonNull
-        String getMessage();
+    /**
+     * Creates a new instance of simple dialog that shows message, could have title and will have
+     * only positive button with 'OK' text.
+     *
+     * @param title           Title of dialog.
+     * @param message         Message of dialog.
+     * @param onPositiveClick Positive button click listener.
+     * @return New instance of dialog.
+     */
+    public static AlertDialogFragment newInstance(final @Nullable String title,
+                                                  final @NonNull String message,
+                                                  final @Nullable DialogInterface.OnClickListener onPositiveClick) {
+        final AlertDialogFragment fragment = new AlertDialogFragment();
+        // Supply params as an argument.
+        final Bundle arguments = new Bundle();
+        arguments.putString(ARG_TITLE, title);
+        arguments.putString(ARG_MESSAGE, message);
+        arguments.putParcelable(ARG_POSITIVE_ATTR, new ButtonAttribute() {
+            @NonNull
+            @Override
+            public String getText() {
+                return fragment.getResources().getString(R.string.label_ok);
+            }
 
-        @Nullable
-        DialogInterface.OnClickListener getOnClickListener();
-    }
-
-    public static AlertDialogFragment newInstance(@Nullable String title, @NonNull String message, @Nullable DialogInterface.OnClickListener onPositiveClick) {
-        AlertDialogFragment fragment = new AlertDialogFragment();
-        fragment.mOnPositiveClick = onPositiveClick;
-        Bundle args = new Bundle();
-        args.putString(ARG_TITLE, title);
-        args.putString(ARG_MESSAGE, message);
-        fragment.setArguments(args);
+            @Nullable
+            @Override
+            public DialogInterface.OnClickListener getOnClickListener() {
+                return onPositiveClick;
+            }
+        });
+        fragment.setArguments(arguments);
         return fragment;
     }
 
-    @Nullable
-    private DialogInterface.OnClickListener mOnPositiveClick;
+    /**
+     * Creates a new instance of dialog that shows message, could have title, will have a positive
+     * button with given text and also could have negative button with given text.
+     *
+     * @param title           Title of dialog.
+     * @param message         Message of dialog.
+     * @param positiveText    Positive button text.
+     * @param onPositiveClick Positive button click listener.
+     * @param negativeText    Negative button text.
+     * @param onNegativeClick Negative button click listener.
+     * @return New instance of dialog.
+     */
+    public static AlertDialogFragment newInstance(final @Nullable String title,
+                                                  final @NonNull String message,
+                                                  final @NonNull String positiveText,
+                                                  final @Nullable DialogInterface.OnClickListener onPositiveClick,
+                                                  final @Nullable String negativeText,
+                                                  final @Nullable DialogInterface.OnClickListener onNegativeClick) {
+        final AlertDialogFragment fragment = new AlertDialogFragment();
+        // Supply params as an argument.
+        final Bundle arguments = new Bundle();
+        arguments.putString(ARG_TITLE, title);
+        arguments.putString(ARG_MESSAGE, message);
+        arguments.putParcelable(ARG_POSITIVE_ATTR, new ButtonAttribute() {
+            @NonNull
+            @Override
+            public String getText() {
+                return positiveText;
+            }
+
+            @Nullable
+            @Override
+            public DialogInterface.OnClickListener getOnClickListener() {
+                return onPositiveClick;
+            }
+        });
+        arguments.putParcelable(ARG_NEGATIVE_ATTR, new ButtonAttribute() {
+            @NonNull
+            @Override
+            public String getText() {
+                return negativeText;
+            }
+
+            @Nullable
+            @Override
+            public DialogInterface.OnClickListener getOnClickListener() {
+                return onNegativeClick;
+            }
+        });
+        fragment.setArguments(arguments);
+        return fragment;
+    }
 
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         String title = getArguments().getString(ARG_TITLE);
         String message = getArguments().getString(ARG_MESSAGE);
-
-        ButtonAttributes positiveButtonAttributes = getPositiveButtonAttributes();
-        ButtonAttributes negativeButtonAttributes = getNegativeButtonAttributes();
-
+        ButtonAttribute positiveButtonAttr = getArguments().getParcelable(ARG_POSITIVE_ATTR);
+        ButtonAttribute negativeButtonAttr = getArguments().getParcelable(ARG_NEGATIVE_ATTR);
         AlertDialog alertDialog = new AlertDialog.Builder(getContext())
                 .setMessage(message)
-                .setPositiveButton(positiveButtonAttributes.getMessage(), positiveButtonAttributes.getOnClickListener())
+                .setPositiveButton(positiveButtonAttr.getText(), positiveButtonAttr.getOnClickListener())
                 .create();
-
         alertDialog.setCanceledOnTouchOutside(false);
-
         if (title != null) {
             alertDialog.setTitle(title);
         }
-
-        if (negativeButtonAttributes != null) {
-            alertDialog.setButton(DialogInterface.BUTTON_NEGATIVE, negativeButtonAttributes.getMessage(), negativeButtonAttributes.getOnClickListener());
+        if (negativeButtonAttr != null) {
+            alertDialog.setButton(DialogInterface.BUTTON_NEGATIVE, negativeButtonAttr.getText(),
+                    negativeButtonAttr.getOnClickListener());
         }
-
         return alertDialog;
     }
 
-    @NonNull
-    protected ButtonAttributes getPositiveButtonAttributes() {
-        return new ButtonAttributes() {
+    public static abstract class ButtonAttribute implements Parcelable {
+        @Nullable
+        abstract String getText();
 
-            @NonNull
-            @Override
-            public String getMessage() {
-                return getContext().getResources().getString(R.string.label_ok);
-            }
+        @Nullable
+        abstract DialogInterface.OnClickListener getOnClickListener();
 
-            @Nullable
-            @Override
-            public DialogInterface.OnClickListener getOnClickListener() {
-                return mOnPositiveClick;
-            }
-        };
-    }
+        @Override
+        public int describeContents() {
+            return 0;
+        }
 
-    @Nullable
-    protected ButtonAttributes getNegativeButtonAttributes() {
-        return null;
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+        }
     }
 }


### PR DESCRIPTION
### Description

[MA-3173](https://openedx.atlassian.net/browse/MA-3173)

When a new version in config is added with expire date of platform has been passed. User try to login in or register in app, Android shows proper upgrade error message now.
Android app's behavior is consistent with iOS app.

### Screen Shots
<img src="https://cloud.githubusercontent.com/assets/25842457/23361635/74b5c850-fd13-11e6-9206-ce0d79257424.png" width="200">
<img src="https://cloud.githubusercontent.com/assets/25842457/23361634/74b3f14c-fd13-11e6-8b41-00bd94a04daf.png" width="200">

