### PR TITLE
Analytics: Remove map entry if a key’s value is null

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/AnalyticsRegistry.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/AnalyticsRegistry.java
@@ -35,6 +35,15 @@ public class AnalyticsRegistry implements Analytics {
     @Override
     public void trackScreenView(@NonNull String screenName, @Nullable String courseId,
                                 @Nullable String action, @Nullable Map<String, String> values) {
+        // Remove a key-value pair, if the value for a key is null
+        if (values != null) {
+            for (Map.Entry<String, String> entry : values.entrySet()) {
+                if (entry.getValue() == null) {
+                    values.remove(entry.getKey());
+                }
+            }
+        }
+
         for (Analytics service : services) {
             service.trackScreenView(screenName, courseId, action, values);
         }


### PR DESCRIPTION
### Description

[LEARNER-916](https://openedx.atlassian.net/browse/LEARNER-916)

Incase of sending screen event for a parent discussion topic, since the identifier is `null`, it caused the crash when our Firebase logic tried to apply the restrictions we do in `org.edx.mobile.module.analytics.FirebaseEvent#applyRestrictions` function.

This PR solves the issue by removing an entry from the `values` map whenever a `key` has
`value` == `null`.