### PR TITLE
Customize a11y behavior for registration screen fields.

### DIFF
--- a/OpenEdXMobile/res/values/labels.xml
+++ b/OpenEdXMobile/res/values/labels.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Divider between current time and total time. For example  "2:33/5:10" -->
 	<string name="lbl_slash">/</string>
     <!-- Button allowing user to open a web page corresponding to the current screen in a web browser -->
@@ -40,4 +40,6 @@
     <string name="label_done">Done</string>
     <!-- Undo button label -->
     <string name="label_undo">Undo</string>
+    <!-- Label denoting an error -->
+    <string name="label_error" tools:ignore="MissingTranslation">Error</string>
 </resources>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/registration/view/IRegistrationFieldView.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/registration/view/IRegistrationFieldView.java
@@ -25,6 +25,13 @@ public interface IRegistrationFieldView {
     void setActionListener(IActionListener actionListener);
 
     /**
+     * Get the specific child view which should be focused when the error child view is visible.
+     *
+     * @return Child view which needs to be focused in case of error.
+     */
+    View getOnErrorFocusView();
+
+    /**
      * used to programmatically set the value
      * return false if not implemented yet, or can not set the value
      *

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/registration/view/RegistrationAgreementView.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/registration/view/RegistrationAgreementView.java
@@ -120,4 +120,9 @@ class RegistrationAgreementView implements IRegistrationFieldView {
     public void setActionListener(IActionListener actionListener) {
         this.actionListener = actionListener;
     }
+
+    @Override
+    public View getOnErrorFocusView() {
+        return mInputView;
+    }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/registration/view/RegistrationCheckBoxView.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/registration/view/RegistrationCheckBoxView.java
@@ -122,4 +122,9 @@ class RegistrationCheckBoxView implements IRegistrationFieldView {
     public void setActionListener(IActionListener actionListener) {
         // no actions for this field
     }
+
+    @Override
+    public View getOnErrorFocusView() {
+        return mInputView;
+    }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/registration/view/RegistrationOptionSpinner.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/registration/view/RegistrationOptionSpinner.java
@@ -16,6 +16,7 @@ import java.util.List;
 public class RegistrationOptionSpinner extends AppCompatSpinner {
 
     private ArrayAdapter<RegistrationOption> adapter;
+    private RegistrationSelectView.OnSpinnerFocusedListener onSpinnerFocusedListener;
 
     public RegistrationOptionSpinner(Context context) {
         super(context);
@@ -45,11 +46,22 @@ public class RegistrationOptionSpinner extends AppCompatSpinner {
         }
     }
 
-    public @Nullable String getSelectedItemValue() {
+    @Nullable
+    public String getSelectedItemValue() {
         String value = null;
-        RegistrationOption selected = (RegistrationOption)getSelectedItem();
+        final RegistrationOption selected = (RegistrationOption) getSelectedItem();
         if (selected != null) {
             value = selected.getValue();
+        }
+        return value;
+    }
+
+    @NonNull
+    public String getSelectedItemName() {
+        String value = null;
+        final RegistrationOption selected = (RegistrationOption) getSelectedItem();
+        if (selected != null) {
+            value = selected.getName();
         }
         return value;
     }
@@ -76,6 +88,10 @@ public class RegistrationOptionSpinner extends AppCompatSpinner {
         }
     }
 
+    public void setOnSpinnerFocusedListener(@Nullable RegistrationSelectView.OnSpinnerFocusedListener onSpinnerFocusedListener) {
+        this.onSpinnerFocusedListener = onSpinnerFocusedListener;
+    }
+
     @Override
     public void onInitializeAccessibilityEvent(AccessibilityEvent event) {
         /*
@@ -85,8 +101,16 @@ public class RegistrationOptionSpinner extends AppCompatSpinner {
         There's an open StackOverflow issue on this as well:
         https://stackoverflow.com/questions/44708495/how-to-prevent-spinner-announcement-when-initialized
          */
-        if (event.getEventType() == AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED) {
+        if (event.getEventType() == AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED
+                || event.getEventType() == AccessibilityEvent.TYPE_VIEW_FOCUSED) {
             super.onInitializeAccessibilityEvent(event);
+        }
+        if (event.getEventType() == AccessibilityEvent.TYPE_VIEW_CLICKED ||
+                event.getEventType() == AccessibilityEvent.TYPE_VIEW_FOCUSED ||
+                event.getEventType() == AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED) {
+            if (onSpinnerFocusedListener != null) {
+                onSpinnerFocusedListener.onSpinnerFocused();
+            }
         }
     }
 }


### PR DESCRIPTION
### Description

[LEARNER-2916](https://openedx.atlassian.net/browse/LEARNER-2916)

- I have assigned customized content (by adding instruction views content and error content if exit) to contentDescription property of TextInputLayout at run time.
- I haven't used lableFor property in instruction views because once i assigns it TextInputLayout reads the instructions text on its focus which is fine, but in next step talkback focus goes to instructions view which make it twice to read. And if i make instruction view disable for a11y than talkback never read its content even when talkback focus goes to TextInputLayout.
- When user press create account button and some field is validated false, particular field was not getting focused after closing error dialog. This issue has also been fixed within this PR.