### PR TITLE
UX improvement on discussion forum buttons

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/DiscussionReportViewHolder.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/DiscussionReportViewHolder.java
@@ -21,15 +21,21 @@ public class DiscussionReportViewHolder {
                 findViewById(R.id.discussion_responses_action_bar_report_icon_view);
         reportTextView = (TextView) itemView.
                 findViewById(R.id.discussion_responses_action_bar_report_text_view);
-
     }
 
+
     public void setReported(boolean isReported) {
+        reportLayout.setSelected(isReported);
         int reportStringResId = isReported ? R.string.discussion_responses_reported_label :
                 R.string.discussion_responses_report_label;
         reportTextView.setText(reportTextView.getResources().getString(reportStringResId));
 
         int iconColor = isReported ? R.color.edx_brand_primary_base : R.color.edx_brand_gray_base;
         reportIconImageView.setIconColorResource(iconColor);
+    }
+
+    public boolean toggleReported() {
+        setReported(!reportLayout.isSelected());
+        return reportLayout.isSelected();
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/view_holders/DiscussionSocialLayoutViewHolder.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/view_holders/DiscussionSocialLayoutViewHolder.java
@@ -41,26 +41,37 @@ public class DiscussionSocialLayoutViewHolder extends RecyclerView.ViewHolder {
     }
 
     public void setDiscussionThread(final DiscussionThread discussionThread) {
-        threadVoteTextView.setText(ResourceUtil.getFormattedStringForQuantity(
-                threadVoteTextView.getResources(), R.plurals.discussion_responses_action_bar_vote_text, discussionThread.getVoteCount()));
-        threadVoteIconImageView.setIconColorResource(discussionThread.isVoted() ?
-                R.color.edx_brand_primary_base : R.color.edx_brand_gray_base);
-
+        setVote(discussionThread.isVoted(), discussionThread.isVoted() ? discussionThread.getVoteCount() - 1 : discussionThread.getVoteCount());
+        setFollowing(discussionThread.isFollowing());
         threadFollowContainer.setVisibility(View.VISIBLE);
-
-        if (discussionThread.isFollowing()) {
-            threadFollowTextView.setText(R.string.forum_unfollow);
-            threadFollowIconImageView.setIconColorResource(R.color.edx_brand_primary_base);
-        } else {
-            threadFollowTextView.setText(R.string.forum_follow);
-            threadFollowIconImageView.setIconColorResource(R.color.edx_brand_gray_base);
-        }
     }
 
     public void setDiscussionResponse(final DiscussionComment discussionResponse) {
+        setVote(discussionResponse.isVoted(), discussionResponse.isVoted() ? discussionResponse.getVoteCount() - 1 : discussionResponse.getVoteCount());
+    }
+
+    public boolean toggleFollow() {
+        setFollowing(!threadFollowContainer.isSelected());
+        return threadFollowContainer.isSelected();
+    }
+
+    public boolean toggleVote(int otherUserVotes) {
+        setVote(!voteViewContainer.isSelected(), otherUserVotes);
+        return voteViewContainer.isSelected();
+    }
+
+    private void setFollowing(boolean follow) {
+        if (threadFollowContainer.isSelected() != follow) {
+            threadFollowContainer.setSelected(follow);
+            threadFollowTextView.setText(follow ? R.string.forum_unfollow : R.string.forum_follow);
+            threadFollowIconImageView.setIconColorResource(follow ? R.color.edx_brand_primary_base : R.color.edx_brand_gray_base);
+        }
+    }
+
+    private void setVote(boolean vote, int otherUserVotes) {
+        voteViewContainer.setSelected(vote);
         threadVoteTextView.setText(ResourceUtil.getFormattedStringForQuantity(
-                threadVoteTextView.getResources(), R.plurals.discussion_responses_action_bar_vote_text, discussionResponse.getVoteCount()));
-        threadVoteIconImageView.setIconColorResource(discussionResponse.isVoted() ?
-                R.color.edx_brand_primary_base : R.color.edx_brand_gray_base);
+                threadVoteTextView.getResources(), R.plurals.discussion_responses_action_bar_vote_text, vote ? otherUserVotes + 1 : otherUserVotes));
+        threadVoteIconImageView.setIconColorResource(vote ? R.color.edx_brand_primary_base : R.color.edx_brand_gray_base);
     }
 }


### PR DESCRIPTION
Before this commit the buttons (report, follow and vote) in discussion adapter waited for api to complete before appearing selected, this creates a bad user experience as users expect immediate responses and has the potential to create unexpected results if users click lots of times very quickly.  Since most of the time api calls will succeed it is better to have the buttons respond immediately assuming they will work.  Then if the api call fails turn them back.

### Description

[LEARNER-XXXX](https://openedx.atlassian.net/browse/LEARNER-XXXX)
There was a learner that someone brought up about these buttons when a user clicks lots of times it creates unexpected results, this learner seems to have been removed (or I just can't find it).  
