### PR TITLE
Added Language helper

### DIFF
--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -621,4 +621,13 @@
     <string name="rating_bar_selection">{rating} out of {num_of_stars}</string>
     <!-- Title of the Whats New screen e.g. Version 2.8.1 New Features -->
     <string name="whats_new_title">Version {version_number} New Features</string>
+
+    <!-- Title for alert dialogue when language changes -->
+    <string name="language_changed_title">The language has changed</string>
+
+    <!-- Message for alert dialogue when language changes -->
+    <string name="language_changed_message">The app will have to restart</string>
+
+    <!-- Positive response button for alert dialogue when language changes -->
+    <string name="Okay">Ok</string>
 </resources>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseAppActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseAppActivity.java
@@ -1,14 +1,21 @@
 package org.edx.mobile.base;
 
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 
+import com.google.inject.Inject;
 import org.edx.mobile.event.NewRelicEvent;
 
 import de.greenrobot.event.EventBus;
+import org.edx.mobile.module.Language.LanguageHelper;
 import uk.co.chrisjenx.calligraphy.CalligraphyContextWrapper;
 
 public abstract class BaseAppActivity extends RoboAppCompatActivity {
+
+    @Inject
+    LanguageHelper languageHelper;
+
     @Override
     protected void attachBaseContext(Context newBase) {
         super.attachBaseContext(CalligraphyContextWrapper.wrap(newBase));
@@ -18,5 +25,23 @@ public abstract class BaseAppActivity extends RoboAppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         EventBus.getDefault().post(new NewRelicEvent(getClass().getSimpleName()));
+        resetTitle();
+        // this is needed for when the language changes during runtime
+        // the title's get cached in the previous language
+    }
+
+    @Override
+    protected void onResume(){
+        super.onResume();
+        languageHelper.configureLanguage(this);
+    }
+
+    private void resetTitle() {
+        try {
+            int label = getPackageManager().getActivityInfo(getComponentName(), PackageManager.GET_META_DATA).labelRes;
+            if (label != 0) {
+                setTitle(label);
+            }
+        } catch (PackageManager.NameNotFoundException e) { }
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/Language/LanguageHelper.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/Language/LanguageHelper.java
@@ -1,0 +1,122 @@
+package org.edx.mobile.module.Language;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.support.annotation.NonNull;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Singleton;
+import org.edx.mobile.R;
+import org.edx.mobile.base.MainApplication;
+import org.edx.mobile.http.callback.Callback;
+import org.edx.mobile.module.prefs.LoginPrefs;
+import org.edx.mobile.module.prefs.PrefManager;
+import org.edx.mobile.user.Preferences;
+import org.edx.mobile.user.UserService;
+import org.edx.mobile.view.MyCoursesListActivity;
+import roboguice.RoboGuice;
+
+import java.util.Locale;
+
+/**
+ * Created by adamkatz on 2018/02/01.
+ */
+
+@Singleton
+public class LanguageHelper {
+  @Inject
+  LoginPrefs loginPrefs;
+
+  @NonNull
+  private final PrefManager.AppInfoPrefManager pref;
+
+  @javax.inject.Inject
+  public LanguageHelper() {
+    pref = new PrefManager.AppInfoPrefManager(MainApplication.instance());
+  }
+
+  public void configureLanguage(Activity activity) {
+    getAppLanguageFromLocalStorage(activity);
+    getAppLanguageByApi(activity);
+  }
+
+  public void configureLanguage(String language, Activity activity){
+    saveLanguage(language);
+    changeLanguage(language, activity);
+  }
+
+  private void saveLanguage(String language){
+    pref.setLanguage(language);
+  }
+
+  private void setLanguage(Locale newLocale, Activity activity){
+    Locale.setDefault(newLocale);
+    Configuration config = new Configuration();
+    config.locale = newLocale;
+    MainApplication.instance().getResources().updateConfiguration(config, MainApplication.instance().getResources().getDisplayMetrics());
+    makeAlert(activity);
+  }
+
+  private void changeLanguage(String language, Activity activity){
+    Locale phoneLocale = Resources.getSystem().getConfiguration().locale;
+    Locale displayLocale = Locale.getDefault();
+    Locale newLocale = new Locale(language);
+    if (!language.equals("en") && !displayLocale.equals(newLocale)){
+      setLanguage(newLocale, activity);
+    }
+    else if (language.equals("en")  && !displayLocale.equals(phoneLocale)){
+      setLanguage(phoneLocale, activity);
+    }
+  }
+
+  private void getAppLanguageByApi(final Activity activity){
+    final Injector injector = RoboGuice.getInjector(MainApplication.instance());
+    UserService userService = injector.getInstance(UserService.class);
+    userService.getPreferences(loginPrefs.getUsername()).enqueue(new Callback<Preferences>() {
+      @Override
+      protected void onResponse(@NonNull Preferences preferences) {
+        String displayLanguage = Locale.getDefault().getDisplayLanguage().substring(0,2);
+        if (!displayLanguage.toLowerCase().equals(preferences.getPrefLang())) {
+          configureLanguage(preferences.getPrefLang(), activity);
+        }
+      }
+
+      @Override
+      protected void onFailure(@NonNull Throwable error) {
+
+      }
+    });
+  }
+
+  private void getAppLanguageFromLocalStorage(Activity activity){
+    String language = pref.getUserLanguages();
+    if(language!=null) {
+      changeLanguage(language, activity);
+    }
+  }
+
+  private void makeAlert(final Activity activity){
+    new AlertDialog.Builder(activity)
+      .setTitle(activity.getResources().getString(R.string.language_changed_title))
+      .setMessage(activity.getResources().getString(R.string.language_changed_message))
+      .setPositiveButton(activity.getResources().getString(R.string.Okay), new DialogInterface.OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+          restartApp();
+        }
+      }).show();
+  }
+
+  private void restartApp(){
+    //This must point to the opening activity after login
+    Intent myIntent = new Intent(MainApplication.instance(), MyCoursesListActivity.class);
+    myIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent
+      .FLAG_ACTIVITY_CLEAR_TOP);
+    MainApplication.instance().startActivity(myIntent);
+  }
+
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
@@ -82,7 +82,7 @@ public class PrefManager {
     public String getString(String key) {
         if (context != null) {
             return context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
-                    .getString(key, null);
+              .getString(key, null);
         }
         return null;
     }
@@ -97,7 +97,7 @@ public class PrefManager {
     public boolean getBoolean(String key, boolean defaultValue) {
         if (context != null) {
             return context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
-                    .getBoolean(key, defaultValue);
+              .getBoolean(key, defaultValue);
         }
         return defaultValue;
     }
@@ -111,7 +111,7 @@ public class PrefManager {
     public long getLong(String key) {
         if (context != null) {
             return context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
-                    .getLong(key, -1);
+              .getLong(key, -1);
         }
         return -1;
     }
@@ -124,7 +124,7 @@ public class PrefManager {
      */
     public float getFloat(String key) {
         return context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
-                .getFloat(key, -1.0f);
+          .getFloat(key, -1.0f);
     }
 
     /**
@@ -137,7 +137,7 @@ public class PrefManager {
     public float getFloat(String key, float defaultValue) {
         if (context != null) {
             return context.getSharedPreferences(prefName, Context.MODE_PRIVATE)
-                    .getFloat(key, defaultValue);
+              .getFloat(key, defaultValue);
         }
         return defaultValue;
     }
@@ -187,6 +187,10 @@ public class PrefManager {
             super.put(Key.AppSettingNeedSyncWithParse, enabled);
         }
 
+        public String getUserLanguages() {
+            return getString(Key.USER_LANGUAGE);
+        }
+
         public String getPrevNotificationHashKey() {
             return getString(Key.AppNotificationPushHash);
         }
@@ -211,6 +215,10 @@ public class PrefManager {
             super.put(Key.LAST_RATED_VERSION, versionName);
         }
 
+        public void setLanguage(String language) {
+            super.put(Key.USER_LANGUAGE, language);
+        }
+
         @Nullable
         public String getWhatsNewShownVersion() {
             return getString(Key.WHATS_NEW_SHOWN_FOR_VERSION);
@@ -218,6 +226,20 @@ public class PrefManager {
 
         public void setWhatsNewShown(@NonNull String version) {
             super.put(Key.WHATS_NEW_SHOWN_FOR_VERSION, version);
+        }
+    }
+
+    public static class UserPrefManager extends PrefManager {
+        public UserPrefManager(Context context) {
+            super(context, Pref.USER_PREF);
+        }
+
+        public boolean isVideosCacheRestored() {
+            return getBoolean(Key.VIDEOS_CACHE_RESTORED, false);
+        }
+
+        public void setIsVideosCacheRestored(boolean restored) {
+            super.put(Key.VIDEOS_CACHE_RESTORED, restored);
         }
     }
 
@@ -269,6 +291,14 @@ public class PrefManager {
         public static final String AppNotificationPushHash = "AppNotificationPushHash";
         public static final String AppUpgradeNeedSyncWithParse = "AppUpgradeNeedSyncWithParse";
         public static final String AppSettingNeedSyncWithParse = "AppSettingNeedSyncWithParse";
+        public static final String USER_LANGUAGE = "pref_language";
+
+        /**
+         * For downloaded videos to appear in order on the My Videos screen, we need
+         * to have the videos' courses data cached. This is the key to a persistent
+         * flag which marks whether the cache has been restored
+         */
+        public static final String VIDEOS_CACHE_RESTORED = "VideosCacheRestored";
 
         // Preference to save user app rating
         public static final String APP_RATING = "APP_RATING";
@@ -297,7 +327,7 @@ public class PrefManager {
                 continue;
             }
             MainApplication.application.getSharedPreferences(
-                    prefName, Context.MODE_PRIVATE).edit().clear().apply();
+              prefName, Context.MODE_PRIVATE).edit().clear().apply();
         }
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/user/Preferences.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/user/Preferences.java
@@ -1,0 +1,22 @@
+package org.edx.mobile.user;
+
+import android.support.annotation.NonNull;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Created by adamkatz on 2018/01/29.
+ */
+
+public class Preferences {
+
+  @SerializedName("pref-lang")
+  @NonNull
+  private String prefLang;
+
+  public String getPrefLang() {
+    return prefLang;
+  }
+}
+
+
+

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/user/UserService.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/user/UserService.java
@@ -41,6 +41,10 @@ public interface UserService {
     Call<Account> getAccount(@Path("username") String username);
 
     @Headers("Cache-Control: no-cache")
+    @GET("/api/user/v1/preferences/{username}")
+    Call<Preferences> getPreferences(@Path("username") String username);
+
+    @Headers("Cache-Control: no-cache")
     @PATCH("/api/user/v1/accounts/{username}")
     Call<Account> updateAccount(@Path("username") String username, @Body Map<String, Object> fields);
 


### PR DESCRIPTION
Currently the only way to change the android apps language is in the phone settings, this is problematic for two reasons.

1.  The website has a language switcher that shows what the user wants their language to be, once they use this switch is makes more sense to change the language on the app accordingly.  

2.  Not all languages that the website supports are supported by Android so it is frustrating if a user who only speaks an unusual language has set their website to said language but cannot use their app in the same language.  

The way the app works with the language helper, is when the user changes the language on the website and the user changes screens the user will get an alert letting them know that the language has changed and that the app will reset, the app will go back to the starting screen and then the language will have changed.  

If the app is closed when the language is changed then the language will be correct when the user opens the app.  

[LEARNER-XXXX](https://openedx.atlassian.net/browse/LEARNER-XXXX)

