### PR TITLE
Focus search bar on selection of discovery tab.

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/WebViewDiscoverCoursesFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/WebViewDiscoverCoursesFragment.java
@@ -122,8 +122,9 @@ public class WebViewDiscoverCoursesFragment extends BaseWebViewDiscoverFragment 
     @Override
     public void setUserVisibleHint(boolean isVisibleToUser) {
         super.setUserVisibleHint(isVisibleToUser);
-        if (toolbarCallbacks != null && toolbarCallbacks.getSearchView() != null) {
-            toolbarCallbacks.getSearchView().setVisibility(isVisibleToUser ? View.VISIBLE : View.GONE);
+        if (searchView != null) {
+            searchView.setVisibility(isVisibleToUser ? View.VISIBLE : View.GONE);
+            searchView.setIconified(!isVisibleToUser);
         }
     }
 


### PR DESCRIPTION
[LEARNER-4169](https://openedx.atlassian.net/browse/LEARNER-4169)

### Description
- Please refer to Jira story for more details.
- Search bar focusing on selection of discovery tab has been implemented on WebViewDiscoverCoursesFragment.
- Search bar focusing on selection of discovery tab is not implemented on NativeFindCoursesFragment because we haven't implemented search bar on that yet. 


