### PR TITLE
Remove duration from downloading screen if have zero value

### DIFF
--- a/OpenEdXMobile/res/layout/row_download_list.xml
+++ b/OpenEdXMobile/res/layout/row_download_list.xml
@@ -1,112 +1,98 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/downloads_row_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@android:color/white"
-    android:padding="10dp">
+    android:orientation="horizontal"
+    android:padding="@dimen/edx_margin">
 
-    <TextView
-        android:id="@+id/downloads_name"
-        style="@style/semibold_text"
-        android:layout_width="match_parent"
+    <LinearLayout
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="18dp"
-        android:layout_marginStart="18dp"
-        android:layout_marginRight="45dp"
-        android:layout_marginEnd="45dp"
-        android:layout_marginTop="5dp"
-        android:ellipsize="end"
-        android:fadingEdge="horizontal"
-        android:marqueeRepeatLimit="marquee_forever"
-        android:maxWidth="210dp"
-        android:scrollHorizontally="true"
-        android:singleLine="true"
-        tools:text="Engaging in Interaction"
-        android:textColor="@color/grey_text_mycourse"
-        android:textSize="14sp"
-        tools:targetApi="17" />
+        android:layout_marginEnd="@dimen/widget_margin"
+        android:layout_marginRight="@dimen/widget_margin"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        tools:targetApi="17">
 
-    <LinearLayout android:id="@+id/close_btn_layout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_above="@+id/progressBar"
-        android:layout_alignParentRight="true"
-        android:layout_alignParentEnd="true"
-        android:layout_centerHorizontal="true"
-        android:layout_marginRight="5dp"
-        android:layout_marginLeft="5dp"
-        android:padding="5dp"
-        tools:targetApi="17" >
+        <TextView
+            android:id="@+id/downloads_name"
+            style="@style/semibold_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:textColor="@color/grey_text_mycourse"
+            android:textSize="@dimen/edx_small"
+            tools:text="@string/download_pending" />
 
-        <ImageView
-            android:id="@+id/close_btn"
-            android:contentDescription="@string/cancel_download"
-            android:layout_width="15dp"
-            android:layout_height="15dp"
-            android:src="@drawable/ic_close" />
+        <LinearLayout
+            android:id="@+id/download_content_layout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/download_time"
+                style="@style/regular_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/edx_margin"
+                android:layout_marginRight="@dimen/edx_margin"
+                android:singleLine="true"
+                android:textColor="@color/grey_video_size_text"
+                android:textSize="@dimen/edx_x_small"
+                tools:targetApi="17"
+                tools:text="53:59:21" />
+
+            <TextView
+                android:id="@+id/download_percentage"
+                style="@style/regular_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:singleLine="true"
+                android:textColor="@color/grey_video_size_text"
+                android:textSize="@dimen/edx_x_small"
+                tools:targetApi="17"
+                tools:text="45.20/200MB" />
+
+        </LinearLayout>
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            style="@style/CustomProgressBar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/widget_margin_half"
+            android:layout_marginTop="@dimen/widget_margin_half"
+            android:max="100"
+            android:progress="40"
+            tools:targetApi="17" />
+
+        <TextView
+            android:id="@+id/txtDownloadFailed"
+            style="@style/semibold_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/download_failed_text"
+            android:textColor="@color/edx_error_text"
+            android:textSize="@dimen/edx_x_small"
+            tools:targetApi="17" />
+
     </LinearLayout>
 
-    <TextView
-        android:id="@+id/download_time"
-        style="@style/regular_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/downloads_name"
-        android:layout_marginLeft="18dp"
-        android:layout_marginStart="18dp"
-        android:lines="1"
-        android:singleLine="true"
-        tools:text="53:59:21"
-        android:textColor="@color/grey_video_size_text"
-        android:textSize="12sp"
+    <ImageView
+        android:id="@+id/close_btn"
+        android:layout_width="@dimen/fa_xxxx_large"
+        android:layout_height="@dimen/fa_xxxx_large"
+        android:background="@drawable/selectable_box_overlay"
+        android:layout_marginLeft="@dimen/widget_margin_half"
+        android:layout_marginStart="@dimen/widget_margin_half"
+        android:contentDescription="@string/cancel_download"
+        android:padding="@dimen/widget_margin"
+        android:layout_gravity="center"
+        android:src="@drawable/ic_close"
         tools:targetApi="17" />
 
