### PR TITLE
Offline Mode setup for Tabs Dashboard

### DIFF
--- a/OpenEdXMobile/res/layout/authenticated_webview.xml
+++ b/OpenEdXMobile/res/layout/authenticated_webview.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/content_error_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white">
@@ -12,9 +13,6 @@
 
     <include layout="@layout/loading_indicator" />
 
-    <TextView
-        android:id="@+id/error_text"
-        style="@style/content_unavailable_error_text"
-        android:text="@string/reset_no_network_message" />
+    <include layout="@layout/content_error" />
 
 </FrameLayout>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/event/CourseDashboardRefreshEvent.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/event/CourseDashboardRefreshEvent.java
@@ -1,0 +1,8 @@
+package org.edx.mobile.event;
+
+/**
+ * The event to fire through {@link de.greenrobot.event.EventBus EventBus} whenever some screen state
+ * needs to refresh on {@link org.edx.mobile.view.CourseTabsDashboardActivity CourseTabsDashboard}.
+ */
+public class CourseDashboardRefreshEvent {
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/notifications/FullScreenErrorNotification.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/notifications/FullScreenErrorNotification.java
@@ -65,6 +65,28 @@ public class FullScreenErrorNotification extends ErrorNotification {
                           @Nullable final Icon icon,
                           @StringRes final int actionTextResId,
                           @Nullable final View.OnClickListener actionListener) {
+        showError(view.getContext().getString(errorResId), icon, actionTextResId, actionListener);
+    }
+
+    /**
+     * Show the error notification as an overlay message on top of the content area, according to
+     * the provided details.
+     * <p>
+     * The root view will be determined by walking up the view tree to see if there is any view with
+     * the ID of {@link R.id#content_error R.id.content_error}. If one is found, then that would be
+     * used as the root. If not, then if the content view's parent is already a FrameLayout, then
+     * that would be used; otherwise a new one will be created, inserted as the new parent, and used
+     * as the root.
+     *
+     * @param errorMsg        The error message.
+     * @param icon            The error icon.
+     * @param actionTextResId The resource ID of the action button text.
+     * @param actionListener  The callback to be invoked when the action button is clicked.
+     */
+    public void showError(@NonNull final String errorMsg,
+                          @Nullable final Icon icon,
+                          @StringRes final int actionTextResId,
+                          @Nullable final View.OnClickListener actionListener) {
         final ViewGroup root = findSuitableAncestorLayout();
         if (root == null) return;
 
@@ -80,7 +102,7 @@ public class FullScreenErrorNotification extends ErrorNotification {
         final Button actionButton = (Button) errorLayout.findViewById(R.id.content_error_action);
         final IconImageView iconView = (IconImageView) errorLayout.findViewById(R.id.content_error_icon);
 
-        messageView.setText(errorResId);
+        messageView.setText(errorMsg);
         if (icon == null) {
             iconView.setVisibility(GONE);
         } else {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/interfaces/RefreshListener.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/interfaces/RefreshListener.java
@@ -1,5 +1,8 @@
 package org.edx.mobile.interfaces;
 
+/**
+ * Provides callbacks for a screen to refresh its contents.
+ */
 public interface RefreshListener {
-    public void onRefresh();
+    void onRefresh();
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/interfaces/SnackbarStatusListener.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/interfaces/SnackbarStatusListener.java
@@ -1,0 +1,22 @@
+package org.edx.mobile.interfaces;
+
+/**
+ * Provides callbacks to control the visibility of {@link android.support.design.widget.Snackbar Snackbar}.
+ */
+public interface SnackbarStatusListener {
+    /**
+     * Hide {@link android.support.design.widget.Snackbar Snackbar} if its being displayed.
+     */
+    void hideSnackBar();
+
+    /**
+     * Set the visibility of {@link android.support.design.widget.Snackbar Snackbar} based on the
+     * visibility of {@link org.edx.mobile.http.notifications.FullScreenErrorNotification FullScreenErrorNotification}.
+     * <br/>
+     * Note: At one time only one type of error i.e. either SnackBar or Full Screen error should be
+     * visible on screen.
+     *
+     * @param fullScreenErrorVisibility Visibility of {@link org.edx.mobile.http.notifications.FullScreenErrorNotification FullScreenErrorNotification}.
+     */
+    void resetSnackbarVisibility(boolean fullScreenErrorVisibility);
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/AdditionalResourcesFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/AdditionalResourcesFragment.java
@@ -15,8 +15,10 @@ import com.joanzapata.iconify.widget.IconImageView;
 import org.edx.mobile.R;
 import org.edx.mobile.base.BaseFragment;
 import org.edx.mobile.core.IEdxEnvironment;
+import org.edx.mobile.event.NetworkConnectivityChangeEvent;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 
+import de.greenrobot.event.EventBus;
 import roboguice.inject.InjectExtra;
 
 public class AdditionalResourcesFragment extends BaseFragment {
@@ -29,6 +31,7 @@ public class AdditionalResourcesFragment extends BaseFragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
+        EventBus.getDefault().registerSticky(AdditionalResourcesFragment.this);
         // Inflate the layout for this fragment
         return inflater.inflate(R.layout.fragment_additional_resources, container, false);
     }
@@ -85,5 +88,27 @@ public class AdditionalResourcesFragment extends BaseFragment {
         IconImageView typeView;
         TextView titleView;
         TextView subtitleView;
+    }
+
+    @Override
+    public void setUserVisibleHint(boolean isVisibleToUser) {
+        super.setUserVisibleHint(isVisibleToUser);
+        CourseTabsUtils.setUserVisibleHint(getActivity(), isVisibleToUser, false);
+    }
+
+    @SuppressWarnings("unused")
+    public void onEvent(NetworkConnectivityChangeEvent event) {
+        CourseTabsUtils.onNetworkConnectivityChangeEvent(getActivity(), getUserVisibleHint(), false);
+    }
+
+    @Override
+    protected void onRevisit() {
+        CourseTabsUtils.onRevisit(getActivity());
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        EventBus.getDefault().unregister(this);
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/AuthenticatedWebViewFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/AuthenticatedWebViewFragment.java
@@ -24,13 +24,15 @@ public class AuthenticatedWebViewFragment extends BaseFragment {
     protected final Logger logger = new Logger(getClass().getName());
     public static final String ARG_URL = "ARG_URL";
     public static final String ARG_JAVASCRIPT = "ARG_JAVASCRIPT";
+    public static final String ARG_IS_MANUALLY_RELOADABLE = "ARG_IS_MANUALLY_RELOADABLE";
 
     @InjectView(R.id.auth_webview)
-    private AuthenticatedWebView authWebView;
+    protected AuthenticatedWebView authWebView;
 
-    public static Bundle makeArguments(@NonNull String url, @Nullable String javascript) {
+    public static Bundle makeArguments(@NonNull String url, @Nullable String javascript, boolean isManuallyReloadable) {
         final Bundle args = new Bundle();
         args.putString(ARG_URL, url);
+        args.putBoolean(ARG_IS_MANUALLY_RELOADABLE, isManuallyReloadable);
         if (!TextUtils.isEmpty(javascript)) {
             args.putString(ARG_JAVASCRIPT, javascript);
         }
@@ -43,7 +45,13 @@ public class AuthenticatedWebViewFragment extends BaseFragment {
 
     public static Fragment newInstance(@NonNull String url, @Nullable String javascript) {
         final Fragment fragment = new AuthenticatedWebViewFragment();
-        fragment.setArguments(makeArguments(url, javascript));
+        fragment.setArguments(makeArguments(url, javascript, false));
+        return fragment;
+    }
+
+    public static Fragment newInstance(@NonNull String url, @Nullable String javascript, boolean isManuallyReloadable) {
+        final Fragment fragment = new AuthenticatedWebViewFragment();
+        fragment.setArguments(makeArguments(url, javascript, isManuallyReloadable));
         return fragment;
     }
 
@@ -56,10 +64,12 @@ public class AuthenticatedWebViewFragment extends BaseFragment {
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        authWebView.initWebView(getActivity(), false);
         if (getArguments() != null) {
             final String url = getArguments().getString(ARG_URL);
             final String javascript = getArguments().getString(ARG_JAVASCRIPT);
+            final boolean isManuallyReloadable = getArguments().getBoolean(ARG_IS_MANUALLY_RELOADABLE);
+
+            authWebView.initWebView(getActivity(), false, isManuallyReloadable);
             authWebView.loadUrlWithJavascript(true, url, javascript);
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardActivity.java
@@ -6,13 +6,22 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 
+import org.edx.mobile.R;
 import org.edx.mobile.base.BaseSingleFragmentActivity;
+import org.edx.mobile.event.CourseDashboardRefreshEvent;
+import org.edx.mobile.http.notifications.SnackbarErrorNotification;
+import org.edx.mobile.interfaces.RefreshListener;
+import org.edx.mobile.interfaces.SnackbarStatusListener;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
+import org.edx.mobile.util.NetworkUtil;
+
+import de.greenrobot.event.EventBus;
 
 import static org.edx.mobile.view.Router.EXTRA_ANNOUNCEMENTS;
 import static org.edx.mobile.view.Router.EXTRA_COURSE_DATA;
 
-public class CourseTabsDashboardActivity extends BaseSingleFragmentActivity {
+public class CourseTabsDashboardActivity extends BaseSingleFragmentActivity
+        implements SnackbarStatusListener, RefreshListener {
     public static Intent newIntent(@NonNull Activity activity,
                                    @NonNull EnrolledCoursesResponse courseData,
                                    boolean announcements) {
@@ -23,14 +32,49 @@ public class CourseTabsDashboardActivity extends BaseSingleFragmentActivity {
         return intent;
     }
 
+    private SnackbarErrorNotification snackbarErrorNotification;
+    private boolean isFullScreenErrorVisible = true;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         blockDrawerFromOpening();
+        snackbarErrorNotification = new SnackbarErrorNotification(findViewById(R.id.coordinator_layout));
     }
 
     @Override
     public Fragment getFirstFragment() {
         return CourseTabsDashboardFragment.newInstance();
+    }
+
+    @Override
+    public void hideSnackBar() {
+        snackbarErrorNotification.hideError();
+    }
+
+    @Override
+    public void resetSnackbarVisibility(boolean fullScreenErrorVisibility) {
+        this.isFullScreenErrorVisible = fullScreenErrorVisibility;
+        final boolean isNetworkConnected = NetworkUtil.isConnected(this);
+        if (fullScreenErrorVisibility || isNetworkConnected) {
+            snackbarErrorNotification.hideError();
+        } else if (!isNetworkConnected) {
+            snackbarErrorNotification.showOfflineError(this);
+        }
+    }
+
+    @Override
+    public void onRestart() {
+        super.onRestart();
+        if (NetworkUtil.isConnected(this)) {
+            snackbarErrorNotification.hideError();
+        } else if (!isFullScreenErrorVisible) {
+            snackbarErrorNotification.showOfflineError(this);
+        }
+    }
+
+    @Override
+    public void onRefresh() {
+        EventBus.getDefault().post(new CourseDashboardRefreshEvent());
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsUtils.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsUtils.java
@@ -1,0 +1,38 @@
+package org.edx.mobile.view;
+
+
+import android.app.Activity;
+import android.support.annotation.Nullable;
+
+import org.edx.mobile.interfaces.SnackbarStatusListener;
+import org.edx.mobile.util.NetworkUtil;
+
+public class CourseTabsUtils {
+    public static void setUserVisibleHint(@Nullable Activity activity, boolean isVisibleToUser,
+                                          boolean isShowingFullScreenError) {
+        if (isVisibleToUser &&
+                activity != null &&
+                activity instanceof SnackbarStatusListener) {
+            ((SnackbarStatusListener) activity).resetSnackbarVisibility(isShowingFullScreenError);
+        }
+    }
+
+    public static void onRevisit(@Nullable Activity activity) {
+        if (activity != null &&
+                activity instanceof SnackbarStatusListener &&
+                NetworkUtil.isConnected(activity)) {
+            ((SnackbarStatusListener) activity).hideSnackBar();
+        }
+    }
+
+    public static void onNetworkConnectivityChangeEvent(@Nullable Activity activity,
+                                                        boolean isVisibleToUser,
+                                                        boolean isShowingFullScreenError) {
+        if (isVisibleToUser &&
+                activity != null &&
+                activity instanceof SnackbarStatusListener &&
+                !NetworkUtil.isConnected(activity)) {
+            ((SnackbarStatusListener) activity).resetSnackbarVisibility(isShowingFullScreenError);
+        }
+    }
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitWebViewFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitWebViewFragment.java
@@ -44,7 +44,7 @@ public class CourseUnitWebViewFragment extends CourseUnitFragment {
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
-        authWebView.initWebView(getActivity(), true);
+        authWebView.initWebView(getActivity(), true, false);
         authWebView.getWebViewClient().setPageStatusListener(new URLInterceptorWebViewClient.IPageStatusListener() {
             @Override
             public void onPageStarted() {


### PR DESCRIPTION
### Description

[LEARNER-3060](https://openedx.atlassian.net/browse/LEARNER-3060)

- Ensure no 2 error types appear on screen at a time
- SnackBar showing/hiding will be controlled by the activity now, since, its the activity's layout that contains the CoordinatorLayout in which the SnackBar will appear.
- Fragments inside ViewPager will tell the Activity about showing/hiding SnackBar based on the visibility of FullScreenError within them.
- Whenever Reload button will be pressed (whether its pressed on SnackBar or FullScreenError) it'll fire a RefreshEvent on EventBus, so that every fragment can update/reload itself.
- CourseDatesFragment auto loads itself upon connection when its not loaded.
- On AdditionalResourcesFragment we only need to show SnackBar in case of no connectivity.
- Hide Snackbar upon switching of Tabs (when the internet is available).