### PR TITLE
Handle the case where server sends non-parsable course content

### DIFF
--- a/OpenEdXMobile/res/values/errors.xml
+++ b/OpenEdXMobile/res/values/errors.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- An error occurred but we don't know why -->
     <string name="error_unknown">Unknown error. Please try again later.</string>
+
+    <!-- Course related error messages -->
+    <!-- Error shown when a course's content is invalid or not in the format that we expect -->
+    <string name="course_error_content_invalid" tools:ignore="MissingTranslation">Unable to load course content. Try again later.</string>
 
     <!-- Network error messages -->
     <!-- Error shown when  user attempts an action but needs an internet connection -->

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/exception/CourseContentNotValidException.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/exception/CourseContentNotValidException.java
@@ -1,0 +1,13 @@
+package org.edx.mobile.exception;
+
+import android.support.annotation.NonNull;
+
+/**
+ * Signals that the course content returned from server is not valid. Example issues in the course's
+ * content could be, it being not parsable or incomplete according to what we expect.
+ */
+public class CourseContentNotValidException extends Exception {
+    public CourseContentNotValidException(@NonNull String message) {
+        super(message);
+    }
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/images/ErrorUtils.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/images/ErrorUtils.java
@@ -9,6 +9,7 @@ import com.joanzapata.iconify.Icon;
 import com.joanzapata.iconify.fonts.FontAwesomeIcons;
 
 import org.edx.mobile.R;
+import org.edx.mobile.exception.CourseContentNotValidException;
 import org.edx.mobile.http.HttpStatus;
 import org.edx.mobile.http.HttpStatusException;
 import org.edx.mobile.http.callback.CallTrigger;
@@ -76,6 +77,8 @@ public enum ErrorUtils {
                     errorResId = R.string.app_version_unsupported;
                     break;
             }
+        } else if (error instanceof CourseContentNotValidException) {
+            errorResId = R.string.course_error_content_invalid;
         }
         if (errorResId == R.string.error_unknown) {
             // Submit crash report since this is an unknown type of error
@@ -88,7 +91,7 @@ public enum ErrorUtils {
     public static Icon getErrorIcon(@NonNull Throwable ex) {
         if (ex instanceof IOException) {
             return FontAwesomeIcons.fa_wifi;
-        } else if (ex instanceof HttpStatusException) {
+        } else if (ex instanceof HttpStatusException || ex instanceof CourseContentNotValidException) {
             return FontAwesomeIcons.fa_exclamation_circle;
         } else {
             return null;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/NewCourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/NewCourseOutlineFragment.java
@@ -33,10 +33,12 @@ import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.course.CourseAPI;
 import org.edx.mobile.event.CourseDashboardRefreshEvent;
 import org.edx.mobile.event.NetworkConnectivityChangeEvent;
+import org.edx.mobile.exception.CourseContentNotValidException;
 import org.edx.mobile.http.notifications.FullScreenErrorNotification;
 import org.edx.mobile.interfaces.RefreshListener;
 import org.edx.mobile.loader.AsyncTaskResult;
 import org.edx.mobile.loader.CourseOutlineAsyncLoader;
+import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.model.course.BlockPath;
 import org.edx.mobile.model.course.CourseComponent;
@@ -70,6 +72,8 @@ public class NewCourseOutlineFragment extends OfflineSupportBaseFragment
     private static final int REQUEST_SHOW_COURSE_UNIT_DETAIL = 0;
     private static final int AUTOSCROLL_DELAY_MS = 500;
     private static final int SNACKBAR_SHOWTIME_MS = 5000;
+
+    protected final Logger logger = new Logger(getClass().getName());
 
     private NewCourseOutlineAdapter adapter;
     private ListView listView;
@@ -211,6 +215,15 @@ public class NewCourseOutlineFragment extends OfflineSupportBaseFragment
                 courseComponentId = courseComponent.getId();
                 courseManager.addCourseDataInAppLevelCache(courseId, courseComponent);
                 loadData(courseComponent);
+            }
+
+            @Override
+            protected void onFailure(@NonNull Throwable error) {
+                super.onFailure(error);
+                if (error instanceof CourseContentNotValidException) {
+                    errorNotification.showError(getContext(), error);
+                    logger.error(error, true);
+                }
             }
 
             @Override

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/test/http/ApiTests.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/test/http/ApiTests.java
@@ -240,8 +240,7 @@ public class ApiTests extends HttpBaseTestCase {
         EnrolledCoursesResponse e = executeStrict(courseAPI.getEnrolledCourses()).get(0);
         final String courseId = e.getCourse().getId();
         final CourseStructureV1Model model = executeStrict(courseAPI.getCourseStructure(courseId));
-        final CourseComponent courseComponent = (CourseComponent)
-                CourseAPI.normalizeCourseStructure(model, courseId);
+        final CourseComponent courseComponent = (CourseComponent) CourseAPI.normalizeCourseStructure(model, courseId);
         assertNotNull(courseComponent);
         assertNotNull(courseComponent.getRoot());
         assertEquals(courseId, courseComponent.getCourseId());

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/view/CourseBaseActivityTest.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/view/CourseBaseActivityTest.java
@@ -9,7 +9,6 @@ import android.widget.ProgressBar;
 
 import org.edx.mobile.R;
 import org.edx.mobile.course.CourseAPI;
-import org.edx.mobile.http.provider.OkHttpClientProvider;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.model.course.CourseComponent;
 import org.edx.mobile.model.course.CourseStructureV1Model;
@@ -20,7 +19,8 @@ import org.robolectric.util.ActivityController;
 
 import static org.assertj.android.api.Assertions.assertThat;
 import static org.edx.mobile.http.util.CallUtil.executeStrict;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public abstract class CourseBaseActivityTest extends BaseFragmentActivityTest {
     /**
@@ -58,13 +58,13 @@ public abstract class CourseBaseActivityTest extends BaseFragmentActivityTest {
         if (provideCourseId) {
             String courseId = courseData.getCourse().getId();
             CourseStructureV1Model model;
+            CourseComponent courseComponent;
             try {
                 model = executeStrict(courseAPI.getCourseStructure(courseId));
+                courseComponent = (CourseComponent) CourseAPI.normalizeCourseStructure(model, courseId);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
-            CourseComponent courseComponent = (CourseComponent)
-                    CourseAPI.normalizeCourseStructure(model, courseId);
             extras.putString(Router.EXTRA_COURSE_COMPONENT_ID, courseComponent.getId());
         }
         intent.putExtra(Router.EXTRA_BUNDLE, extras);

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/view/CourseOutlineActivityTest.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/view/CourseOutlineActivityTest.java
@@ -121,13 +121,13 @@ public class CourseOutlineActivityTest extends CourseBaseActivityTest {
         assertNotNull(courseData);
         String courseId = courseData.getCourse().getId();
         CourseStructureV1Model model;
+        CourseComponent courseComponent;
         try {
             model = executeStrict(courseAPI.getCourseStructure(courseId));
+            courseComponent = (CourseComponent) CourseAPI.normalizeCourseStructure(model, courseId);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        CourseComponent courseComponent = (CourseComponent)
-                CourseAPI.normalizeCourseStructure(model, courseId);
         int subsectionRowIndex = -1;
         String subsectionId = null;
         CourseComponent subsectionUnit = null;
@@ -200,13 +200,13 @@ public class CourseOutlineActivityTest extends CourseBaseActivityTest {
         assertNotNull(courseData);
         String courseId = courseData.getCourse().getId();
         CourseStructureV1Model model;
+        CourseComponent courseComponent;
         try {
             model = executeStrict(courseAPI.getCourseStructure(courseId));
+            courseComponent = (CourseComponent) CourseAPI.normalizeCourseStructure(model, courseId);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        CourseComponent courseComponent = (CourseComponent)
-                CourseAPI.normalizeCourseStructure(model, courseId);
         List<CourseComponent> leafComponents = new ArrayList<>();
         courseComponent.fetchAllLeafComponents(leafComponents,
                 EnumSet.allOf(BlockType.class));

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/view/CourseUnitNavigationActivityTest.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/view/CourseUnitNavigationActivityTest.java
@@ -79,13 +79,14 @@ public class CourseUnitNavigationActivityTest extends CourseBaseActivityTest {
         }
         String courseId = courseData.getCourse().getId();
         CourseStructureV1Model model;
+        CourseComponent courseComponent;
         try {
             model = executeStrict(courseAPI.getCourseStructure(courseId));
+            courseComponent = (CourseComponent) CourseAPI.normalizeCourseStructure(model, courseId);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        CourseComponent courseComponent = (CourseComponent)
-                CourseAPI.normalizeCourseStructure(model, courseId);
+
         List<CourseComponent> leafComponents = new ArrayList<>();
         courseComponent.fetchAllLeafComponents(leafComponents,
                 EnumSet.allOf(BlockType.class));
@@ -151,13 +152,13 @@ public class CourseUnitNavigationActivityTest extends CourseBaseActivityTest {
         assertNotNull(courseData);
         String courseId = courseData.getCourse().getId();
         CourseStructureV1Model model;
+        CourseComponent courseComponent;
         try {
             model = executeStrict(courseAPI.getCourseStructure(courseId));
+            courseComponent = (CourseComponent) CourseAPI.normalizeCourseStructure(model, courseId);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        CourseComponent courseComponent = (CourseComponent)
-                CourseAPI.normalizeCourseStructure(model, courseId);
         assertNotNull(courseComponent);
         final String unitId = extras.getString(Router.EXTRA_COURSE_COMPONENT_ID);
         assertNotNull(unitId);

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/view/CourseUnitVideoFragmentTest.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/view/CourseUnitVideoFragmentTest.java
@@ -50,13 +50,14 @@ public class CourseUnitVideoFragmentTest extends UiTest {
         }
         String courseId = courseData.getCourse().getId();
         CourseStructureV1Model model;
+        CourseComponent courseComponent;
         try {
             model = executeStrict(courseAPI.getCourseStructure(courseId));
+            courseComponent = (CourseComponent) CourseAPI.normalizeCourseStructure(model, courseId);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        CourseComponent courseComponent = (CourseComponent)
-                CourseAPI.normalizeCourseStructure(model, courseId);
+
         return (VideoBlockModel) courseComponent.getVideos().get(0);
     }
 

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/view/CourseUnitWebViewFragmentTest.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/view/CourseUnitWebViewFragmentTest.java
@@ -5,6 +5,7 @@ import android.webkit.WebView;
 
 import org.edx.mobile.R;
 import org.edx.mobile.course.CourseAPI;
+import org.edx.mobile.exception.CourseContentNotValidException;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.model.course.BlockType;
 import org.edx.mobile.model.course.CourseComponent;
@@ -29,7 +30,7 @@ public class CourseUnitWebViewFragmentTest extends UiTest {
      *
      * @return The first {@link HtmlBlockModel} leaf in the mock course data
      */
-    private HtmlBlockModel getHtmlUnit() {
+    private HtmlBlockModel getHtmlUnit() throws CourseContentNotValidException {
         EnrolledCoursesResponse courseData;
         try {
             courseData = executeStrict(courseAPI.getEnrolledCourses()).get(0);
@@ -55,7 +56,7 @@ public class CourseUnitWebViewFragmentTest extends UiTest {
      * Testing initialization
      */
     @Test
-    public void initializeTest() {
+    public void initializeTest() throws CourseContentNotValidException {
         CourseUnitWebViewFragment fragment = CourseUnitWebViewFragment.newInstance(getHtmlUnit());
         SupportFragmentTestUtil.startVisibleFragment(fragment);
         View view = fragment.getView();


### PR DESCRIPTION
### Description

[LEARNER-3785](https://openedx.atlassian.net/browse/LEARNER-3785)

Previously our app used to crash whenever the server returned a course whose content was invalid and logged an exception on Crashlytics. This commit gracefully handles that exception by wrapping it into `CourseContentNotValidException` and showing an error on the screen while sending the exception to Crashlytics in the background too.

This is the error we'll be showing when we encounter this or similar courses having invalid content.

![error_on_invalid_course_content](https://user-images.githubusercontent.com/1710804/37159175-f749b430-230e-11e8-9f1d-66e26d9345a3.png)
