### PR TITLE
MA-3175, Profile image rotation issue

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/user/SetAccountImageTask.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/user/SetAccountImageTask.java
@@ -29,7 +29,7 @@ public class SetAccountImageTask extends
     private final String username;
 
     @NonNull
-    private final Uri uri;
+    private Uri uri;
 
     @NonNull
     private final Rect cropRect;
@@ -46,6 +46,7 @@ public class SetAccountImageTask extends
         final File cropped = new File(context.getExternalCacheDir(), "cropped-image" + System.currentTimeMillis() + ".jpg");
         CropUtil.crop(getContext(), uri, cropRect, 500, 500, cropped);
         userAPI.setProfileImage(username, cropped).execute();
+        uri = Uri.fromFile(cropped);
         return null;
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/images/ImageCaptureHelper.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/images/ImageCaptureHelper.java
@@ -39,6 +39,14 @@ public class ImageCaptureHelper {
         // Support using Camera
         final Intent intent = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
         intent.putExtra(MediaStore.EXTRA_OUTPUT, outputFileUri);
+
+        // Adding extras to open front camera by default. Officially, there's no intent that targets
+        // the front-facing camera, its just a hack not all device camera apps support these extras.
+        // TODO: For complete solution we can build a custom camera interface and add the functionality.
+        intent.putExtra("android.intent.extras.CAMERA_FACING", android.hardware.Camera.CameraInfo.CAMERA_FACING_FRONT);
+        intent.putExtra("android.intent.extras.LENS_FACING_FRONT", 1);
+        intent.putExtra("android.intent.extra.USE_FRONT_CAMERA", true);
+
         return intent;
     }
 


### PR DESCRIPTION
### Description

[MA-3175](https://openedx.atlassian.net/browse/MA-3175)

- When uploading an image on the server, the image appears correctly on Android and website now.
- Made profile jpg compression lossless (maximum quality).
- Currently, by default any camera could be opened when user want to take profile picture from camera, depends on what camera user was using in camera app last time, we should force it to always open the front (selfie) camera.
- When user change photo either by using 'Take photo' or 'Choose a photo' and crop & resize that photo, app still shows complete photo instead of showing the cropped photo on Edit profile screen/profile screen and user profile section in left drawer. However, it reloads and show the cropped photo when user tap on some other sections like 'My Courses' and come back on profile screen.

### Testing
- Change a profile picture by capturing photo from camera.
- You can capture picture from any camera front or back and can capture in any camera direction upright, clockwise 90 (landscape), clockwise 180 or clockwise 270 (landscape) degrees.
- After successful cropping and loading of profile image on device, check on website; profile image should be upright there.