### PR TITLE
LEARNER-553: Updated support libraries & did share improvements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,24 +4,20 @@ sudo: required
 dist: precise # For 7.5GB of memory since the emulator requires a big chunk.
 env:
   matrix:
-    - ANDROID_TARGET=android-23
+    - ANDROID_TARGET=android-25
   global:
     - ADB_INSTALL_TIMEOUT=12
 android:
   components:
-    # use the latest revision of Android SDK Tools
-    - platform-tools
-    - tools
-
-    # The BuildTools version used
-    - build-tools-23.0.3
-
-    # The SDK version used to compile the project
-    - android-23
-
-    # Additional components
-    - extra-google-m2repository
-    - extra-android-m2repository
+   - tools
+   # The BuildTools version used
+   - build-tools-25.0.3
+   - platform-tools
+   # Additional components
+   - extra-google-m2repository
+   - extra-android-m2repository
+   # The SDK version used to compile the project
+   - android-25
 
 notifications:
   email: true
@@ -44,6 +40,8 @@ script:
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
   - travis_wait make e2e
+  # Script to print lint information in logs.
+  - ./gradlew lintProdDebug --info
 
 after_script:
   - make artifacts

--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -149,11 +149,10 @@ dependencies {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
         exclude group: 'com.google.code.gson', module: 'gson'
     }
-    compile 'com.android.support:support-v4:23.3.0'
-    compile 'com.android.support:recyclerview-v7:23.3.0'
-    compile 'com.android.support:cardview-v7:23.3.0'
-    compile 'com.android.support:appcompat-v7:23.3.0'
-    compile 'com.android.support:design:23.3.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:recyclerview-v7:25.3.1'
+    compile 'com.android.support:cardview-v7:25.3.1'
+    compile 'com.android.support:design:25.3.1'
     compile 'com.android.support:multidex:1.0.1'
     compile 'com.github.bumptech.glide:glide:3.7.0'
     compile 'de.hdodenhof:circleimageview:2.0.0'
@@ -184,7 +183,7 @@ dependencies {
     provided 'org.roboguice:roboblender:3.0.1'
 
     // For the optional Nullable annotation
-    compile 'com.android.support:support-annotations:23.3.0'
+    compile 'com.android.support:support-annotations:25.3.1'
 
     // test project configuration
     testCompile 'junit:junit:4.12'
@@ -244,7 +243,7 @@ android {
         }
     }
 
-    compileSdkVersion 23
+    compileSdkVersion COMPILE_SDK_VERSION
     buildToolsVersion BUILD_TOOLS_VERSION
 
     dataBinding {

--- a/OpenEdXMobile/res/layout/fragment_course_dashboard.xml
+++ b/OpenEdXMobile/res/layout/fragment_course_dashboard.xml
@@ -58,11 +58,12 @@
                     android:layout_gravity="bottom|right"
                     android:background="@null"
                     android:contentDescription="@string/share_course_button"
-                    android:padding="@dimen/widget_margin"
+                    android:padding="@dimen/edx_margin"
                     android:scaleType="fitCenter"
                     android:src="@drawable/abc_ic_menu_share_mtrl_alpha"
                     android:tint="@color/black"
-                    android:visibility="invisible" />
+                    android:visibility="invisible"
+                    tools:visibility="visible"/>
             </LinearLayout>
 
             <ImageView

--- a/OpenEdXMobile/res/values/dimens.xml
+++ b/OpenEdXMobile/res/values/dimens.xml
@@ -23,7 +23,6 @@
     <dimen name="drawer_app_version_text">12sp</dimen>
 
     <!-- Popup Spinner -->
-    <dimen name="popup_menu_icon_default_size">16dp</dimen>
     <dimen name="popup_spinner_border">1dp</dimen>
     <dimen name="popup_spinner_min_height">34dp</dimen>
 
@@ -42,7 +41,7 @@
     <dimen name="course_card_height">190dp</dimen>
     <dimen name="course_card_play_icon_size">60dp</dimen>
     <dimen name="course_detail_card_height">70dp</dimen>
-    <dimen name="course_detail_share_icon_size">36dp</dimen>
+    <dimen name="course_detail_share_icon_size">50dp</dimen>
 
     <!-- Course Dashboard-->
     <dimen name="dashboard_nav_element_height">85dp</dimen>

--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -33,8 +33,6 @@
 
     <!-- Description of button that will open the share course menu -->
     <string name="share_course_button">Share your course</string>
-    <!-- Share menu title -->
-    <string name="share_course_popup_header">Share this course via&#8230;</string>
     <!-- Share course -->
     <string name="share_course_message">I’m taking a course on {platform_name}! Check it out:</string>
 
@@ -51,8 +49,6 @@
     <string name="share_certificate_message">I just earned a Certificate on {platform_name}! Check it out: {certificate_url}</string>
     <!-- Tab of tab for certicate for finished course -->
     <string name="tab_label_certificate">Certificate</string>
-    <!-- Header for popup list of share targets -->
-    <string name="share_certificate_popup_header">Share your certificate via…</string>
 
     <!-- Data Usage Dialog -->
     <!-- Alert dialog error message shown when using a feature with a required Internet connection -->

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
@@ -3,7 +3,6 @@ package org.edx.mobile.base;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
@@ -13,12 +12,10 @@ import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarDrawerToggle;
-import android.util.TypedValue;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.WindowManager;
-import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -88,7 +85,6 @@ public abstract class BaseFragmentActivity extends BaseAppActivity
     @Override
     protected void onCreate(Bundle arg0) {
         super.onCreate(arg0);
-        updateActionBarShadow();
         ActionBar bar = getSupportActionBar();
         if (bar != null) {
             bar.setDisplayShowHomeEnabled(true);
@@ -118,33 +114,6 @@ public abstract class BaseFragmentActivity extends BaseAppActivity
             }
         }
     }
