### PR TITLE
LEARNER-795: Add UTM params for course sharing feature

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/CourseEntry.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/CourseEntry.java
@@ -11,6 +11,7 @@ import org.edx.mobile.util.images.CourseCardUtils;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 @SuppressWarnings("serial")
 public class CourseEntry implements Serializable {
@@ -35,6 +36,7 @@ public class CourseEntry implements Serializable {
     private String discussion_url;
     private SocialURLModel social_urls;
     private CoursewareAccess courseware_access;
+    @Nullable private Map<String, String> course_sharing_utm_parameters;
 
     public LatestUpdateModel getLatest_updates() {
         return latest_updates;
@@ -220,4 +222,8 @@ public class CourseEntry implements Serializable {
         return CourseCardUtils.getDescription(org, number, CourseCardUtils.getFormattedDate(context, this));
     }
 
+    @Nullable
+    public String getCourseSharingUtmParams(@NonNull String sharingPlatformKey) {
+        return course_sharing_utm_parameters == null ? null : course_sharing_utm_parameters.get(sharingPlatformKey);
+    }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/images/ShareUtils.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/images/ShareUtils.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v7.view.menu.MenuBuilder;
 import android.support.v7.view.menu.MenuPopupHelper;
 import android.support.v7.widget.PopupMenu;
@@ -53,9 +54,21 @@ public enum ShareUtils {
     }
 
     public enum ShareType {
-        TWITTER,
-        FACEBOOK,
-        UNKNOWN
+        TWITTER("twitter"),
+        FACEBOOK("facebook"),
+        UNKNOWN(null)
+        ;
+
+        private String utmParamKey;
+
+        ShareType(@Nullable String key) {
+            utmParamKey = key;
+        }
+
+        @Nullable
+        public String getUtmParamKey() {
+            return utmParamKey;
+        }
     }
 
     @NonNull


### PR DESCRIPTION
### Description

[LEARNER-795](https://openedx.atlassian.net/browse/LEARNER-795)

In this PR i have added the utm parameters in course sharing url for facebook and twitter platform.
These utm parameters are coming from server as a dictionary in `course_sharing_utm_parameters` key in Course Enrollments server call i-e-
https://courses.edx.org/api/mobile/v0.5/users/{username}/course_enrollments/

- Incase of Facebook final sharing url will be like: 
https://www.edx.org/course/android-app-development-beginners-galileox-caad002x?utm_campaign=social-sharing&utm_medium=social-post&utm_source=facebook

- In case of Twitter final sharing url will be like:
https://www.edx.org/course/android-app-development-beginners-galileox-caad002x?utm_campaign=social-sharing&utm_medium=social-post&utm_source=twitter