### PR TITLE
Improvements to delete videos by long press

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java
@@ -422,6 +422,9 @@ public class CourseOutlineAdapter extends BaseAdapter {
                 break;
         }
         row.numOfVideoAndDownloadArea.setOnClickListener(listener);
+        if (listener == null) {
+            row.numOfVideoAndDownloadArea.setClickable(false);
+        }
     }
 
     public View getHeaderView(int position, View convertView) {


### PR DESCRIPTION
### Description

[LEARNER-1288](https://openedx.atlassian.net/browse/LEARNER-1288)

- SnackBar's visibility time increased to 5000 milliseconds
- Allow whole row long tap if its downloaded i.e. make downloaded state
icon non-clickable
- Fix crash where SnackBar's dismiss callback gets called twice when it
is about to dismiss and the activity finishes