-
-
-    private void updateActionBarShadow() {
-        //Check for JellyBeans version
-        if (Build.VERSION.SDK_INT == 18) {
-            // Get the content view
-            View contentView = findViewById(android.R.id.content);
-
-            // Make sure it's a valid instance of a FrameLayout
-            if (contentView instanceof FrameLayout) {
-                TypedValue tv = new TypedValue();
-
-                // Get the windowContentOverlay value of the current theme
-                if (getTheme().resolveAttribute(
-                        android.R.attr.windowContentOverlay, tv, true)) {
-
-                    // If it's a valid resource, set it as the foreground drawable
-                    // for the content view
-                    if (tv.resourceId != 0) {
-                        ((FrameLayout) contentView).setForeground(
-                                getResources().getDrawable(tv.resourceId));
-                    }
-                }
-            }
-        }
-    }
-
 
     @Override
     protected void onStop() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/images/ShareUtils.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/images/ShareUtils.java
@@ -6,14 +6,11 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.support.annotation.NonNull;
-import android.support.annotation.StringRes;
+import android.support.v7.view.menu.MenuBuilder;
+import android.support.v7.view.menu.MenuPopupHelper;
 import android.support.v7.widget.PopupMenu;
 import android.view.MenuItem;
-import android.view.SubMenu;
 import android.view.View;
-
-import org.edx.mobile.R;
-import org.edx.mobile.view.custom.popup.SizedDrawable;
 
 import java.util.List;
 
@@ -27,16 +24,15 @@ public enum ShareUtils {
                 .setType("text/plain");
     }
 
