### PR TITLE
Show proper error messages in Find Courses

### DIFF
--- a/OpenEdXMobile/res/layout/activity_find_course_info.xml
+++ b/OpenEdXMobile/res/layout/activity_find_course_info.xml
@@ -4,13 +4,13 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <include layout="@layout/toolbar"/>
+    <include layout="@layout/toolbar" />
 
     <RelativeLayout
+        android:id="@+id/content_error_root"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:background="@color/grey_act_background"
         android:orientation="vertical">
 
         <org.edx.mobile.view.custom.EdxWebView
@@ -21,10 +21,10 @@
 
         <include layout="@layout/loading_indicator" />
 
-        <TextView
-            android:id="@+id/offline_mode_message"
-            style="@style/offline_mode_message" />
+        <include layout="@layout/content_error" />
     </RelativeLayout>
 
-    <include layout="@layout/auth_panel" android:id="@+id/auth_panel" />
+    <include
+        android:id="@+id/auth_panel"
+        layout="@layout/auth_panel" />
 </LinearLayout>

--- a/OpenEdXMobile/res/layout/activity_find_courses.xml
+++ b/OpenEdXMobile/res/layout/activity_find_courses.xml
@@ -2,11 +2,11 @@
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/grey_act_background"
     android:fitsSystemWindows="true"
     android:splitMotionEvents="false">
 
     <LinearLayout
+        android:id="@+id/content_error_root"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
@@ -16,24 +16,24 @@
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1"
-            android:background="@color/grey_act_background">
+            android:layout_weight="1">
 
             <org.edx.mobile.view.custom.EdxWebView
                 android:id="@+id/webview"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:background="@color/grey_act_background" />
+                android:background="@color/grey_act_background"
+                android:visibility="gone" />
 
             <include layout="@layout/loading_indicator" />
 
-            <TextView
-                android:id="@+id/offline_mode_message"
-                style="@style/offline_mode_message" />
+            <include layout="@layout/content_error" />
 
         </RelativeLayout>
 
-        <include layout="@layout/auth_panel" android:id="@+id/auth_panel" />
+        <include
+            android:id="@+id/auth_panel"
+            layout="@layout/auth_panel" />
     </LinearLayout>
 
     <include layout="@layout/navigation_drawer_container" />

--- a/OpenEdXMobile/res/values-es/strings.xml
+++ b/OpenEdXMobile/res/values-es/strings.xml
@@ -406,9 +406,6 @@ Si no lo recibe en algunos minutos, asegúrese de revisar su carpeta de spam.</s
   <string name="facebook_text">Facebook</string>
   <!--Google login method-->
   <string name="google_text">Google</string>
-  <!--Message shown when attempting to find courses with no Internet connection-->
-  <string name="find_courses_offline_text">Usted está en modo sin conexión.
-Para encontrar cursos, debe estar conectado a Internet.</string>
   <!--Prompt allowing user to choose email program-->
   <string name="email_chooser_header">Enviar email usando...</string>
   <!--Error shown when user attempts to send email, but has no email app-->

--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -463,8 +463,6 @@
     <string name="facebook_text">Facebook</string>
     <!-- Google login method -->
     <string name="google_text">Google</string>
-    <!-- Message shown when attempting to find courses with no Internet connection -->
-    <string name="find_courses_offline_text">You are in offline mode.\nTo find courses, connect to the Internet.</string>
     <!-- Prompt allowing user to choose email program -->
     <string name="email_chooser_header">Send email using...</string>
     <!-- Error shown when user attempts to send email, but has no email app -->

--- a/OpenEdXMobile/res/values/text_styles.xml
+++ b/OpenEdXMobile/res/values/text_styles.xml
@@ -238,18 +238,6 @@
         <item name="android:textColor">@color/white</item>
     </style>
 
