### PR TITLE
Discussions | Dont consider cancelling of a server call as error

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
@@ -384,7 +384,7 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
             @Override
             public void onFailure(@NonNull final Call<Page<DiscussionThread>> call,
                                   @NonNull final Throwable error) {
-                if (getView() == null) return;
+                if (getView() == null || call.isCanceled()) return;
                 // Don't display any error message if we're doing a silent
                 // refresh, as that would be confusing to the user.
                 if (!callback.isRefreshingSilently()) {
@@ -427,6 +427,7 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
     }
 
     private void setScreenStateUponResult() {
+        errorNotification.hideError();
         centerMessageBox.setVisibility(View.GONE);
         spinnersContainerLayout.setVisibility(View.VISIBLE);
         discussionPostsListView.setVisibility(View.VISIBLE);


### PR DESCRIPTION
### Description

[LEARNER-3657](https://openedx.atlassian.net/browse/LEARNER-3657)

- Upon canceling a server call, our error handling callback's onError function was getting called, which shouldn't be considered as error.
- Also hiding the error explicitly when data is loaded on screen.