### PR TITLE
LEARNER-98, Renamed button text 'Find a mobile-friendly course' to 'Find a Course'.

### DIFF
--- a/OpenEdXMobile/res/layout/panel_find_course.xml
+++ b/OpenEdXMobile/res/layout/panel_find_course.xml
@@ -35,22 +35,8 @@
                 style="@style/edX.Widget.BrandPillButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/find_course_btn_text" />
-
-            <TextView
-                android:id="@+id/course_not_listed_tv"
-                style="@style/semibold_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/widget_margin"
-                android:contentDescription="@string/course_not_listed_btn"
-                android:gravity="center"
-                android:background="@drawable/selectable_rounded_box_overlay"
-                android:padding="@dimen/edx_box_radius"
-                android:text="@string/course_not_listed_text"
-                android:layout_marginBottom="@dimen/widget_margin"
-                android:textColor="@color/text_navigation"
-                android:textSize="@dimen/edx_small" />
+                android:text="@string/find_course_btn_text"
+                android:layout_marginBottom="@dimen/edx_margin" />
 
         </LinearLayout>
     </FrameLayout>

--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -429,17 +429,13 @@
     <!-- Button label to bring up course finder -->
     <string name="find_course_text">Looking for a new challenge?</string>
     <!-- Button label to bring up course finder -->
-    <string name="find_course_btn_text">Find a mobile-friendly course</string>
+    <string name="find_course_btn_text">Find a Course</string>
     <!-- Message between sign in button and social login buttons -->
     <string name="or_sign_in_with">Or sign in with</string>
     <!-- Facebook login method -->
     <string name="facebook_text">Facebook</string>
     <!-- Google login method -->
     <string name="google_text">Google</string>
-    <!-- Message on course list -->
-    <string name="course_not_listed_text">Can’t find one of your courses?</string>
-    <!-- Accessible content description of course not listed button on Course list screen -->
-    <string name="course_not_listed_btn">Can’t find one of your courses button</string>
     <!-- Title of find course screen -->
     <string name="find_courses_title">Find Courses</string>
     <!-- Message shown when attempting to find courses with no Internet connection -->
@@ -450,8 +446,6 @@
     <string name="email_client_not_present">No e-mail clients installed</string>
     <!-- Search for a course prompt -->
     <string name="search_for_courses">I want to learn about...</string>
-    <!-- A prompt message telling user that we're working hard to make courses mobile-friendly -->
-    <string name="cant_find_course_prompt">We’re working hard to make all of our courses mobile-friendly. If you can’t find a course, check back soon. We’re adding more courses every day!</string>
 
     <!-- Landing Activity text -->
     <!-- Prompt leading user to sign in screen -->

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.java
@@ -246,7 +246,8 @@ public class MyCoursesListFragment extends BaseFragment implements NetworkObserv
     }
 
     private void addFindCoursesFooter() {
-        final PanelFindCourseBinding footer = DataBindingUtil.inflate(LayoutInflater.from(getActivity()), R.layout.panel_find_course, binding.myCourseList, false);
+        final PanelFindCourseBinding footer = DataBindingUtil.inflate(LayoutInflater.from(getActivity()),
+                R.layout.panel_find_course, binding.myCourseList, false);
         binding.myCourseList.addFooterView(footer.getRoot(), null, false);
         footer.courseBtn.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -255,13 +256,5 @@ public class MyCoursesListFragment extends BaseFragment implements NetworkObserv
                 environment.getRouter().showFindCourses(getActivity());
             }
         });
-        footer.courseNotListedTv.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                AlertDialogFragment.newInstance(null, getString(R.string.cant_find_course_prompt), null)
-                        .show(getFragmentManager(), null);
-            }
-        });
     }
-
 }


### PR DESCRIPTION
[LEARNER-98](https://openedx.atlassian.net/browse/LEARNER-98)

### Description
- Renamed button text 'Find a mobile-friendly course' to 'Find a Course'.
- Removed 'Can't find one of your courses' text and its dialog.

### Screenshot

<img src="https://cloud.githubusercontent.com/assets/25842457/24038347/d0b3c108-0b22-11e7-8fae-974d497af2ae.png" width="200">