-    <TextView
-        android:id="@+id/download_percentage"
-        style="@style/regular_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/downloads_name"
-        android:layout_marginLeft="15dp"
-        android:layout_marginStart="15dp"
-        android:layout_toRightOf="@+id/download_time"
-        android:layout_toEndOf="@+id/download_time"
-        android:lines="1"
-        android:singleLine="true"
-        tools:text="45.20/200MB"
-        android:textColor="@color/grey_video_size_text"
-        android:textSize="12sp"
-        tools:targetApi="17" />
-
-    <ProgressBar
-        android:id="@+id/progressBar"
-        style="@style/CustomProgressBar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/download_time"
-        android:layout_marginBottom="4dp"
-        android:layout_marginLeft="18dp"
-        android:layout_marginStart="18dp"
-        android:layout_marginRight="45dp"
-        android:layout_marginEnd="45dp"
-        android:layout_marginTop="4dp"
-        android:max="100"
-        android:progress="40"
-        tools:targetApi="17" />
-
-    <TextView
-        android:id="@+id/txtDownloadFailed"
-        style="@style/semibold_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/progressBar"
-        android:layout_marginBottom="5dp"
-        android:layout_marginLeft="18dp"
-        android:layout_marginStart="18dp"
-        android:text="@string/download_failed_text"
-        android:textColor="@color/edx_error_text"
-        android:textSize="12sp"
-        tools:targetApi="17" />
-
-</RelativeLayout>
+</LinearLayout>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/SummaryModel.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/SummaryModel.java
@@ -118,12 +118,4 @@ public class SummaryModel implements Serializable {
     public int getDuration() {
         return (int)duration;
     }
-    
-    /**
-     * Returns duration in the format hh:mm:ss
-     * @return
-     */
-    public String getDurationString() {
-        return JavaUtil.getDurationString((long)duration);
-    }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/db/DownloadEntry.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/db/DownloadEntry.java
@@ -1,7 +1,6 @@
 package org.edx.mobile.model.db;
 
 import android.content.Context;
-import android.database.Cursor;
 import android.text.TextUtils;
 
 import com.google.inject.Inject;
@@ -9,12 +8,10 @@ import com.google.inject.Inject;
 import org.edx.mobile.R;
 import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.interfaces.SectionItemInterface;
-import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.VideoModel;
 import org.edx.mobile.model.api.EncodingsModel;
 import org.edx.mobile.model.api.TranscriptModel;
 import org.edx.mobile.model.download.NativeDownloadModel;
-import org.edx.mobile.module.db.DbStructure;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.util.JavaUtil;
 
@@ -54,8 +51,10 @@ public class DownloadEntry implements SectionItemInterface, VideoModel {
     IEdxEnvironment environment;
 
     /**
-     * Returns duration in the format hh:mm:ss
-     * @return
+     * Returns duration in the readable format i.e. hh:mm:ss. Returns null if duration is zero or
+     * negative.
+     *
+     * @return Formatted duration.
      */
     public String getDurationReadable() {
         return JavaUtil.getDurationString(duration);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/JavaUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/JavaUtil.java
@@ -1,6 +1,7 @@
 package org.edx.mobile.util;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -43,12 +44,19 @@ public class JavaUtil {
         return String.format("%d MB", mb);
     }
 
+    /**
+     * Converts and returns the provided duration into a readable format i.e. hh:mm:ss. Returns null
+     * if duration is zero or negative.
+     *
+     * @param duration Video duration in seconds.
+     * @return Formatted duration.
+     */
+    @Nullable
     public static String getDurationString(long duration) {
-        if (duration == 0) {
-            return "00:00";
+        if (duration <= 0) {
+            return null;
         }
-
-        long d = (long) duration;
+        long d = duration;
         int hours = (int) (d / 3600f);
         d = d % 3600;
         int mins = (int) (d / 60f);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/DownloadEntryAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/DownloadEntryAdapter.java
@@ -4,10 +4,11 @@ import android.content.Context;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.AdapterView;
-import android.widget.LinearLayout;
+import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -25,7 +26,12 @@ public abstract class DownloadEntryAdapter extends BaseListAdapter<DownloadEntry
     public void render(BaseViewHolder tag, final Item item) {
         final ViewHolder holder = (ViewHolder) tag;
         holder.title.setText(item.getTitle());
-        holder.duration.setText(item.getDuration());
+        if (TextUtils.isEmpty(item.getDuration())) {
+            holder.duration.setVisibility(View.GONE);
+        } else {
+            holder.duration.setVisibility(View.VISIBLE);
+            holder.duration.setText(item.getDuration());
+        }
         holder.progress.setProgress(item.getPercent());
         @DrawableRes
         final int progressDrawable;
@@ -75,7 +81,7 @@ public abstract class DownloadEntryAdapter extends BaseListAdapter<DownloadEntry
             holder.error.setVisibility(View.VISIBLE);
         }
 
-        holder.cross_image_layout.setOnClickListener(new OnClickListener() {
+        holder.cross_button.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
                 onDeleteClicked(item);
@@ -102,7 +108,7 @@ public abstract class DownloadEntryAdapter extends BaseListAdapter<DownloadEntry
         final TextView title;
         final TextView duration;
         final TextView percent;
-        final LinearLayout cross_image_layout;
+        final ImageView cross_button;
         final TextView error;
         final ProgressBar progress;
 
@@ -116,8 +122,8 @@ public abstract class DownloadEntryAdapter extends BaseListAdapter<DownloadEntry
                     .findViewById(R.id.txtDownloadFailed);
             progress = (ProgressBar) view
                     .findViewById(R.id.progressBar);
-            cross_image_layout = (LinearLayout) view
-                    .findViewById(R.id.close_btn_layout);
+            cross_button = (ImageView) view
+                    .findViewById(R.id.close_btn);
         }
     }
 


### PR DESCRIPTION
### Description

[LEARNER-2767](https://openedx.atlassian.net/browse/LEARNER-2767)

- Remove duration from downloading screen if have zero value
- Rewrite xml of row_download_list for code optimization
- Add ripple on cancel download button

Please refer to Jira story for further details.

### Screen shots
- Don't show duration if of 0 length.

<img src="https://user-images.githubusercontent.com/25842457/31504924-1366bc26-af8d-11e7-87c8-b5d9fd9e7556.png" width="200">

- Added pressed state of cancel button.
<img src="https://user-images.githubusercontent.com/25842457/31500084-f67c9da4-af7f-11e7-865c-a16cd629313f.png" width="200">


