### PR TITLE
MA-3193 : Blackout discussions for a course

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrolledCoursesResponse.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/EnrolledCoursesResponse.java
@@ -11,6 +11,7 @@ public class EnrolledCoursesResponse implements SectionItemInterface {
     private String mode;
     private boolean is_active;
     private CourseEntry course;
+    private boolean isDiscussionBlackedOut = false;
     
     private CertificateModel certificate;
 
@@ -91,5 +92,13 @@ public class EnrolledCoursesResponse implements SectionItemInterface {
     public boolean isCertificateEarned() {
         return this.certificate != null && !TextUtils.isEmpty(this.certificate.certificateURL);
 
+    }
+
+    public boolean isDiscussionBlackedOut() {
+        return isDiscussionBlackedOut;
+    }
+
+    public void setDiscussionBlackedOut(boolean discussionBlackedOut) {
+        isDiscussionBlackedOut = discussionBlackedOut;
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
@@ -26,6 +26,7 @@ import org.edx.mobile.discussion.DiscussionUtils;
 import org.edx.mobile.http.callback.CallTrigger;
 import org.edx.mobile.http.callback.ErrorHandlingCallback;
 import org.edx.mobile.model.Page;
+import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.module.analytics.Analytics;
 import org.edx.mobile.module.analytics.AnalyticsRegistry;
 import org.edx.mobile.view.adapters.DiscussionCommentsAdapter;
@@ -64,6 +65,9 @@ public class CourseDiscussionCommentsFragment extends BaseFragment implements Di
 
     @InjectExtra(Router.EXTRA_DISCUSSION_COMMENT)
     private DiscussionComment discussionResponse;
+
+    @InjectExtra(value = Router.EXTRA_COURSE_DATA, optional = true)
+    private EnrolledCoursesResponse courseData;
 
     @Inject
     private DiscussionService discussionService;
@@ -122,6 +126,8 @@ public class CourseDiscussionCommentsFragment extends BaseFragment implements Di
                         router.showCourseDiscussionAddComment(context, discussionResponse, discussionThread);
                     }
                 });
+
+        createNewCommentLayout.setEnabled(!courseData.isDiscussionBlackedOut());
     }
 
     protected void getCommentsList(@NonNull final InfiniteScrollUtils.PageLoadCallback<DiscussionComment> callback) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
@@ -94,7 +94,7 @@ public class CourseDiscussionResponsesFragment extends BaseFragment implements C
                 discussionThread.getType() == DiscussionThread.ThreadType.QUESTION);
 
         courseDiscussionResponsesAdapter = new CourseDiscussionResponsesAdapter(
-                getActivity(), this, discussionThread);
+                getActivity(), this, discussionThread, courseData);
         controller = InfiniteScrollUtils.configureRecyclerViewWithInfiniteList(
                 discussionResponsesRecyclerView, courseDiscussionResponsesAdapter, responsesLoader);
         discussionResponsesRecyclerView.setAdapter(courseDiscussionResponsesAdapter);
@@ -125,6 +125,8 @@ public class CourseDiscussionResponsesFragment extends BaseFragment implements C
                         router.showCourseDiscussionAddResponse(getActivity(), discussionThread);
                     }
                 });
+
+        addResponseLayout.setEnabled(!courseData.isDiscussionBlackedOut());
     }
 
     @Override
@@ -183,7 +185,7 @@ public class CourseDiscussionResponsesFragment extends BaseFragment implements C
 
     @Override
     public void onClickViewComments(@NonNull DiscussionComment response) {
-        router.showCourseDiscussionComments(getActivity(), response, discussionThread);
+        router.showCourseDiscussionComments(getActivity(), response, discussionThread, courseData);
     }
 
     private static class ResponsesLoader implements

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
@@ -232,8 +232,9 @@ public class Router {
         activity.startActivity(addPostIntent);
     }
 
