### PR TITLE
Fixing bug related to Firebase event bundle value

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/FirebaseEvent.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/FirebaseEvent.java
@@ -227,7 +227,7 @@ public class FirebaseEvent {
             final String key = entry.getKey();
             if (isSkippableKey(key)) continue;
             bundle.putString(applyRestrictions(key, PARAM_NAME_MAX_CHARS),
-                    applyRestrictions(entry.getValue(), PARAM_VALUE_MAX_CHARS));
+                    truncateString(entry.getValue(), PARAM_VALUE_MAX_CHARS));
         }
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/FirebaseEvent.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/FirebaseEvent.java
@@ -227,7 +227,7 @@ public class FirebaseEvent {
             final String key = entry.getKey();
             if (isSkippableKey(key)) continue;
             bundle.putString(applyRestrictions(key, PARAM_NAME_MAX_CHARS),
-                    truncateString(entry.getValue(), PARAM_VALUE_MAX_CHARS));
+                    truncateString(entry.getValue(), PARAM_VALUE_MAX_CHARS)); // 100 char limit
         }
     }
 


### PR DESCRIPTION
### Description

Fixing bug related to Firebase event bundle value. Firebase imposed no other restriction on values except string length of 100 chars; [see](https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Param).


