### PR TITLE
Apply activity visiblity check before showing dialog

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
@@ -480,7 +480,9 @@ public abstract class BaseFragmentActivity extends BaseAppActivity
     }
 
     public void showAlertDialog(@Nullable String title, @NonNull String message, @Nullable DialogInterface.OnClickListener onPositiveClick) {
-        AlertDialogFragment.newInstance(title, message, onPositiveClick).show(getSupportFragmentManager(), null);
+        if (isInForeground) {
+            AlertDialogFragment.newInstance(title, message, onPositiveClick).show(getSupportFragmentManager(), null);
+        }
     }
 
     public void showAlertDialog(@Nullable String title, @NonNull String message,
@@ -488,8 +490,10 @@ public abstract class BaseFragmentActivity extends BaseAppActivity
                                 @Nullable DialogInterface.OnClickListener onPositiveClick,
                                 @Nullable String  negativeButtonText,
                                 @Nullable DialogInterface.OnClickListener onNegativeClick) {
-        AlertDialogFragment.newInstance(title, message, positiveButtonText, onPositiveClick, negativeButtonText, onNegativeClick)
-                .show(getSupportFragmentManager(), null);
+        if (isInForeground) {
+            AlertDialogFragment.newInstance(title, message, positiveButtonText, onPositiveClick, negativeButtonText, onNegativeClick)
+                    .show(getSupportFragmentManager(), null);
+        }
     }
 
     @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/RoboAppCompatActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/RoboAppCompatActivity.java
