### PR TITLE
Change Content-Type of create comment/response API

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/discussion/CommentBody.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/discussion/CommentBody.java
@@ -1,0 +1,17 @@
+package org.edx.mobile.discussion;
+
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+public class CommentBody {
+    private String threadId;
+    private String rawBody;
+    private String parentId;
+
+    public CommentBody(@NonNull String threadId, @NonNull String rawBody, @Nullable String parentId) {
+        this.threadId = threadId;
+        this.rawBody = rawBody;
+        this.parentId = parentId;
+    }
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/discussion/DiscussionService.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/discussion/DiscussionService.java
@@ -25,8 +25,6 @@ import java.util.List;
 
 import retrofit2.Call;
 import retrofit2.http.Body;
-import retrofit2.http.Field;
-import retrofit2.http.FormUrlEncoded;
 import retrofit2.http.GET;
 import retrofit2.http.Headers;
 import retrofit2.http.PATCH;
@@ -148,12 +146,9 @@ public interface DiscussionService {
     @POST("/api/discussion/v1/threads/")
     Call<DiscussionThread> createThread(@Body ThreadBody threadBody);
 
-    @FormUrlEncoded
     @Headers("Cache-Control: no-cache")
     @POST("/api/discussion/v1/comments/")
-    Call<DiscussionComment> createComment(@Field("thread_id") String threadId,
-                                          @Field("raw_body") String rawBody,
-                                          @Field("parent_id") String parentId);
+    Call<DiscussionComment> createComment(@Body CommentBody commentBody);
 
     final class FlagBody {
         private boolean abuseFlagged;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
@@ -16,6 +16,7 @@ import com.google.inject.Inject;
 
 import org.edx.mobile.R;
 import org.edx.mobile.base.BaseFragment;
+import org.edx.mobile.discussion.CommentBody;
 import org.edx.mobile.discussion.DiscussionComment;
 import org.edx.mobile.discussion.DiscussionCommentPostedEvent;
 import org.edx.mobile.discussion.DiscussionService;
@@ -151,8 +152,9 @@ public class DiscussionAddCommentFragment extends BaseFragment {
             createCommentCall.cancel();
         }
 
-        createCommentCall = discussionService.createComment(discussionResponse.getThreadId(),
-                editTextNewComment.getText().toString(), discussionResponse.getIdentifier());
+        createCommentCall = discussionService.createComment(new CommentBody(
+                discussionResponse.getThreadId(), editTextNewComment.getText().toString(),
+                discussionResponse.getIdentifier()));
         createCommentCall.enqueue(new ErrorHandlingCallback<DiscussionComment>(
                 getActivity(),
                 new ProgressViewController(createCommentProgressBar),

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
@@ -16,6 +16,7 @@ import com.google.inject.Inject;
 
 import org.edx.mobile.R;
 import org.edx.mobile.base.BaseFragment;
+import org.edx.mobile.discussion.CommentBody;
 import org.edx.mobile.discussion.DiscussionComment;
 import org.edx.mobile.discussion.DiscussionCommentPostedEvent;
 import org.edx.mobile.discussion.DiscussionService;
@@ -144,8 +145,8 @@ public class DiscussionAddResponseFragment extends BaseFragment {
             createCommentCall.cancel();
         }
 
-        createCommentCall = discussionService.createComment(discussionThread.getIdentifier(),
-                editTextNewComment.getText().toString(), null);
+        createCommentCall = discussionService.createComment(new CommentBody(
+                discussionThread.getIdentifier(), editTextNewComment.getText().toString(), null));
         createCommentCall.enqueue(new ErrorHandlingCallback<DiscussionComment>(
                 getActivity(),
                 new ProgressViewController(createCommentProgressBar),


### PR DESCRIPTION
### Description

[LEARNER-2734](https://openedx.atlassian.net/browse/LEARNER-2734)

Changes done to support the `Content-Type: application/json` instead of the previously used `application/x-www-form-urlencoded` type.

Retrofit 2 by default applies the `Content-Type: application/x-www-form-urlencoded` when the `@FormUrlEncoded` annotation is applied on a `Call's` declaration. In our case, this content type wasn't acceptable and we needed to send `application/json` as our Content-Type, which is what this PR does.

In case of `Content-Type: application/x-www-form-urlencoded`, the server responds with this error: `415 UNSUPPORTED MEDIA TYPE`.
`{"developer_message":"Unsupported media type \"application/x-www-form-urlencoded\" in request."}`