### PR TITLE
Fix wrong a11y focus issue existed on registration screen.

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -343,7 +343,7 @@ public class RegisterActivity extends BaseFragmentActivity
                                 if (!errorShown) {
                                     // this is the first input field with error,
                                     // so focus on it after showing the popup
-                                    showErrorPopup(fieldView.getView());
+                                    showErrorPopup(fieldView.getOnErrorFocusView());
                                     errorShown = true;
                                 }
                                 break;


### PR DESCRIPTION
### Description

[LEARNER-3656](https://openedx.atlassian.net/browse/LEARNER-3656)

Fix wrong a11y focus issue existed on registration screen.

Please refer to Jira story for reproduction steps and details of a fix done in this PR.