@@ -51,6 +51,7 @@ import roboguice.util.RoboContext;
 public class RoboAppCompatActivity extends AppCompatActivity implements RoboContext {
     protected EventManager eventManager;
     protected HashMap<Key<?>, Object> scopedObjects = new HashMap<Key<?>, Object>();
+    protected boolean isInForeground = false;
 
     @Inject
     ContentViewListener ignored; // BUG find a better place to put this
@@ -85,12 +86,14 @@ public class RoboAppCompatActivity extends AppCompatActivity implements RoboCont
     @Override
     protected void onResume() {
         super.onResume();
+        isInForeground = true;
         eventManager.fire(new OnResumeEvent(this));
     }
 
     @Override
     protected void onPause() {
         super.onPause();
+        isInForeground = false;
         eventManager.fire(new OnPauseEvent(this));
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/notifications/DialogErrorNotification.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/notifications/DialogErrorNotification.java
@@ -4,12 +4,12 @@ import android.content.DialogInterface;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
-import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AlertDialog;
 import android.view.View;
 
 import com.joanzapata.iconify.Icon;
 
+import org.edx.mobile.base.BaseFragment;
 import org.edx.mobile.view.dialog.AlertDialogFragment;
 
 /**
@@ -17,19 +17,19 @@ import org.edx.mobile.view.dialog.AlertDialogFragment;
  */
 public class DialogErrorNotification extends ErrorNotification {
     /**
-     * The Fragment manager of the concerned Activity.
+     * Reference of the {@link android.support.v4.app.Fragment} we will be displaying this error on.
      */
     @NonNull
-    private final FragmentManager fragmentManager;
+    private final BaseFragment baseFragment;
 
     /**
      * Construct a new instance of the notification.
      *
-     * @param fragmentManager The Fragment manager of the concerned Activity, to use for displaying
-     *                        the DialogFragment.
+     * @param baseFragment Reference of the {@link android.support.v4.app.Fragment} to use for
+     *                     displaying the {@link android.support.v4.app.DialogFragment}.
      */
-    public DialogErrorNotification(@NonNull final FragmentManager fragmentManager) {
-        this.fragmentManager = fragmentManager;
+    public DialogErrorNotification(@NonNull final BaseFragment baseFragment) {
+        this.baseFragment = baseFragment;
     }
 
     /**
@@ -45,14 +45,16 @@ public class DialogErrorNotification extends ErrorNotification {
                           @Nullable final Icon icon,
                           @StringRes final int actionTextResId,
                           @Nullable final View.OnClickListener actionListener) {
-        AlertDialogFragment.newInstance(0, errorResId,
-                actionListener == null ? null :
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                actionListener.onClick(((AlertDialog) dialog).getButton(AlertDialog.BUTTON_POSITIVE));
+        if (baseFragment.isResumed()) {
+            AlertDialogFragment.newInstance(0, errorResId,
+                    actionListener == null ? null :
+                            new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    actionListener.onClick(((AlertDialog) dialog).getButton(AlertDialog.BUTTON_POSITIVE));
+                                }
                             }
-                        }
-        ).show(fragmentManager, null);
+            ).show(baseFragment.getChildFragmentManager(), null);
+        }
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
@@ -205,7 +205,7 @@ public class CourseDiscussionCommentsFragment extends BaseFragment implements Di
         setCommentFlaggedCall = discussionService.setCommentFlagged(
                 comment.getIdentifier(), new FlagBody(!comment.isAbuseFlagged()));
         setCommentFlaggedCall.enqueue(new ErrorHandlingCallback<DiscussionComment>(
-                context, null, new DialogErrorNotification(getChildFragmentManager())) {
+                context, null, new DialogErrorNotification(this)) {
             @Override
             protected void onResponse(@NonNull final DiscussionComment comment) {
                 discussionCommentsAdapter.updateComment(comment);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
@@ -99,7 +99,7 @@ public class CourseDiscussionResponsesFragment extends BaseFragment implements C
                 discussionThread.getType() == DiscussionThread.ThreadType.QUESTION);
 
         courseDiscussionResponsesAdapter = new CourseDiscussionResponsesAdapter(
-                activity, getChildFragmentManager(), this, discussionThread, courseData);
+                activity, this, this, discussionThread, courseData);
         controller = InfiniteScrollUtils.configureRecyclerViewWithInfiniteList(
                 discussionResponsesRecyclerView, courseDiscussionResponsesAdapter, responsesLoader);
         discussionResponsesRecyclerView.setAdapter(courseDiscussionResponsesAdapter);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
@@ -156,7 +156,7 @@ public class DiscussionAddCommentFragment extends BaseFragment {
         createCommentCall.enqueue(new ErrorHandlingCallback<DiscussionComment>(
                 getActivity(),
                 new ProgressViewController(createCommentProgressBar),
-                new DialogErrorNotification(getChildFragmentManager())) {
+                new DialogErrorNotification(this)) {
             @Override
             protected void onResponse(@NonNull final DiscussionComment thread) {
                 logger.debug(thread.toString());

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddPostFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddPostFragment.java
@@ -216,7 +216,7 @@ public class DiscussionAddPostFragment extends BaseFragment {
         createThreadCall.enqueue(new ErrorHandlingCallback<DiscussionThread>(
                 getActivity(),
                 new ProgressViewController(addPostProgressBar),
-                new DialogErrorNotification(getChildFragmentManager())) {
+                new DialogErrorNotification(this)) {
             @Override
             protected void onResponse(@NonNull final DiscussionThread courseTopics) {
                 EventBus.getDefault().post(new DiscussionThreadPostedEvent(courseTopics));

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
@@ -149,7 +149,7 @@ public class DiscussionAddResponseFragment extends BaseFragment {
         createCommentCall.enqueue(new ErrorHandlingCallback<DiscussionComment>(
                 getActivity(),
                 new ProgressViewController(createCommentProgressBar),
-                new DialogErrorNotification(getChildFragmentManager())) {
+                new DialogErrorNotification(this)) {
             @Override
             protected void onResponse(@NonNull final DiscussionComment thread) {
                 logger.debug(thread.toString());

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/EditUserProfileFragment.java
@@ -452,7 +452,7 @@ public class EditUserProfileFragment extends BaseFragment {
         }
         userService.updateAccount(username, Collections.singletonMap(field.getName(), valueObject))
                 .enqueue(new AccountDataUpdatedCallback(getActivity(), username,
-                        new DialogErrorNotification(getChildFragmentManager())) {
+                        new DialogErrorNotification(this)) {
                     @Override
                     protected void onResponse(@NonNull final Account account) {
                         super.onResponse(account);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseDiscussionResponsesAdapter.java
@@ -19,6 +19,7 @@ import com.joanzapata.iconify.IconDrawable;
 import com.joanzapata.iconify.fonts.FontAwesomeIcons;
 
 import org.edx.mobile.R;
+import org.edx.mobile.base.BaseFragment;
 import org.edx.mobile.discussion.DiscussionComment;
 import org.edx.mobile.discussion.DiscussionService;
 import org.edx.mobile.discussion.DiscussionService.FlagBody;
@@ -68,7 +69,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
     private final Context context;
 
     @NonNull
-    private final FragmentManager fragmentManager;
+    private final BaseFragment baseFragment;
 
     @NonNull
     private final Listener listener;
@@ -92,11 +93,12 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
     }
 
     public CourseDiscussionResponsesAdapter(@NonNull Context context,
-                @NonNull FragmentManager fragmentManager, @NonNull Listener listener,
-                @NonNull DiscussionThread discussionThread,
-                @NonNull EnrolledCoursesResponse courseData) {
+                                            @NonNull BaseFragment baseFragment,
+                                            @NonNull Listener listener,
+                                            @NonNull DiscussionThread discussionThread,
+                                            @NonNull EnrolledCoursesResponse courseData) {
         this.context = context;
-        this.fragmentManager = fragmentManager;
+        this.baseFragment = baseFragment;
         this.discussionThread = discussionThread;
         this.listener = listener;
         this.courseData = courseData;
@@ -194,7 +196,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
                     discussionService.setThreadFlagged(discussionThread.getIdentifier(),
                             new FlagBody(!discussionThread.isAbuseFlagged()))
                             .enqueue(new ErrorHandlingCallback<DiscussionThread>(
-                                    context, null, new DialogErrorNotification(fragmentManager)) {
+                                    context, null, new DialogErrorNotification(baseFragment)) {
                                 @Override
                                 protected void onResponse(@NonNull final DiscussionThread topicThread) {
                                     discussionThread = discussionThread.patchObject(topicThread);
@@ -218,7 +220,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
                 discussionService.setThreadVoted(discussionThread.getIdentifier(),
                         new VoteBody(!discussionThread.isVoted()))
                         .enqueue(new ErrorHandlingCallback<DiscussionThread>(
-                                context, null, new DialogErrorNotification(fragmentManager)) {
+                                context, null, new DialogErrorNotification(baseFragment)) {
                             @Override
                             protected void onResponse(@NonNull final DiscussionThread updatedDiscussionThread) {
                                 discussionThread = discussionThread.patchObject(updatedDiscussionThread);
@@ -236,7 +238,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
                 discussionService.setThreadFollowed(discussionThread.getIdentifier(),
                         new FollowBody(!discussionThread.isFollowing()))
                         .enqueue(new ErrorHandlingCallback<DiscussionThread>(
-                                context, null, new DialogErrorNotification(fragmentManager)) {
+                                context, null, new DialogErrorNotification(baseFragment)) {
                             @Override
                             protected void onResponse(@NonNull final DiscussionThread updatedDiscussionThread) {
                                 discussionThread = discussionThread.patchObject(updatedDiscussionThread);
@@ -340,7 +342,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
                     discussionService.setCommentFlagged(comment.getIdentifier(),
                             new FlagBody(!comment.isAbuseFlagged()))
                             .enqueue(new ErrorHandlingCallback<DiscussionComment>(
-                                    context, null, new DialogErrorNotification(fragmentManager)) {
+                                    context, null, new DialogErrorNotification(baseFragment)) {
                                 @Override
                                 protected void onResponse(@NonNull final DiscussionComment comment) {
                                     discussionResponses.get(position - 1).patchObject(comment);
@@ -366,7 +368,7 @@ public class CourseDiscussionResponsesAdapter extends RecyclerView.Adapter imple
                 discussionService.setCommentVoted(response.getIdentifier(),
                         new VoteBody(!response.isVoted()))
                         .enqueue(new ErrorHandlingCallback<DiscussionComment>(
-                                context, null, new DialogErrorNotification(fragmentManager)) {
+                                context, null, new DialogErrorNotification(baseFragment)) {
                             @Override
                             protected void onResponse(@NonNull final DiscussionComment comment) {
                                 discussionResponses.get(position - 1).patchObject(comment);


### PR DESCRIPTION
### Description

[LEARNER-1988](https://openedx.atlassian.net/browse/LEARNER-1988)

App gets crashed whenever we try to show dialog when the dialogs creator activity is no more in foreground. To avoid all these crashes we have applied the activity/fragment foreground check before showing dialog in this PR.