### PR TITLE
HLS | Find downloadable url from ‘all_sources’ if video pipeline is disabled.

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/VideoResponseModel.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/api/VideoResponseModel.java
@@ -1,5 +1,7 @@
 package org.edx.mobile.model.api;
 
+import android.support.annotation.Nullable;
+
 import org.edx.mobile.interfaces.SectionItemInterface;
 import org.edx.mobile.model.course.BlockType;
 import org.edx.mobile.model.course.HasDownloadEntry;
@@ -146,6 +148,12 @@ public class VideoResponseModel implements SectionItemInterface, HasDownloadEntr
                 .getDownloadEntryfromVideoResponseModel(this);
         }
         return downloadEntry;
+    }
+
+    @Nullable
+    @Override
+    public String getDownloadUrl() {
+        return null;
     }
 
     public long getSize(){

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/EncodedVideos.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/EncodedVideos.java
@@ -35,7 +35,7 @@ public class EncodedVideos implements Serializable {
         }
         if (new Config(MainApplication.instance()).isUsingVideoPipeline()) {
             if (fallback != null && URLUtil.isNetworkUrl(fallback.url) &&
-                    VideoUtil.isSupportedVideoFormat(fallback.url, AppConstants.VIDEO_FORMAT_M3U8)) {
+                    VideoUtil.videoHasFormat(fallback.url, AppConstants.VIDEO_FORMAT_M3U8)) {
                 return fallback;
             }
         } else {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/HasDownloadEntry.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/HasDownloadEntry.java
@@ -8,4 +8,7 @@ import org.edx.mobile.module.storage.IStorage;
 public interface HasDownloadEntry {
     @Nullable
     DownloadEntry getDownloadEntry(IStorage storage);
+
+    @Nullable
+    String getDownloadUrl();
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/VideoBlockModel.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/VideoBlockModel.java
@@ -12,6 +12,7 @@ public class VideoBlockModel extends CourseComponent implements HasDownloadEntry
 
     private DownloadEntry downloadEntry;
     private VideoData data;
+    private String downloadUrl;
 
     public VideoBlockModel(BlockModel blockModel, CourseComponent parent){
         super(blockModel,parent);
@@ -28,6 +29,16 @@ public class VideoBlockModel extends CourseComponent implements HasDownloadEntry
                 .getDownloadEntryFromVideoModel(this);
         }
         return downloadEntry;
+    }
+
+    public void setDownloadUrl(@Nullable String downloadUrl) {
+        this.downloadUrl = downloadUrl;
+    }
+
+    @Nullable
+    @Override
+    public String getDownloadUrl() {
+        return downloadUrl;
     }
 
     public VideoData getData() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/VideoData.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/VideoData.java
@@ -18,6 +18,9 @@ public class VideoData extends BlockData {
     @SerializedName("only_on_web")
     public boolean onlyOnWeb;
 
+    @SerializedName("all_sources")
+    public String[] allSources;
+
     @SerializedName("encoded_videos")
     public EncodedVideos encodedVideos;
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/IDatabaseImpl.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/IDatabaseImpl.java
@@ -428,12 +428,7 @@ public class IDatabaseImpl extends IDatabaseBaseImpl implements IDatabase {
 
     @Override
     public Integer deleteVideoByVideoId(VideoModel video, DataCallback<Integer> callback) {
-        ContentValues values = new ContentValues();
-        values.put(DbStructure.Column.DOWNLOADED, DownloadedState.ONLINE.ordinal());
-        values.put(DbStructure.Column.DM_ID, -1);
-        values.put(DbStructure.Column.FILEPATH, "");
-
-        DbOperationUpdate op = new DbOperationUpdate(DbStructure.Table.DOWNLOADS, values,
+        DbOperationDelete op = new DbOperationDelete(DbStructure.Table.DOWNLOADS,
                 DbStructure.Column.VIDEO_ID + "=? AND " + DbStructure.Column.USERNAME + "=?",
                 new String[]{video.getVideoId(), username()});
         op.setCallback(callback);
@@ -443,18 +438,12 @@ public class IDatabaseImpl extends IDatabaseBaseImpl implements IDatabase {
     @Override
     public Integer deleteVideoByVideoId(VideoModel video, DataCallback<Integer> callback,
                                         String username) {
-        ContentValues values = new ContentValues();
-        values.put(DbStructure.Column.DOWNLOADED, DownloadedState.ONLINE.ordinal());
-        values.put(DbStructure.Column.DM_ID, -1);
-        values.put(DbStructure.Column.FILEPATH, "");
-
-        DbOperationUpdate op = new DbOperationUpdate(DbStructure.Table.DOWNLOADS, values,
+        DbOperationDelete op = new DbOperationDelete(DbStructure.Table.DOWNLOADS,
                 DbStructure.Column.VIDEO_ID + "=? AND " + DbStructure.Column.USERNAME + "=?",
                 new String[]{video.getVideoId(), username});
         op.setCallback(callback);
         return enqueue(op);
     }
-
 
     @Override
     public Boolean isVideoFilePresentByUrl(String videoUrl, final DataCallback<Boolean> callback) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/services/VideoDownloadHelper.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/services/VideoDownloadHelper.java
@@ -2,6 +2,7 @@ package org.edx.mobile.services;
 
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.FragmentActivity;
+import android.text.TextUtils;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -79,10 +80,14 @@ public class VideoDownloadHelper {
 
     private void startDownloadVideos(List<? extends HasDownloadEntry> model, FragmentActivity activity, DownloadManagerCallback callback) {
         long downloadSize = 0;
-        ArrayList<DownloadEntry> downloadList = new ArrayList<DownloadEntry>();
+        ArrayList<DownloadEntry> downloadList = new ArrayList<>();
         int downloadCount = 0;
         for (HasDownloadEntry v : model) {
             DownloadEntry de = v.getDownloadEntry(storage);
+            if (!TextUtils.isEmpty(v.getDownloadUrl())) {
+                // Prefer download url to download
+                de.url = v.getDownloadUrl();
+            }
             if (null == de
                     || de.downloaded == DownloadEntry.DownloadedState.DOWNLOADING
                     || de.downloaded == DownloadEntry.DownloadedState.DOWNLOADED

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/VideoUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/VideoUtil.java
@@ -1,7 +1,9 @@
 package org.edx.mobile.util;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
+import org.edx.mobile.base.MainApplication;
 import org.edx.mobile.model.course.VideoData;
 import org.edx.mobile.model.course.VideoInfo;
 
@@ -21,19 +23,24 @@ public class VideoUtil {
      * @return <code>true</code> if video url is valid, <code>false</code> otherwise.
      */
     public static boolean isValidVideoUrl(@NonNull String videoUrl) {
-        return isSupportedVideoFormat(videoUrl, SUPPORTED_VIDEO_FORMATS);
+        return videoHasFormat(videoUrl, SUPPORTED_VIDEO_FORMATS);
     }
 
     /**
      * Check if format of video url exists in specified list of video formats.
      *
-     * @param videoUrl         Video url whose format needs to be checked.
-     * @param supportedFormats List of supported video formats.
-     * @return <code>true</code> if video url format exist in supported formats list, <code>false</code> otherwise.
+     * @param videoUrl         Video url whose format needs to be matched.
+     * @param supportedFormats List of video formats.
+     * @return <code>true</code> if video url format exist in specified formats list, <code>false</code> otherwise.
      */
-    public static boolean isSupportedVideoFormat(@NonNull String videoUrl, @NonNull String... supportedFormats) {
+    public static boolean videoHasFormat(@NonNull String videoUrl, @NonNull String... supportedFormats) {
         for (final String format : supportedFormats) {
-            if (videoUrl.endsWith(format)) {
+            /*
+             * Its better to find a video format extension in the whole url because there is a
+             * possibility that extension exists somewhere in between of url for e.g.
+             * https://player.vimeo.com/external/225003478.m3u8?s=6438b130458bd0eb38f7625ffa26623caee8ff7c
+             */
+            if (videoUrl.contains(format)) {
                 return true;
             }
         }
@@ -47,9 +54,36 @@ public class VideoUtil {
      * @return <code>true</code> if video is downloadable, <code>false</code> otherwise.
      */
     public static boolean isVideoDownloadable(@NonNull VideoData video) {
+        return getPreferredVideoUrlForDownloading(video) != null;
+    }
+
+    /**
+     * Gives the preferred video url for downloading from a specified {@link VideoData} object.
+     *
+     * @param video Data of the video whose preferred download url is needed.
+     * @return download url of video, return null if unable to find any suitable url for downloading.
+     */
+    @Nullable
+    public static String getPreferredVideoUrlForDownloading(@NonNull VideoData video) {
         final VideoInfo preferredVideoInfo = video.encodedVideos.getPreferredVideoInfo();
-        return preferredVideoInfo != null &&
-                !isSupportedVideoFormat(preferredVideoInfo.url, VIDEO_FORMAT_M3U8) &&
-                !video.onlyOnWeb;
+        if (preferredVideoInfo == null || video.onlyOnWeb) {
+            return null;
+        }
+        if (!videoHasFormat(preferredVideoInfo.url, VIDEO_FORMAT_M3U8)) {
+            return preferredVideoInfo.url;
+        }
+        if (!new Config(MainApplication.instance()).isUsingVideoPipeline()) {
+            /**
+             * If preferred video url for downloading has HLS format and
+             * {@link Config#USING_VIDEO_PIPELINE} feature flag is disabled, try to find some .mp4
+             * format url from {@link VideoData#allSources} urls and consider it for download.
+             */
+            for (String url : video.allSources) {
+                if (VideoUtil.videoHasFormat(url, AppConstants.VIDEO_FORMAT_MP4)) {
+                    return url;
+                }
+            }
+        }
+        return null;
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitVideoFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitVideoFragment.java
@@ -365,7 +365,7 @@ public class CourseUnitVideoFragment extends CourseUnitFragment
 
     private String getVideoPath(DownloadEntry video){
         String filepath = null;
-        if (!(video.filepath != null && video.filepath.length()>0)) {
+        if (video.filepath != null && video.filepath.length()>0) {
             if (video.isDownloaded()) {
                 File f = new File(video.filepath);
                 if (f.exists()) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/NewCourseOutlineAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/NewCourseOutlineAdapter.java
@@ -354,7 +354,7 @@ public class NewCourseOutlineAdapter extends BaseAdapter {
     }
 
     private void updateUIForVideo(@NonNull final ViewHolder viewHolder, @NonNull final DownloadEntry videoData,
-                                  @NonNull VideoBlockModel videoBlockModel) {
+                                  @NonNull final VideoBlockModel videoBlockModel) {
         viewHolder.rowType.setIcon(FontAwesomeIcons.fa_film);
         viewHolder.numOfVideoAndDownloadArea.setVisibility(View.VISIBLE);
         viewHolder.bulkDownload.setVisibility(View.VISIBLE);
@@ -406,6 +406,12 @@ public class NewCourseOutlineAdapter extends BaseAdapter {
                                         new View.OnClickListener() {
                                             @Override
                                             public void onClick(View v) {
+                                                /**
+                                                 * Assign preferred downloadable url to {@link DownloadEntry#url}
+                                                 * to use this url to download. After downloading
+                                                 * only downloaded video path will be used for streaming.
+                                                 */
+                                                videoData.url = VideoUtil.getPreferredVideoUrlForDownloading(videoBlockModel.getData());
                                                 downloadListener.download(videoData);
                                             }
                                         });
@@ -495,7 +501,16 @@ public class NewCourseOutlineAdapter extends BaseAdapter {
                         new View.OnClickListener() {
                             @Override
                             public void onClick(View downloadView) {
-                                downloadListener.download(component.getVideos());
+                                final List<VideoBlockModel> downloadableVideos = (List<VideoBlockModel>) (List) component.getVideos(true);
+                                for (VideoBlockModel videoBlockModel : downloadableVideos) {
+                                    /**
+                                     * Assign preferred downloadable url to {@link VideoBlockModel#downloadUrl},
+                                     * to use this url to download. After downloading only downloaded
+                                     * video path will be used for streaming.
+                                     */
+                                    videoBlockModel.setDownloadUrl(VideoUtil.getPreferredVideoUrlForDownloading(videoBlockModel.getData()));
+                                }
+                                downloadListener.download(downloadableVideos);
                             }
                         });
             }


### PR DESCRIPTION
### Description

[LEARNER-3743](https://openedx.atlassian.net/browse/LEARNER-3743)
Please refer to story for the changes implemented in this story.

### Relevant PR's
Android initial PR for HLS support: https://github.com/edx/edx-app-android/pull/1034
iOS OSPR: https://github.com/edx/edx-app-ios/pull/1033

### Testing
For testing i have created a following course on lahore sandbox.
https://lahore.sandbox.edx.org/courses/course-v1:Edx+HLS101+2018_T1/info

### Screen shots

`USING_VIDEO_PIPELINE: true`

<img src="https://user-images.githubusercontent.com/25842457/35682975-5b4cde54-0784-11e8-9269-b71d447a754a.png" width="200"> 


`USING_VIDEO_PIPELINE: false`

<img src="https://user-images.githubusercontent.com/25842457/35731543-c73ee112-0837-11e8-9485-cde281679e70.png" width="200">    <img src="https://user-images.githubusercontent.com/25842457/35731544-c76ce850-0837-11e8-9a2b-88902c969ea4.png" width="200">


**Dev Notes**
Following is the zipped course that can be used to test the implementation of this PR:
https://github.com/edx/edx-app-ios/files/1493756/video_test_course.Dl2Kjh.tar.gz
