### PR TITLE
Add HLS support with an .m3u8 extension

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/CourseComponent.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/CourseComponent.java
@@ -7,6 +7,7 @@ import org.edx.mobile.base.MainApplication;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.Filter;
 import org.edx.mobile.model.api.IPathNode;
+import org.edx.mobile.util.VideoUtil;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -263,7 +264,7 @@ public class CourseComponent implements IBlock, IPathNode {
         int downloadableCount = 0;
         List<VideoBlockModel> videos = getVideos();
         for (VideoBlockModel video : videos) {
-            if (video.getData().encodedVideos.getPreferredVideoInfo() != null && !video.getData().onlyOnWeb) {
+            if (VideoUtil.isVideoDownloadable(video.getData())) {
                 downloadableCount++;
             }
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/EncodedVideos.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/EncodedVideos.java
@@ -5,9 +5,17 @@ import android.webkit.URLUtil;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.edx.mobile.base.MainApplication;
+import org.edx.mobile.util.AppConstants;
+import org.edx.mobile.util.Config;
+import org.edx.mobile.util.VideoUtil;
+
 import java.io.Serializable;
 
 public class EncodedVideos implements Serializable {
+    @SerializedName("fallback")
+    public VideoInfo fallback;
+
     @SerializedName("mobile_high")
     public VideoInfo mobileHigh;
 
@@ -19,11 +27,29 @@ public class EncodedVideos implements Serializable {
 
     @Nullable
     public VideoInfo getPreferredVideoInfo() {
-        if (mobileLow != null && URLUtil.isNetworkUrl(mobileLow.url))
+        if (isPreferredVideoInfo(mobileLow)) {
             return mobileLow;
-        if (mobileHigh != null && URLUtil.isNetworkUrl(mobileHigh.url))
+        }
+        if (isPreferredVideoInfo(mobileHigh)) {
             return mobileHigh;
+        }
+        if (new Config(MainApplication.instance()).isUsingVideoPipeline()) {
+            if (fallback != null && URLUtil.isNetworkUrl(fallback.url) &&
+                    VideoUtil.isSupportedVideoFormat(fallback.url, AppConstants.VIDEO_FORMAT_M3U8)) {
+                return fallback;
+            }
+        } else {
+            if (isPreferredVideoInfo(fallback)) {
+                return fallback;
+            }
+        }
         return null;
+    }
+
+    private boolean isPreferredVideoInfo(@Nullable VideoInfo videoInfo) {
+        return videoInfo != null &&
+                URLUtil.isNetworkUrl(videoInfo.url) &&
+                VideoUtil.isValidVideoUrl(videoInfo.url);
     }
 
     @Nullable
@@ -40,6 +66,8 @@ public class EncodedVideos implements Serializable {
 
         EncodedVideos that = (EncodedVideos) o;
 
+        if (fallback != null ? !fallback.equals(that.fallback) : that.fallback != null)
+            return false;
         if (mobileHigh != null ? !mobileHigh.equals(that.mobileHigh) : that.mobileHigh != null)
             return false;
         if (mobileLow != null ? !mobileLow.equals(that.mobileLow) : that.mobileLow != null)

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/AppConstants.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/AppConstants.java
@@ -18,6 +18,9 @@ public enum AppConstants {
     // Minimum minor version changes required to show whats new screens
     public static final int MINOR_VERSIONS_DIFF_REQUIRED_FOR_WHATS_NEW = 1;
 
+    public static final String VIDEO_FORMAT_M3U8 = ".m3u8";
+    public static final String VIDEO_FORMAT_MP4 = ".mp4";
+
     /**
      * This class defines the names of various directories which are used for
      * storing application data.

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
@@ -70,6 +70,7 @@ public class Config {
     private static final String FIREBASE_ENABLED = "FIREBASE_ENABLED";
     private static final String APP_REVIEWS_ENABLED = "APP_REVIEWS_ENABLED";
     private static final String VIDEO_TRANSCRIPT_ENABLED = "VIDEO_TRANSCRIPT_ENABLED";
+    private static final String USING_VIDEO_PIPELINE = "USING_VIDEO_PIPELINE";
     private static final String COURSE_DATES_ENABLED = "COURSE_DATES_ENABLED";
     private static final String WHATS_NEW_ENABLED = "WHATS_NEW_ENABLED";
     private static final String COURSE_VIDEOS_ENABLED = "COURSE_VIDEOS_ENABLED";
@@ -574,6 +575,10 @@ public class Config {
 
     public boolean isVideoTranscriptEnabled() {
         return getBoolean(VIDEO_TRANSCRIPT_ENABLED, false);
+    }
+
+    public boolean isUsingVideoPipeline() {
+        return getBoolean(USING_VIDEO_PIPELINE, true);
     }
 
     public boolean isCourseDatesEnabled() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/VideoUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/VideoUtil.java
@@ -1,0 +1,55 @@
+package org.edx.mobile.util;
+
+import android.support.annotation.NonNull;
+
+import org.edx.mobile.model.course.VideoData;
+import org.edx.mobile.model.course.VideoInfo;
+
+import static org.edx.mobile.util.AppConstants.VIDEO_FORMAT_M3U8;
+import static org.edx.mobile.util.AppConstants.VIDEO_FORMAT_MP4;
+
+public class VideoUtil {
+    public static final String[] SUPPORTED_VIDEO_FORMATS = {
+            VIDEO_FORMAT_MP4,
+            VIDEO_FORMAT_M3U8
+    };
+
+    /**
+     * Check the validity of video url.
+     *
+     * @param videoUrl Url which needs to be validated.
+     * @return <code>true</code> if video url is valid, <code>false</code> otherwise.
+     */
+    public static boolean isValidVideoUrl(@NonNull String videoUrl) {
+        return isSupportedVideoFormat(videoUrl, SUPPORTED_VIDEO_FORMATS);
+    }
+
+    /**
+     * Check if format of video url exists in specified list of video formats.
+     *
+     * @param videoUrl         Video url whose format needs to be checked.
+     * @param supportedFormats List of supported video formats.
+     * @return <code>true</code> if video url format exist in supported formats list, <code>false</code> otherwise.
+     */
+    public static boolean isSupportedVideoFormat(@NonNull String videoUrl, @NonNull String... supportedFormats) {
+        for (final String format : supportedFormats) {
+            if (videoUrl.endsWith(format)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Validate if video is downloadable.
+     *
+     * @param video Data of the video whose download validity needs to be checked.
+     * @return <code>true</code> if video is downloadable, <code>false</code> otherwise.
+     */
+    public static boolean isVideoDownloadable(@NonNull VideoData video) {
+        final VideoInfo preferredVideoInfo = video.encodedVideos.getPreferredVideoInfo();
+        return preferredVideoInfo != null &&
+                !isSupportedVideoFormat(preferredVideoInfo.url, VIDEO_FORMAT_M3U8) &&
+                !video.onlyOnWeb;
+    }
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java
@@ -36,6 +36,7 @@ import org.edx.mobile.util.DateUtil;
 import org.edx.mobile.util.MemoryUtil;
 import org.edx.mobile.util.ResourceUtil;
 import org.edx.mobile.util.TimeZoneUtils;
+import org.edx.mobile.util.VideoUtil;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -242,9 +243,10 @@ public class CourseOutlineAdapter extends BaseAdapter {
         viewHolder.rowTitle.setText(unit.getDisplayName());
 
         if (row.component instanceof VideoBlockModel) {
-            final DownloadEntry videoData = ((VideoBlockModel) row.component).getDownloadEntry(storage);
+            final VideoBlockModel videoBlockModel = (VideoBlockModel) row.component;
+            final DownloadEntry videoData = videoBlockModel.getDownloadEntry(storage);
             if (null != videoData) {
-                updateUIForVideo(viewHolder, videoData);
+                updateUIForVideo(viewHolder, videoData, videoBlockModel);
                 return;
             }
         }
@@ -285,7 +287,8 @@ public class CourseOutlineAdapter extends BaseAdapter {
         }, unit.getId());
     }
 
-    private void updateUIForVideo(@NonNull final ViewHolder viewHolder, @NonNull final DownloadEntry videoData) {
+    private void updateUIForVideo(@NonNull final ViewHolder viewHolder, @NonNull final DownloadEntry videoData,
+                                  @NonNull VideoBlockModel videoBlockModel) {
         viewHolder.rowType.setIcon(FontAwesomeIcons.fa_film);
         viewHolder.numOfVideoAndDownloadArea.setVisibility(View.VISIBLE);
         viewHolder.bulkDownload.setVisibility(View.VISIBLE);
@@ -324,7 +327,7 @@ public class CourseOutlineAdapter extends BaseAdapter {
                     }
                 });
 
-        if (videoData.isVideoForWebOnly()) {
+        if (!VideoUtil.isVideoDownloadable(videoBlockModel.getData())) {
             viewHolder.numOfVideoAndDownloadArea.setVisibility(View.GONE);
         } else {
             viewHolder.numOfVideoAndDownloadArea.setVisibility(View.VISIBLE);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/NewCourseOutlineAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/NewCourseOutlineAdapter.java
@@ -42,6 +42,7 @@ import org.edx.mobile.util.DateUtil;
 import org.edx.mobile.util.MemoryUtil;
 import org.edx.mobile.util.ResourceUtil;
 import org.edx.mobile.util.TimeZoneUtils;
+import org.edx.mobile.util.VideoUtil;
 import org.edx.mobile.util.images.TopAnchorFillWidthTransformation;
 
 import java.text.SimpleDateFormat;
@@ -293,9 +294,10 @@ public class NewCourseOutlineAdapter extends BaseAdapter {
         viewHolder.rowTitle.setText(unit.getDisplayName());
 
         if (row.component instanceof VideoBlockModel) {
-            final DownloadEntry videoData = ((VideoBlockModel) row.component).getDownloadEntry(storage);
+            final VideoBlockModel videoBlockModel = (VideoBlockModel) row.component;
+            final DownloadEntry videoData = videoBlockModel.getDownloadEntry(storage);
             if (null != videoData) {
-                updateUIForVideo(viewHolder, videoData);
+                updateUIForVideo(viewHolder, videoData, videoBlockModel);
                 return;
             }
         }
@@ -336,7 +338,8 @@ public class NewCourseOutlineAdapter extends BaseAdapter {
         }, unit.getId());
     }
 
-    private void updateUIForVideo(@NonNull final ViewHolder viewHolder, @NonNull final DownloadEntry videoData) {
+    private void updateUIForVideo(@NonNull final ViewHolder viewHolder, @NonNull final DownloadEntry videoData,
+                                  @NonNull VideoBlockModel videoBlockModel) {
         viewHolder.rowType.setIcon(FontAwesomeIcons.fa_film);
         viewHolder.numOfVideoAndDownloadArea.setVisibility(View.VISIBLE);
         viewHolder.bulkDownload.setVisibility(View.VISIBLE);
@@ -374,8 +377,7 @@ public class NewCourseOutlineAdapter extends BaseAdapter {
                         logger.error(ex);
                     }
                 });
-
-        if (videoData.isVideoForWebOnly()) {
+        if (!VideoUtil.isVideoDownloadable(videoBlockModel.getData())) {
             viewHolder.numOfVideoAndDownloadArea.setVisibility(View.GONE);
         } else {
             viewHolder.numOfVideoAndDownloadArea.setVisibility(View.VISIBLE);


### PR DESCRIPTION
### Description

[LEARNER-3077](https://openedx.atlassian.net/browse/LEARNER-3077)

- Added support of HLS videos to stream with .m3u8 extension.
- Introduce the supported video formats list and check if video url format lies in that. Supported video formats are ".m3u8" and ".mp4".
