### PR TITLE
Add invitation only button to course detail view

### DIFF
--- a/OpenEdXMobile/res/drawable/edx_enroll_button.xml
+++ b/OpenEdXMobile/res/drawable/edx_enroll_button.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/edx_brand_gray_back" />
+            <corners android:radius="@dimen/edx_box_radius" />
+        </shape>
+    </item>
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@color/edx_success_accent" />

--- a/OpenEdXMobile/res/drawable/edx_enroll_button_text_color.xml
+++ b/OpenEdXMobile/res/drawable/edx_enroll_button_text_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@color/edx_brand_gray_accent" />
+    <item android:state_enabled="true" android:color="@color/edx_white" />
+</selector>

--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -17,6 +17,8 @@
 
     <!-- Enroll Now button text-->
     <string name="enroll_now_button_text">Enroll now</string>
+    <!-- Invitation Only button text-->
+    <string name="invitation_only_button_text">Invitation only</string>
     <!-- Effort field name -->
     <string name="effort_field_name">Effort:</string>
     <!-- When discovering courses, some courses have an externally hosted video that describes it.

--- a/OpenEdXMobile/res/values/styles.xml
+++ b/OpenEdXMobile/res/values/styles.xml
@@ -374,7 +374,7 @@
 
     <style name="edX.Widget.EnrollButton" parent="edX.Widget.Button">
         <item name="android:minHeight">@dimen/edx_button_height</item>
-        <item name="android:textColor">@color/edx_white</item>
+        <item name="android:textColor">@drawable/edx_enroll_button_text_color</item>
         <item name="android:layout_gravity">center</item>
         <item name="android:background">@drawable/edx_enroll_button</item>
         <item name="android:textSize">@dimen/edx_small</item>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseDetail.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseDetail.java
@@ -23,6 +23,7 @@ public class CourseDetail implements Parcelable {
     public Media media;
     public String effort;
     public String overview;
+    public Boolean invitation_only;
 
     public static class Media implements Parcelable {
         public Image course_image;
@@ -141,6 +142,7 @@ public class CourseDetail implements Parcelable {
         media = (Media) in.readValue(Media.class.getClassLoader());
         effort = in.readString();
         overview = in.readString();
+        invitation_only = (Boolean) in.readValue(Boolean.class.getClassLoader());
     }
 
     @Override
@@ -165,6 +167,7 @@ public class CourseDetail implements Parcelable {
         dest.writeValue(media);
         dest.writeString(effort);
         dest.writeString(overview);
+        dest.writeValue(invitation_only);
     }
 
     @SuppressWarnings("unused")

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDetailFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDetailFragment.java
@@ -14,6 +14,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -307,6 +308,9 @@ public class CourseDetailFragment extends BaseFragment {
 
         if (mEnrolled) {
             mEnrollButton.setText(R.string.view_course_button_text);
+        } else if (courseDetail.invitation_only != null && courseDetail.invitation_only) {
+            mEnrollButton.setText(R.string.invitation_only_button_text);
+            mEnrollButton.setEnabled(false);
         } else {
             mEnrollButton.setText(R.string.enroll_now_button_text);
         }


### PR DESCRIPTION
### Description

[OSPR-1782](https://openedx.atlassian.net/browse/OSPR-1782)

This PR disables the enroll button in a course if it is invite only and changes the text.

### Notes

For this PR to work it depends on edx/edx-platform#15223.

### How to test this PR

- Have a course invite only.
- Find the course in the app.
- Click on it, should see button disabled.

### Reviewers
- [x] Code review: @miankhalid
- [x] Code review: @farhan 

cc @marcotuts @gsong 