### PR TITLE
Corrected the wrong icon of courseware assignments, discussions

### DIFF
--- a/OpenEdXMobile/res/layout/row_course_outline_list.xml
+++ b/OpenEdXMobile/res/layout/row_course_outline_list.xml
@@ -61,13 +61,13 @@
                 style="@style/regular_grey_text"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:orientation="horizontal"
+                android:gravity="center">
 
                 <TextView
                     android:id="@+id/row_subtitle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_centerVertical="true"
                     android:ellipsize="end"
                     android:singleLine="true"
                     android:textColor="@color/edx_brand_gray_accent"
@@ -78,14 +78,13 @@
 
                 <org.edx.mobile.view.custom.IconImageViewXml
                     android:id="@+id/row_subtitle_icon"
-                    android:layout_width="16dp"
-                    android:layout_height="16dp"
+                    android:layout_width="@dimen/fa_large"
+                    android:layout_height="@dimen/fa_large"
                     android:baselineAlignBottom="true"
-                    android:gravity="center_vertical"
-                    android:paddingLeft="2dp"
-                    android:paddingStart="2dp"
+                    android:layout_marginLeft="@dimen/x_small_icon_margin"
+                    android:layout_marginStart="@dimen/x_small_icon_margin"
                     android:visibility="gone"
-                    app:iconName="fa-check" />
+                    app:iconName="fa-edit" />
             </LinearLayout>
 
         </LinearLayout>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java
@@ -441,7 +441,7 @@ public class CourseOutlineAdapter extends BaseAdapter {
                 .findViewById(R.id.row_subtitle);
         holder.rowSubtitleIcon = (IconImageView) convertView
                 .findViewById(R.id.row_subtitle_icon);
-        holder.rowSubtitleIcon.setIconColorResource(R.color.edx_brand_gray_back);
+        holder.rowSubtitleIcon.setIconColorResource(R.color.edx_brand_primary_base);
         holder.noOfVideos = (TextView) convertView
                 .findViewById(R.id.no_of_videos);
         holder.bulkDownload = (IconImageView) convertView


### PR DESCRIPTION
### Description
Corrected the wrong icon (replaced question mark icon with edit icon) of courseware assignments, discussions

[MA-3189](https://openedx.atlassian.net/browse/MA-3189)

### Screenshot
<img src="https://cloud.githubusercontent.com/assets/25842457/24091837/68aa30c8-0d6c-11e7-88b1-4de1ee5cbbc5.png" width="200">