-    public void showCourseDiscussionComments(Context context, DiscussionComment comment, DiscussionThread discussionThread) {
+    public void showCourseDiscussionComments(Context context, DiscussionComment comment, DiscussionThread discussionThread, EnrolledCoursesResponse courseData) {
         Intent commentListIntent = new Intent(context, CourseDiscussionCommentsActivity.class);
+        commentListIntent.putExtra(EXTRA_COURSE_DATA, courseData);
         commentListIntent.putExtra(Router.EXTRA_DISCUSSION_COMMENT, comment);
         commentListIntent.putExtra(Router.EXTRA_DISCUSSION_THREAD, discussionThread);
         commentListIntent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -28,6 +28,7 @@ import org.edx.mobile.discussion.DiscussionThread;
 import org.edx.mobile.discussion.DiscussionThreadUpdatedEvent;
 import org.edx.mobile.http.callback.CallTrigger;
 import org.edx.mobile.http.callback.ErrorHandlingCallback;
+import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.module.prefs.LoginPrefs;
 import org.edx.mobile.util.Config;
 import org.edx.mobile.util.ResourceUtil;
@@ -72,6 +73,9 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
     @NonNull
     private DiscussionThread discussionThread;
 
+    @NonNull
+    private EnrolledCoursesResponse courseData;
+
     private final List<DiscussionComment> discussionResponses = new ArrayList<>();
 
     private boolean progressVisible = false;
@@ -84,10 +88,11 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
         static final int PROGRESS = 2;
     }
 
-    public CourseDiscussionResponsesAdapter(@NonNull Context context, @NonNull Listener listener, @NonNull DiscussionThread discussionThread) {
+    public CourseDiscussionResponsesAdapter(@NonNull Context context, @NonNull Listener listener, @NonNull DiscussionThread discussionThread, @NonNull EnrolledCoursesResponse courseData) {
         this.context = context;
         this.discussionThread = discussionThread;
         this.listener = listener;
+        this.courseData = courseData;
         RoboGuice.getInjector(context).injectMembers(this);
     }
 
@@ -304,6 +309,8 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
 
         if (discussionThread.isClosed() && comment.getChildCount() == 0) {
             holder.addCommentLayout.setEnabled(false);
+        } else if (courseData.isDiscussionBlackedOut() && comment.getChildCount() == 0) {
+            holder.addCommentLayout.setEnabled(false);
         } else {
             holder.addCommentLayout.setEnabled(true);
             holder.addCommentLayout.setOnClickListener(new View.OnClickListener() {
@@ -379,7 +386,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
         int numChildren = response == null ? 0 : response.getChildCount();
 
         if (response.getChildCount() == 0) {
-            if (discussionThread.isClosed()) {
+            if (discussionThread.isClosed() || courseData.isDiscussionBlackedOut()) {
                 text = context.getString(R.string.discussion_add_comment_disabled_title);
                 icon = FontAwesomeIcons.fa_lock;
             } else {


### PR DESCRIPTION
### Description

[MA-3193](https://openedx.atlassian.net/browse/MA-3193)

If the current date time lies within the blackout timeslots of discussions in a course, we block user from adding any new thread, response or comment by disabling the respective buttons.

Here's how the UIs look when discussions are blacked out for a course:

Threads Screen | Responses Screen | Comments Screen | Threads Screen (in Courseware)
--- | --- | --- | ---
![threads_blackout](https://cloud.githubusercontent.com/assets/1710804/24218790/5f5a7540-0f66-11e7-8965-c3ab63a6b71a.png) | ![responses_blacked](https://cloud.githubusercontent.com/assets/1710804/24218796/634ce282-0f66-11e7-8688-8297a1e1ac15.png) | ![comments_blacked](https://cloud.githubusercontent.com/assets/1710804/24218798/6843dff2-0f66-11e7-9b5c-11f80f665b41.png) | ![courseware_blocked](https://cloud.githubusercontent.com/assets/1710804/24218803/6da451ac-0f66-11e7-81ea-6aaaedd5aa80.png)
