### PR TITLE
Customize a11y for rating dialog cancel action.

### DIFF
--- a/OpenEdXMobile/res/color/dialog_button_selector.xml
+++ b/OpenEdXMobile/res/color/dialog_button_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="true" android:color="@color/edx_brand_primary_accent" />
+    <item android:state_enabled="false" android:color="@color/edx_brand_gray_accent" />
+</selector>

--- a/OpenEdXMobile/res/values/styles.xml
+++ b/OpenEdXMobile/res/values/styles.xml
@@ -76,7 +76,7 @@
     <style name="AppTheme.Dialog.Alert" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="colorPrimary">@color/edx_brand_primary_base</item>
         <item name="colorPrimaryDark">@color/edx_brand_primary_dark</item>
-        <item name="colorAccent">@color/edx_brand_primary_accent</item>
+        <item name="colorAccent">@color/dialog_button_selector</item>
     </style>
 
     <!-- we need to change the color of the drawer arrow toggle -->

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
@@ -891,7 +891,14 @@ public class PlayerFragment extends BaseFragment implements IPlayerListener, Ser
     }
 
     public void showRatingDialog() {
-        RatingDialogFragment.newInstance().show(getFragmentManager(), null);
+        RatingDialogFragment.newInstance(
+                new RatingDialogFragment.OnCancelListener() {
+                    @Override
+                    public void onCancel() {
+                        handler.postDelayed(requestAccessibilityFocusCallback, 2 * UNFREEZE_DELAY_MS);
+                    }
+                }
+        ).show(getFragmentManager(), null);
     }
 
     @Override
@@ -1004,12 +1011,14 @@ public class PlayerFragment extends BaseFragment implements IPlayerListener, Ser
                 handler.sendEmptyMessage(MSG_TYPE_TICK);
             }
 
-            // as before, request accessibility focus after 300 milli seconds, so that it works on HTC One, Nexus5, S4, S5
-            // some devices take little time to be ready
             handler.postDelayed(requestAccessibilityFocusCallback, UNFREEZE_DELAY_MS);
         }
     };
 
+    /**
+     * Request accessibility focus after 300 milli seconds, so that it works on some devices like
+     * HTC One, Nexus5, S4, S5 that take some time to be ready.
+     */
     private Runnable requestAccessibilityFocusCallback = new Runnable() {
         @Override
         public void run() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/RatingDialogFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/RatingDialogFragment.java
@@ -5,6 +5,7 @@ import android.content.DialogInterface;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentActivity;
 import android.support.v7.app.AlertDialog;
 import android.widget.Button;
@@ -38,9 +39,23 @@ public class RatingDialogFragment extends RoboDialogFragment implements AlertDia
     private AlertDialog mAlertDialog;
     @NonNull
     private FragmentDialogRatingBinding binding;
+    @Nullable
+    private OnCancelListener onCancelListener;
 
-    public static RatingDialogFragment newInstance() {
-        return new RatingDialogFragment();
+    public static RatingDialogFragment newInstance(@Nullable OnCancelListener onCancelListener) {
+        RatingDialogFragment fragment = new RatingDialogFragment();
+        fragment.setOnCancelListener(onCancelListener);
+        return fragment;
+    }
+
+    public void setOnCancelListener(@NonNull OnCancelListener onCancelListener) {
+        this.onCancelListener = onCancelListener;
+    }
+
+    private void callCancelListener() {
+        if (onCancelListener != null) {
+            onCancelListener.onCancel();
+        }
     }
 
     @Override
@@ -60,6 +75,7 @@ public class RatingDialogFragment extends RoboDialogFragment implements AlertDia
                     @Override
                     public void onClick(DialogInterface dialogInterface, int id) {
                         persistRatingAndAppVersion(AppConstants.APP_ZERO_RATING);
+                        callCancelListener();
                         analyticsRegistry.trackAppRatingDialogCancelled(BuildConfig.VERSION_NAME);
                     }
                 })
@@ -74,6 +90,7 @@ public class RatingDialogFragment extends RoboDialogFragment implements AlertDia
     public void onCancel(DialogInterface dialogInterface) {
         super.onCancel(dialogInterface);
         persistRatingAndAppVersion(AppConstants.APP_ZERO_RATING);
+        callCancelListener();
         analyticsRegistry.trackAppRatingDialogCancelled(BuildConfig.VERSION_NAME);
     }
 
@@ -119,6 +136,7 @@ public class RatingDialogFragment extends RoboDialogFragment implements AlertDia
             @Override
             public void onClick(DialogInterface dialogInterface, int id) {
                 persistRatingAndAppVersion(AppConstants.APP_ZERO_RATING);
+                callCancelListener();
                 analyticsRegistry.trackUserMayReviewLater(BuildConfig.VERSION_NAME,
                         (int) binding.ratingBar.getRating());
             }
@@ -130,6 +148,7 @@ public class RatingDialogFragment extends RoboDialogFragment implements AlertDia
             @Override
             public void onCancel(DialogInterface dialogInterface) {
                 persistRatingAndAppVersion(AppConstants.APP_ZERO_RATING);
+                callCancelListener();
             }
         });
     }
@@ -153,6 +172,7 @@ public class RatingDialogFragment extends RoboDialogFragment implements AlertDia
             @Override
             public void onClick(DialogInterface dialogInterface, int id) {
                 persistRatingAndAppVersion(AppConstants.APP_ZERO_RATING);
+                callCancelListener();
                 analyticsRegistry.trackUserMayReviewLater(BuildConfig.VERSION_NAME,
                         (int) binding.ratingBar.getRating());
             }
@@ -164,6 +184,7 @@ public class RatingDialogFragment extends RoboDialogFragment implements AlertDia
             @Override
             public void onCancel(DialogInterface dialogInterface) {
                 persistRatingAndAppVersion(AppConstants.APP_ZERO_RATING);
+                callCancelListener();
             }
         });
     }
@@ -183,5 +204,13 @@ public class RatingDialogFragment extends RoboDialogFragment implements AlertDia
         final PrefManager.AppInfoPrefManager appPrefs = new PrefManager.AppInfoPrefManager(MainApplication.application);
         appPrefs.setAppRating(rating);
         appPrefs.setLastRatedVersion(BuildConfig.VERSION_NAME);
+    }
+
+    public interface OnCancelListener {
+        /**
+         * This callback will be called when the user will close the rating dialog without performing
+         * any action (i.e. open play store for rating or giving feedback).
+         */
+        void onCancel();
     }
 }


### PR DESCRIPTION
### Description

[LEARNER-298](https://openedx.atlassian.net/browse/LEARNER-298)

Please refer the to following url for the functionality details implemented in this story.

https://openedx.atlassian.net/browse/LEARNER-298?focusedCommentId=254793&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-254793

**Details:**
- Now, we are customizely focusing the a11y control on Play/Pause button when user cancel the rating dialog. (It goes sync with action now when user go to play store or give feedback via email and come back to player fragment.)
- Submit button doesn't appear disabled on KitKat OS when rating bar has zero rating which has been fixed in this PR.