### PR TITLE
Keep some files common on transifex

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -17,26 +17,20 @@ file_filter = OpenEdXMobile/res/values-<lang>/labels.xml
 source_file = OpenEdXMobile/res/values/labels.xml
 source_lang = en
 
-[edx-mobile-apps.android-app-profiles]
+[edx-mobile-apps.app-localizable-profiles]
 file_filter = OpenEdXMobile/res/raw-<lang>/profiles.json
 source_file = OpenEdXMobile/res/raw/profiles.json
 source_lang = en
 type = KEYVALUEJSON
 
-[edx-mobile-apps.android-app-countries]
+[edx-mobile-apps.app-localizable-countries]
 file_filter = OpenEdXMobile/res/raw-<lang>/countries.json
 source_file = OpenEdXMobile/res/raw/countries.json
 source_lang = en
 type = KEYVALUEJSON
 
-[edx-mobile-apps.android-app-languages]
+[edx-mobile-apps.app-localizable-languages]
 file_filter = OpenEdXMobile/res/raw-<lang>/languages.json
 source_file = OpenEdXMobile/res/raw/languages.json
-source_lang = en
-type = KEYVALUEJSON
-
-[edx-mobile-apps.android-app-whatsNew]
-file_filter = OpenEdXMobile/res/raw-<lang>/whats_new.json
-source_file = OpenEdXMobile/res/raw/whats_new.json
 source_lang = en
 type = KEYVALUEJSON


### PR DESCRIPTION
[LEARNER-2359](https://openedx.atlassian.net/browse/LEARNER-2359)

### Description

Files `profiles.json, languages.json, and countries.json` have been made common on transifex and their particular android specific files has been removed from transifex which we were using before.

`whats_new.json` link with transifex has been removed temporarily, we shall make it again once the common format  for whats_new file has been developed for both mobile platforms.