### PR TITLE
Move initialization of SearchView from onAttach to onActivityCreated

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/WebViewDiscoverCoursesFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/WebViewDiscoverCoursesFragment.java
@@ -1,6 +1,5 @@
 package org.edx.mobile.view;
 
-import android.content.Context;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -42,11 +41,10 @@ public class WebViewDiscoverCoursesFragment extends BaseWebViewDiscoverFragment 
     }
 
     @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
         toolbarCallbacks = (MainDashboardToolbarCallbacks) getActivity();
         initSearchView();
-
     }
 
     private void initSearchView() {


### PR DESCRIPTION
### Description

[LEARNER-4206](https://openedx.atlassian.net/browse/LEARNER-4206)


Having the initialization code in onAttach causes the app to crash
whenever the fragment/activity has to be recreated for whatever reason.
onActivityCreated is also the logically correct home for this code as
activity creation is the prerequisite for the SearchView to be
initialized.