### PR TITLE
Fixed course dates faulty background bug, LEARNER-1509

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/AuthenticatedWebView.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/AuthenticatedWebView.java
@@ -337,6 +337,7 @@ public class AuthenticatedWebView extends FrameLayout {
                             @Override
                             public void run() {
                                 didReceiveError = true;
+                                webView.setVisibility(View.GONE);
                                 showErrorView(errorMsg, FontAwesomeIcons.fa_exclamation_circle);
                             }
                         }


### PR DESCRIPTION
### Description

[LEARNER-1509](https://openedx.atlassian.net/browse/LEARNER-1509)

Please refer to story for a bug fixed in this PR.

Course dates feature is behind feature flag of 'COURSE_DATES_ENABLED'

### Testing:
You can see following course dates (on prod) for testing purpose as it doesn't have any available course dates.
https://courses.edx.org/courses/course-v1:HarvardX+CS50+X/info 

### Screen shots:
Course without course dates | Course with course dates
--- | ---
<img src="https://user-images.githubusercontent.com/25842457/27426673-e118e4c2-5755-11e7-9e68-7e2035aaca29.png" width="200">| <img src="https://user-images.githubusercontent.com/25842457/27426674-e11ec66c-5755-11e7-9f20-29af0b077e8c.png" width="200">

