### PR TITLE
Remove autofocus from email field on Registration screen

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/registration/view/RegistrationOptionSpinner.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/registration/view/RegistrationOptionSpinner.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.AppCompatSpinner;
 import android.util.AttributeSet;
+import android.view.accessibility.AccessibilityEvent;
 import android.widget.ArrayAdapter;
 
 import org.edx.mobile.R;
@@ -72,6 +73,20 @@ public class RegistrationOptionSpinner extends AppCompatSpinner {
         setAdapter(adapter);
         if (defaultOption != null) {
             select(defaultOption.toString());
+        }
+    }
+
+    @Override
+    public void onInitializeAccessibilityEvent(AccessibilityEvent event) {
+        /*
+        Whenever there's an AppCompatSpinner on screen, its read out by TalkBack even when its not
+        in focus. This workaround ensures that AppCompatSpinner's content is read only when its
+        in focus.
+        There's an open StackOverflow issue on this as well:
+        https://stackoverflow.com/questions/44708495/how-to-prevent-spinner-announcement-when-initialized
+         */
+        if (event.getEventType() == AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED) {
+            super.onInitializeAccessibilityEvent(event);
         }
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -252,17 +252,6 @@ public class RegisterActivity extends BaseFragmentActivity
                 agreementLayout.addView(agreementView.getView());
             }
 
-            // request rendering of the layouts
-            requiredFieldsLayout.requestLayout();
-            optionalFieldsLayout.requestLayout();
-            agreementLayout.requestLayout();
-
-            // Set focus to first form field
-            final IRegistrationFieldView fieldView = mFieldViews.get(0);
-            if (fieldView != null) {
-                fieldView.getView().requestFocus();
-            }
-
             // enable all the views
             tryToSetUIInteraction(true);
         } catch (Exception ex) {


### PR DESCRIPTION
### Description

[LEARNER-2913](https://openedx.atlassian.net/browse/LEARNER-2913)

- Remove autofocus from email field on Registration screen
- Also includes a workaround to fix auto announcement of Spinner's
accessibility text