### PR TITLE
Fix 'onRevisit' callback calls wrongly issue.

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragment.java
@@ -2,10 +2,6 @@ package org.edx.mobile.base;
 
 import android.app.Activity;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
 
 import org.edx.mobile.event.NewRelicEvent;
 
@@ -13,19 +9,12 @@ import de.greenrobot.event.EventBus;
 import roboguice.fragment.RoboFragment;
 
 public class BaseFragment extends RoboFragment {
-    private boolean isFirstVisit;
+    private boolean isFirstVisit = true;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         EventBus.getDefault().post(new NewRelicEvent(getClass().getSimpleName()));
-    }
-
-    @Nullable
-    @Override
-    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        isFirstVisit = true;
-        return super.onCreateView(inflater, container, savedInstanceState);
     }
 
     @Override


### PR DESCRIPTION
### Description

[LEARNER-3953](https://openedx.atlassian.net/browse/LEARNER-3953)

### Problem and Fix
There are possibilities that the extender classes of BaseFragment doesn't call **'onCreateView'** function by not calling super. So keeping this scenario in mind we should avoid to do **isFirstVisit=true** in this callback and keep it true in on declaration level.