-    public static void showShareMenu(@NonNull Intent shareIntent, @NonNull View anchor, final @NonNull ShareMenuItemListener listener, @StringRes int menu_title) {
+    public static void showShareMenu(@NonNull Intent shareIntent, @NonNull View anchor,
+                                     final @NonNull ShareMenuItemListener listener) {
         final Context context = anchor.getContext();
         final PopupMenu popupMenu = new PopupMenu(context, anchor);
-        final SubMenu subMenu = popupMenu.getMenu().addSubMenu(menu_title);
         final PackageManager packageManager = context.getPackageManager();
-        final int iconSize = context.getResources().getDimensionPixelSize(R.dimen.popup_menu_icon_default_size);
         final List<ResolveInfo> resolveInfoList = packageManager.queryIntentActivities(shareIntent, 0);
         for (final ResolveInfo resolveInfo : resolveInfoList) {
-            final MenuItem shareItem = subMenu.add(resolveInfo.loadLabel(packageManager));
-            shareItem.setIcon(new SizedDrawable(resolveInfo.loadIcon(packageManager), iconSize, iconSize));
+            final MenuItem shareItem = popupMenu.getMenu().add(resolveInfo.loadLabel(packageManager));
+            shareItem.setIcon(resolveInfo.loadIcon(packageManager));
             shareItem.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
                 @Override
                 public boolean onMenuItemClick(MenuItem item) {
@@ -46,7 +42,10 @@ public enum ShareUtils {
                 }
             });
         }
-        popupMenu.show();
+        // As PopupMenu doesn't support to show icons in main menu, use MenuPopupHelper for it
+        final MenuPopupHelper menuHelper = new MenuPopupHelper(context, (MenuBuilder) popupMenu.getMenu(), anchor);
+        menuHelper.setForceShowIcon(true);
+        menuHelper.show();
     }
 
     public interface ShareMenuItemListener {
@@ -63,6 +62,7 @@ public enum ShareUtils {
     private static ShareType getShareTypeFromComponentName(@NonNull ComponentName componentName) {
         switch (componentName.getPackageName()) {
             case "com.facebook.katana":
+            case "com.facebook.lite":
                 return ShareType.FACEBOOK;
             case "com.twitter.android":
                 return ShareType.TWITTER;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CertificateFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CertificateFragment.java
@@ -15,10 +15,11 @@ import android.webkit.WebView;
 
 import com.google.inject.Inject;
 
+import org.edx.mobile.R;
+import org.edx.mobile.base.BaseFragment;
+import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.module.analytics.Analytics;
 import org.edx.mobile.module.analytics.AnalyticsRegistry;
-import org.edx.mobile.R;
-import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.services.EdxCookieManager;
 import org.edx.mobile.util.ResourceUtil;
 import org.edx.mobile.util.images.ShareUtils;
@@ -27,7 +28,6 @@ import org.edx.mobile.view.custom.URLInterceptorWebViewClient;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.edx.mobile.base.BaseFragment;
 import roboguice.inject.InjectExtra;
 
 public class CertificateFragment extends BaseFragment {
@@ -74,8 +74,7 @@ public class CertificateFragment extends BaseFragment {
                                 intent.setComponent(componentName);
                                 startActivity(intent);
                             }
-                        },
-                R.string.share_certificate_popup_header);
+                        });
                 return true;
             }
             default: {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDashboardFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDashboardFragment.java
@@ -219,8 +219,7 @@ public class CourseDashboardFragment extends BaseFragment {
                         intent.setComponent(componentName);
                         startActivity(intent);
                     }
-                },
-                R.string.share_course_popup_header);
+                });
     }
 
     private ViewHolder createViewHolder(LayoutInflater inflater, LinearLayout parent) {

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/view/BaseFragmentActivityTest.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/view/BaseFragmentActivityTest.java
@@ -89,35 +89,6 @@ public abstract class BaseFragmentActivityTest extends UiTest {
     }
 
     /**
-     * Testing window content overlay hack for API level 18
-     */
-    @Test
-    @Config(sdk = Build.VERSION_CODES.JELLY_BEAN_MR2)
-    public void updateActionBarShadowTest() {
-        BaseFragmentActivity activity =
-                Robolectric.buildActivity(getActivityClass())
-                        .withIntent(getIntent()).create().get();
-
-        // Get the content view
-        View contentView = activity.findViewById(android.R.id.content);
-
-        // Make sure it's a valid instance of a FrameLayout
-        assumeThat(contentView, instanceOf(FrameLayout.class));
-        TypedValue tv = new TypedValue();
-
-        // Get the windowContentOverlay value of the current theme
-        assumeTrue(activity.getTheme().resolveAttribute(
-                android.R.attr.windowContentOverlay, tv, true));
-
-        // If it's a valid resource, confirm that is has been set as
-        // the foreground drawable for the content view
-        assumeTrue(tv.resourceId != 0);
-        Drawable contentForeground = ((FrameLayout) contentView).getForeground();
-        assertEquals(tv.resourceId, Shadows.shadowOf(
-                contentForeground).getCreatedFromResId());
-    }
-
-    /**
      * Generic method for asserting pending transition animation
      *
      * @param shadowActivity The shadow activity

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/view/CourseUnitVideoFragmentTest.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/view/CourseUnitVideoFragmentTest.java
@@ -4,34 +4,27 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
-import android.support.v7.app.ActionBar;
-import android.support.v7.app.AppCompatActivity;
 import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
-import android.view.WindowManager;
 import android.widget.LinearLayout;
 
 import org.edx.mobile.R;
 import org.edx.mobile.course.CourseAPI;
-import org.edx.mobile.http.provider.OkHttpClientProvider;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.model.course.CourseComponent;
 import org.edx.mobile.model.course.CourseStructureV1Model;
 import org.edx.mobile.model.course.VideoBlockModel;
 import org.junit.Test;
-import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.support.v4.SupportFragmentTestUtil;
 
+import static org.junit.Assert.assertNotNull;
 import static org.assertj.android.api.Assertions.assertThat;
 import static org.edx.mobile.http.util.CallUtil.executeStrict;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeNotNull;
 
 // We should add mock downloads, mock play, and state retention tests
 // later. Also, online/offline transition tests; although the
@@ -82,43 +75,6 @@ public class CourseUnitVideoFragmentTest extends UiTest {
         assertNotNull(messageContainer);
     }
 
-
-    /**
-     * Generic method to assert action bar visibility state on a specified orientation
-     *
-     * @param orientation The orientation it should be tested on
-     * @param expected The expected visibility state
-     */
-    private void assertActionBarShowing(int orientation, boolean expected) {
-        AppCompatActivity activity = Robolectric.setupActivity(FragmentUtilActivity.class);
-        activity.getResources().getConfiguration().orientation = orientation;
-        CourseUnitVideoFragment fragment = CourseUnitVideoFragment.newInstance(getVideoUnit(), false, false);
-        activity.getSupportFragmentManager()
-                .beginTransaction().add(1, fragment, null).commit();
-        assertTrue(fragment.getRetainInstance());
-        ActionBar bar = activity.getSupportActionBar();
-        assumeNotNull(bar);
-        assertEquals(expected, bar.isShowing());
-    }
-
-    /**
-     * Testing whether action bar is displayed in portrait orientation
-     */
-    @Test
-    @Config(qualifiers = "port")
-    public void showActionBarOnPortraitTest() {
-        assertActionBarShowing(Configuration.ORIENTATION_PORTRAIT, true);
-    }
-
-    /**
-     * Testing whether action bar is hidden in landscape orientation
-     */
-    @Test
-    @Config(qualifiers = "land")
-    public void showActionBarOnLandscapeTest() {
-        assertActionBarShowing(Configuration.ORIENTATION_LANDSCAPE, true);
-    }
-
     /**
      * Generic method for testing setup on orientation changes
      *
@@ -166,7 +122,7 @@ public class CourseUnitVideoFragmentTest extends UiTest {
         testOrientationChange(fragment, Configuration.ORIENTATION_PORTRAIT);
     }
 
-    private static class FragmentUtilActivity extends AppCompatActivity implements CourseUnitFragment.HasComponent {
+    private static class FragmentUtilActivity extends FragmentActivity implements CourseUnitFragment.HasComponent {
         @Override
         protected void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);

--- a/android-iconify-fontawesome/build.gradle
+++ b/android-iconify-fontawesome/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion COMPILE_SDK_VERSION
     buildToolsVersion BUILD_TOOLS_VERSION
 
     defaultConfig {

--- a/android-iconify/build.gradle
+++ b/android-iconify/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion COMPILE_SDK_VERSION
     buildToolsVersion BUILD_TOOLS_VERSION
 
     defaultConfig {

--- a/android-iconify/src/main/java/com/joanzapata/iconify/internal/CustomTypefaceSpan.java
+++ b/android-iconify/src/main/java/com/joanzapata/iconify/internal/CustomTypefaceSpan.java
@@ -71,7 +71,7 @@ public class CustomTypefaceSpan extends ReplacementSpan {
 
     public CustomTypefaceSpan(@NonNull TextView view, @NonNull Icon icon,
             @NonNull Typeface type, @Size float iconSizePx,
-            @FloatRange(from = 0f, to = 1f) float iconSizeRatio,
+            @FloatRange(from = -1f, to = 1f) float iconSizeRatio,
             @ColorInt int iconColor, @NonNull Animation animation,
             boolean baselineAligned) {
         this.view = view;

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,8 @@ buildscript {
 }
 
 project.ext {
-    BUILD_TOOLS_VERSION = "23.0.3"
+    BUILD_TOOLS_VERSION = "25.0.3"
+    COMPILE_SDK_VERSION = 25
 
     // dummy keystore configuration if not already defined
     if ( !project.properties.containsKey("RELEASE_STORE_FILE")) {


### PR DESCRIPTION
### Description

[LEARNER-553](https://openedx.atlassian.net/browse/LEARNER-553)

Issue described in the story will be fixed after updating support libraries, so in this PR we have updated:

- support libraries to **"25.3.1"**
- `buildToolsVersion` (gradle build tools) to **"25.0.3"**
- `compileSdkVersion` to **"25"**

As discussed in story, this pull request also covers following sharing feature improvements.

- Removed extra menu bar and title from the sharing pop up.
- Removed scaling down of icons in pop up.
- Add Facebook lite id in Facebook apps list to consider it as facebook share.

### Notes

- After updating libraries and tools, i got issues in passing test cases on travis, to resolve them i updated travis configuration file and some test cases as well.
- Certificate sharing feature will also be improved in the same way as course sharing.
(Currently i am seeing certificate sharing pop up with black theme which we will fix in separate story)

### Screen Shots:
Course Dashboard | Course Sharing Popup
--- | ---
<img src="https://cloud.githubusercontent.com/assets/25842457/25712641/9d89f6da-310b-11e7-9b9f-16b4ac346758.png" width="200"> | <img src="https://cloud.githubusercontent.com/assets/25842457/25712640/9d897ed0-310b-11e7-94ac-592366df6b20.png" width="200">