-    <style name="offline_mode_message" parent="@style/bold_text">
-        <item name="android:textSize">20sp</item>
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:gravity">center</item>
-        <item name="android:text">@string/find_courses_offline_text</item>
-        <item name="android:padding">10dp</item>
-        <item name="android:layout_centerInParent">true</item>
-        <item name="android:textColor">@color/edx_brand_gray_base</item>
-        <item name="android:visibility">gone</item>
-    </style>
-
     <!-- TextArea theme -->
     <style name="text_area_style" parent="@android:style/Widget.DeviceDefault.EditText">
         <item name="android:layout_width">match_parent</item>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/interfaces/WebViewStatusListener.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/interfaces/WebViewStatusListener.java
@@ -1,0 +1,21 @@
+package org.edx.mobile.interfaces;
+
+/**
+ * Interface to provide callbacks for a {@link android.webkit.WebView}.
+ */
+public interface WebViewStatusListener {
+    /**
+     * Clear contents/HTML of the WebView.
+     */
+    void clearWebView();
+
+    /**
+     * Show progress wheel while loading the web page.
+     */
+    void showLoadingProgress();
+
+    /**
+     * Hide progress wheel after the web page completes loading.
+     */
+    void hideLoadingProgress();
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/AppConstants.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/AppConstants.java
@@ -10,8 +10,6 @@ public enum AppConstants {
 
     public static final String VIDEOLIST_BACK_PRESSED = "offline_video_back_pressed";
 
-    public final static String EMPTY_HTML = "<html><body></body></html>";
-
     public static final double MILLISECONDS_PER_SECOND = 1000.00;
     // A rating value to mark user has given rating and didn't give review/feedback so don't ask for rating again till next version
     public static final float APP_ZERO_RATING = 0.0f;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/WebViewUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/WebViewUtil.java
@@ -1,15 +1,32 @@
 package org.edx.mobile.util;
 
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.webkit.WebView;
 
+import org.edx.mobile.http.HttpStatus;
+import org.edx.mobile.http.HttpStatusException;
+import org.edx.mobile.http.notifications.FullScreenErrorNotification;
+import org.edx.mobile.http.provider.OkHttpClientProvider;
+import org.edx.mobile.interfaces.WebViewStatusListener;
 import org.edx.mobile.logger.Logger;
 
 import java.io.IOException;
+
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.ResponseBody;
+import retrofit2.Response;
 
 /**
  * Common webview helper for any view that needs to use a webview.
  */
 public class WebViewUtil {
+    public final static String EMPTY_HTML = "<html><body></body></html>";
 
     /**
      * Creates the intial StringBuffer used when an view uses a webview. Uses a common
@@ -30,5 +47,88 @@ public class WebViewUtil {
         }
         buff.append("</head>");
         return buff;
+    }
+
+    /**
+     * Clears content of the WebView and loads {@link #EMPTY_HTML} in it.
+     */
+    public static void clearWebviewHtml(@Nullable WebView webView) {
+        if (webView != null) {
+            webView.loadData(EMPTY_HTML, "text/html", "UTF-8");
+        }
+    }
+
+    /**
+     * Simply loads a url within a WebView for Marshmallow & above and differently in case of
+     * Lollipop & below.<br/>
+     * WebViews prior to Marshmallow (API Level 23) don't provide a way to get the HTTP status
+     * codes if the url being loaded fails.<br/>
+     * This utility function solves this by making a server call using the url provided to query if
+     * an error is being return and show error or move on to load the url in WebView, if the server
+     * is responding correctly.
+     * <p>
+     * Inspiration for this solution has been taken from this link:
+     * https://stackoverflow.com/questions/11889020/get-http-status-code-in-android-webview/21609608#21609608
+     *
+     * @param context              Current context.
+     * @param webView              The WebView to load the URL into.
+     * @param url                  The URL to load.
+     * @param viewInterface        WebView's callbacks interface.
+     * @param errorNotification    The notification setup for showing/hiding errors.
+     * @param okHttpClientProvider The utility to make server calls.
+     */
+    public static void loadUrlBasedOnOsVersion(@NonNull final Context context,
+                                               @NonNull final WebView webView,
+                                               @NonNull final String url,
+                                               @NonNull final WebViewStatusListener viewInterface,
+                                               @NonNull final FullScreenErrorNotification errorNotification,
+                                               @NonNull OkHttpClientProvider okHttpClientProvider) {
+        if (!NetworkUtil.isConnected(context)) {
+            errorNotification.showError(context, new IOException());
+        } else {
+            errorNotification.hideError();
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                viewInterface.showLoadingProgress();
+                okHttpClientProvider.get().newCall(new Request.Builder()
+                        .url(url)
+                        .get()
+                        .build())
+                        .enqueue(new Callback() {
+                            @Override
+                            public void onFailure(Call call, final IOException e) {
+                                webView.post((new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        errorNotification.showError(context, e);
+                                        viewInterface.hideLoadingProgress();
+                                        viewInterface.clearWebView();
+                                    }
+                                }));
+                            }
+
+                            @Override
+                            public void onResponse(Call call, final okhttp3.Response response) throws IOException {
+                                webView.post(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        final int responseCode = response.code();
+                                        if (responseCode >= HttpStatus.BAD_REQUEST) {
+                                            errorNotification.showError(context,
+                                                    new HttpStatusException(Response.error(responseCode,
+                                                            ResponseBody.create(MediaType.parse("text/plain"),
+                                                                    response.message()))));
+                                            viewInterface.hideLoadingProgress();
+                                            viewInterface.clearWebView();
+                                        } else {
+                                            webView.loadUrl(url);
+                                        }
+                                    }
+                                });
+                            }
+                        });
+            } else {
+                webView.loadUrl(url);
+            }
+        }
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/images/ErrorUtils.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/images/ErrorUtils.java
@@ -63,6 +63,7 @@ public enum ErrorUtils {
         } else if (error instanceof HttpStatusException) {
             switch (((HttpStatusException) error).getStatusCode()) {
                 case HttpStatus.SERVICE_UNAVAILABLE:
+                case HttpStatus.INTERNAL_SERVER_ERROR:
                     errorResId = R.string.network_service_unavailable;
                     break;
                 case HttpStatus.BAD_REQUEST:

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseInfoActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseInfoActivity.java
@@ -1,16 +1,15 @@
 package org.edx.mobile.view;
 
 import android.os.Bundle;
-import android.webkit.WebView;
 
 import org.edx.mobile.R;
-import org.edx.mobile.base.FindCoursesBaseActivity;
+import org.edx.mobile.base.BaseWebViewFindCoursesActivity;
 import org.edx.mobile.module.analytics.Analytics;
 
 import roboguice.inject.ContentView;
 
 @ContentView(R.layout.activity_find_course_info)
-public class CourseInfoActivity extends FindCoursesBaseActivity {
+public class CourseInfoActivity extends BaseWebViewFindCoursesActivity {
 
     public static final String EXTRA_PATH_ID = "path_id";
 
@@ -24,12 +23,11 @@ public class CourseInfoActivity extends FindCoursesBaseActivity {
     protected void onStart() {
         super.onStart();
 
-        String pathId = getIntent().getStringExtra(EXTRA_PATH_ID);
-        String url = environment.getConfig().getCourseDiscoveryConfig()
+        final String pathId = getIntent().getStringExtra(EXTRA_PATH_ID);
+        final String url = environment.getConfig().getCourseDiscoveryConfig()
                 .getCourseInfoUrlTemplate()
                 .replace("{" + EXTRA_PATH_ID + "}", pathId);
-        WebView webview = (WebView) findViewById(R.id.webview);
-        webview.loadUrl(url);
+        loadUrl(url);
     }
 
     @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/WebViewFindCoursesActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/WebViewFindCoursesActivity.java
@@ -7,10 +7,9 @@ import android.support.v7.widget.SearchView;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.webkit.WebView;
 
 import org.edx.mobile.R;
-import org.edx.mobile.base.FindCoursesBaseActivity;
+import org.edx.mobile.base.BaseWebViewFindCoursesActivity;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.module.analytics.Analytics;
 import org.edx.mobile.util.Config;
@@ -21,9 +20,7 @@ import java.net.URLEncoder;
 import roboguice.inject.ContentView;
 
 @ContentView(R.layout.activity_find_courses)
-public class WebViewFindCoursesActivity extends FindCoursesBaseActivity {
-
-    private WebView webView;
+public class WebViewFindCoursesActivity extends BaseWebViewFindCoursesActivity {
     private SearchView searchView;
 
     @Override
@@ -35,10 +32,8 @@ public class WebViewFindCoursesActivity extends FindCoursesBaseActivity {
             blockDrawerFromOpening();
         }
         environment.getAnalyticsRegistry().trackScreenView(Analytics.Screens.FIND_COURSES);
-        webView = (WebView) findViewById(R.id.webview);
-        webView.loadUrl(getInitialUrl());
+        loadUrl(getInitialUrl());
     }
-
 
     @Override
     public void onResume() {
@@ -75,7 +70,7 @@ public class WebViewFindCoursesActivity extends FindCoursesBaseActivity {
                 String baseUrl = environment.getConfig().getCourseDiscoveryConfig().getCourseSearchUrl();
                 String searchUrl = buildQuery(baseUrl, query, logger);
                 searchView.onActionViewCollapsed();
-                webView.loadUrl(searchUrl);
+                loadUrl(searchUrl);
                 return true;
             }
 
@@ -112,14 +107,6 @@ public class WebViewFindCoursesActivity extends FindCoursesBaseActivity {
             return true;
         } else {
             return super.onOptionsItemSelected(item);
-        }
-    }
-
-    @Override
-    protected void onOnline() {
-        super.onOnline();
-        if (!isWebViewLoaded()) {
-            webView.reload();
         }
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/AuthenticatedWebView.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/AuthenticatedWebView.java
@@ -35,12 +35,13 @@ import org.edx.mobile.logger.Logger;
 import org.edx.mobile.module.prefs.LoginPrefs;
 import org.edx.mobile.services.EdxCookieManager;
 import org.edx.mobile.util.NetworkUtil;
+import org.edx.mobile.util.WebViewUtil;
 
 import de.greenrobot.event.EventBus;
 import roboguice.RoboGuice;
 import roboguice.inject.InjectView;
 
-import static org.edx.mobile.util.AppConstants.EMPTY_HTML;
+import static org.edx.mobile.util.WebViewUtil.EMPTY_HTML;
 
 /**
  * A custom webview which authenticates the user before loading a page,
@@ -233,9 +234,7 @@ public class AuthenticatedWebView extends FrameLayout {
 
     public void tryToClearWebView() {
         pageIsLoaded = false;
-        if (webView != null) {
-            webView.loadData(EMPTY_HTML, "text/html", "UTF-8");
-        }
+        WebViewUtil.clearWebviewHtml(webView);
     }
 
     private void showLoadingProgress() {


### PR DESCRIPTION
### Description

[LEARNER-2578](https://openedx.atlassian.net/browse/LEARNER-2578)

- Modern design for showing error text with image on top.
- Different logic for showing error on pre-Marshmallow devices by first
hitting the url before loading it in WebView.
- Errors are now shown based on the scenario when and where the issue
occurs.
- Standardize loading of find courses links on all platforms whether it
be all courses, course search or a course's detail.
- Refactored WebView URL loading into WebViewUtil class.

### Testing

To test various scenarios in this PR this website (https://httpstat.us/) can be used to mimic failing URLs. For example:

```java
    @NonNull 
    protected String getInitialUrl() { 
        return "https://www.edx.org/asdfasdfasdf"; 
        //return "https://httpstat.us/404"; 
        //return "https://httpstat.us/500";
        //return environment.getConfig().getCourseDiscoveryConfig().getCourseSearchUrl();
    }
```

Also I found this code link to be quite useful in judging proper errors and their behaviour for Lollipop and below devices:
https://chromium.googlesource.com/chromium/chromium/+/master/content/browser/android/content_view_client.cc

### Note

The inspiration of using an extra server call before loading webview for pre Marshmallow devices is taken from here:
https://stackoverflow.com/a/21609608/1402616