### PR TITLE
EDUCATOR-341 Add author field to forum screen tracking events

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
@@ -340,6 +340,7 @@ public interface Analytics {
         String TOPIC_ID = "topic_id";
         String THREAD_ID = "thread_id";
         String RESPONSE_ID = "response_id";
+        String AUTHOR = "author";
 
         String COMPONENT_VIEWED = "Component Viewed";
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
@@ -170,6 +170,9 @@ public class CourseDiscussionCommentsFragment extends BaseFragment implements Di
         values.put(Analytics.Keys.TOPIC_ID, discussionThread.getTopicId());
         values.put(Analytics.Keys.THREAD_ID, discussionThread.getIdentifier());
         values.put(Analytics.Keys.RESPONSE_ID, discussionResponse.getIdentifier());
+        if (!discussionResponse.isAuthorAnonymous()) {
+            values.put(Analytics.Keys.AUTHOR, discussionResponse.getAuthor());
+        }
         analyticsRegistry.trackScreenView(Analytics.Screens.FORUM_VIEW_RESPONSE_COMMENTS,
                 discussionThread.getCourseId(), discussionThread.getTitle(), values);
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
@@ -143,6 +143,9 @@ public class CourseDiscussionResponsesFragment extends BaseFragment implements C
         Map<String, String> values = new HashMap<>();
         values.put(Analytics.Keys.TOPIC_ID, discussionThread.getTopicId());
         values.put(Analytics.Keys.THREAD_ID, discussionThread.getIdentifier());
+        if (!discussionThread.isAuthorAnonymous()) {
+            values.put(Analytics.Keys.AUTHOR, discussionThread.getAuthor());
+        }
         analyticsRegistry.trackScreenView(Analytics.Screens.FORUM_VIEW_THREAD,
                 courseData.getCourse().getId(), discussionThread.getTitle(), values);
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
@@ -88,6 +88,9 @@ public class DiscussionAddCommentFragment extends BaseFragment {
         values.put(Analytics.Keys.TOPIC_ID, discussionThread.getTopicId());
         values.put(Analytics.Keys.THREAD_ID, discussionThread.getIdentifier());
         values.put(Analytics.Keys.RESPONSE_ID, discussionResponse.getIdentifier());
+        if (!discussionResponse.isAuthorAnonymous()) {
+            values.put(Analytics.Keys.AUTHOR, discussionResponse.getAuthor());
+        }
         analyticsRegistry.trackScreenView(Analytics.Screens.FORUM_ADD_RESPONSE_COMMENT,
                 discussionThread.getCourseId(), discussionThread.getTitle(), values);
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
@@ -84,6 +84,9 @@ public class DiscussionAddResponseFragment extends BaseFragment {
         Map<String, String> values = new HashMap<>();
         values.put(Analytics.Keys.TOPIC_ID, discussionThread.getTopicId());
         values.put(Analytics.Keys.THREAD_ID, discussionThread.getIdentifier());
+        if (!discussionThread.isAuthorAnonymous()) {
+            values.put(Analytics.Keys.AUTHOR, discussionThread.getAuthor());
+        }
         analyticsRegistry.trackScreenView(Analytics.Screens.FORUM_ADD_RESPONSE,
                 discussionThread.getCourseId(), discussionThread.getTitle(), values);
     }


### PR DESCRIPTION
Supports [creation of edx.forum.thread.viewed LMS event](https://github.com/edx/edx-platform/pull/15237). See the corresponding [iOS PR](https://github.com/edx/edx-app-ios/pull/955).

Ticket: [EDUCATOR-341](https://openedx.atlassian.net/browse/EDUCATOR-341)

@edx/educator-dahlia 

### Notes
- The `'author'` field is transformed into a `'target_username'` field in the LMS. The reason I chose to name it `'author'` in the apps was to remain consistent with the terminology already used in the apps.

### Questions for reviewers
- Should any other forum events also be given an `'author'` field?
  - Answer: Yes, any forum action that has a related "author" should have the field
- If we do decide to add `'author'` to events other than just thread-viewed, what should the field contain? The parent thread's author? The comment's author?
  - Answer: The direct parent's author

### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit shows 0 violations
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Analytics
- [ ] Performance
- [ ] Database migrations are backwards-compatible

### Reviews
- [x] Dahlia review (@dsjen)
- [x] Mobile review (@farhan, @miankhalid)

### TODO after merging
- [ ] Update event wiki pages