### PR TITLE
Dropped fallback video encoding

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/EncodedVideos.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/EncodedVideos.java
@@ -8,9 +8,6 @@ import com.google.gson.annotations.SerializedName;
 import java.io.Serializable;
 
 public class EncodedVideos implements Serializable {
-    @SerializedName("fallback")
-    public VideoInfo fallback;
-
     @SerializedName("mobile_high")
     public VideoInfo mobileHigh;
 
@@ -26,8 +23,6 @@ public class EncodedVideos implements Serializable {
             return mobileLow;
         if (mobileHigh != null && URLUtil.isNetworkUrl(mobileHigh.url))
             return mobileHigh;
-        if (fallback != null && URLUtil.isNetworkUrl(fallback.url))
-            return fallback;
         return null;
     }
 
@@ -45,8 +40,6 @@ public class EncodedVideos implements Serializable {
 
         EncodedVideos that = (EncodedVideos) o;
 
-        if (fallback != null ? !fallback.equals(that.fallback) : that.fallback != null)
-            return false;
         if (mobileHigh != null ? !mobileHigh.equals(that.mobileHigh) : that.mobileHigh != null)
             return false;
         if (mobileLow != null ? !mobileLow.equals(that.mobileLow) : that.mobileLow != null)


### PR DESCRIPTION
### Description

[MA-3094](https://openedx.atlassian.net/browse/MA-3094)

We are encouraging to upload all videos by edX video pipeline so that's why we are dropping support fallback encoding. Users can still view their downloaded fallback videos in my videos section.
