### PR TITLE
MA-3153: Firing screen toggled event only on enter/exit full screen button.

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
@@ -903,6 +903,9 @@ public class PlayerFragment extends BaseFragment implements IPlayerListener, Ser
             } else {
                 exitFullScreen();
             }
+            environment.getAnalyticsRegistry().trackVideoOrientation(videoEntry.videoId,
+                    player.getCurrentPosition() / AppConstants.MILLISECONDS_PER_SECOND,
+                    isFullScreen, videoEntry.eid, videoEntry.lmsUrl);
         } else {
             logger.debug("Player not prepared ?? full screen will NOT work!");
         }
@@ -926,10 +929,6 @@ public class PlayerFragment extends BaseFragment implements IPlayerListener, Ser
                     logger.warn("video model instance is null, cannot capture event enterFullScreen");
                     return;
                 }
-
-                environment.getAnalyticsRegistry().trackVideoOrientation(videoEntry.videoId,
-                        player.getCurrentPosition() / AppConstants.MILLISECONDS_PER_SECOND,
-                        true, videoEntry.eid, videoEntry.lmsUrl);
             }
         } catch(Exception ex) {
             logger.error(ex);
@@ -954,10 +953,6 @@ public class PlayerFragment extends BaseFragment implements IPlayerListener, Ser
                     logger.warn("video model instance is null, cannot capture event exitFullScreen");
                     return;
                 }
-
-                environment.getAnalyticsRegistry().trackVideoOrientation(videoEntry.videoId,
-                        player.getCurrentPosition() / AppConstants.MILLISECONDS_PER_SECOND,
-                        false, videoEntry.eid, videoEntry.lmsUrl);
             }
         } catch(Exception ex) {
             logger.error(ex);


### PR DESCRIPTION
### Description

[MA-3153](https://openedx.atlassian.net/browse/MA-3153)

### Notes

Please refer to the Jira ticket for description of the functionality implemented within this PR.

### Testing
- Play any video in the app.
- Press enter full screen button, screen toggled event should be fired.
- In full screen mode, press exit full screen button, screen toggled event should be fired.
- Screen toggled event should not be fired in any other case/possible scenario.
