### PR TITLE
 Add Bulk Download feature on Subsection view

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/EncodedVideos.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/EncodedVideos.java
@@ -56,7 +56,7 @@ public class EncodedVideos implements Serializable {
     }
 
     @Nullable
-    public VideoInfo getPreferredVideoUrlForDownloading() {
+    public VideoInfo getPreferredVideoInfoForDownloading() {
         if (isPreferredVideoInfo(mobileLow)) {
             return mobileLow;
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/VideoBlockModel.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/VideoBlockModel.java
@@ -21,7 +21,7 @@ public class VideoBlockModel extends CourseComponent implements HasDownloadEntry
 
     @Nullable
     public DownloadEntry getDownloadEntry(IStorage storage) {
-        if (data.encodedVideos.getPreferredVideoInfo() == null) {
+        if (data.encodedVideos.getPreferredVideoInfoForDownloading() == null) {
             return null;
         }
         if ( storage != null ) {
@@ -57,8 +57,8 @@ public class VideoBlockModel extends CourseComponent implements HasDownloadEntry
      */
     public long getPreferredVideoEncodingSize() {
         if (data != null && data.encodedVideos != null
-                && data.encodedVideos.getPreferredVideoInfo() != null) {
-            return data.encodedVideos.getPreferredVideoInfo().fileSize;
+                && data.encodedVideos.getPreferredVideoInfoForDownloading() != null) {
+            return data.encodedVideos.getPreferredVideoInfoForDownloading().fileSize;
         }
         return -1;
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/DatabaseModelFactory.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/DatabaseModelFactory.java
@@ -99,7 +99,7 @@ public class DatabaseModelFactory {
         IBlock root = block.getRoot();
         e.eid = root.getCourseId();
         e.duration = vrm.duration;
-        final VideoInfo preferredVideoInfo = vrm.encodedVideos.getPreferredVideoInfo();
+        final VideoInfo preferredVideoInfo = vrm.encodedVideos.getPreferredVideoInfoForDownloading();
         e.size = preferredVideoInfo.fileSize;
         e.title = block.getDisplayName();
         e.url = preferredVideoInfo.url;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/IDatabase.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/IDatabase.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.edx.mobile.model.VideoModel;
+import org.edx.mobile.model.course.CourseComponent;
 import org.edx.mobile.model.db.DownloadEntry.DownloadedState;
 import org.edx.mobile.model.db.DownloadEntry.WatchedState;
 import org.edx.mobile.module.db.impl.DatabaseFactory;
@@ -326,7 +327,7 @@ public interface IDatabase {
     List<VideoModel> getListOfOngoingDownloads(DataCallback<List<VideoModel>> callback);
 
     /**
-     * If the courseId is provided returns the Videos within a course which are currently being
+     * If the courseId is provided, returns the Videos within a course which are currently being
      * downloaded. Otherwise, returns all the videos being downloaded irrespective of course
      * they belong to.
      *
@@ -390,6 +391,20 @@ public interface IDatabase {
      */
     List<VideoModel> getAllVideosByCourse(@NonNull String courseId,
                                           @Nullable DataCallback<List<VideoModel>> callback);
+
+    /**
+     * Returns the list of all videos from the database for the provided video components. If
+     * {@link DownloadedState downloaded state} is non-null the results are filtered accordingly, if
+     * its null the results are returned as is.
+     *
+     * @param videoComponents Video components.
+     * @param callback        Callback to use for delivering the result.
+     * @param downloadedState Video download state against which the result will be filtered..
+     * @return List of all videos from the database for the provided video components.
+     */
+    List<VideoModel> getVideosByVideoIds(@NonNull List<CourseComponent> videoComponents,
+                                         @Nullable DownloadedState downloadedState,
+                                         @Nullable DataCallback<List<VideoModel>> callback);
 
     /**
      * Removes all records of given username from the database.

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/IDatabaseImpl.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/impl/IDatabaseImpl.java
@@ -10,6 +10,7 @@ import com.google.inject.Singleton;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.edx.mobile.model.VideoModel;
+import org.edx.mobile.model.course.CourseComponent;
 import org.edx.mobile.model.db.DownloadEntry.DownloadedState;
 import org.edx.mobile.model.db.DownloadEntry.WatchedState;
 import org.edx.mobile.module.db.DataCallback;
@@ -17,8 +18,10 @@ import org.edx.mobile.module.db.DbStructure;
 import org.edx.mobile.module.db.IDatabase;
 import org.edx.mobile.module.prefs.LoginPrefs;
 import org.edx.mobile.util.Sha1Util;
+import org.edx.mobile.util.TextUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Singleton
@@ -505,7 +508,7 @@ public class IDatabaseImpl extends IDatabaseBaseImpl implements IDatabase {
 
     @Override
     public List<VideoModel> getListOfOngoingDownloadsByCourseId(@Nullable String courseId,
-                                        DataCallback<List<VideoModel>> callback) {
+                                                                DataCallback<List<VideoModel>> callback) {
         final StringBuilder whereClause = new StringBuilder();
         final List<String> whereArgs = new ArrayList<>();
         whereClause.append(DbStructure.Column.DOWNLOADED).append("=? AND ");
@@ -593,6 +596,31 @@ public class IDatabaseImpl extends IDatabaseBaseImpl implements IDatabase {
         DbOperationGetVideos op = new DbOperationGetVideos(false, DbStructure.Table.DOWNLOADS, null,
                 DbStructure.Column.EID + "=? AND " + DbStructure.Column.USERNAME + "=?",
                 new String[]{courseId, username()}, null);
+        op.setCallback(callback);
+        return enqueue(op);
+    }
+
+    @Override
+    public List<VideoModel> getVideosByVideoIds(@NonNull List<CourseComponent> videoComponents,
+                                                @Nullable DownloadedState downloadedState,
+                                                @Nullable DataCallback<List<VideoModel>> callback) {
+        final List<String> whereArgs = new ArrayList<>();
+        whereArgs.add(username());
+        for (CourseComponent component : videoComponents) {
+            whereArgs.add(component.getId());
+        }
+        if (downloadedState != null) {
+            whereArgs.add(String.valueOf(downloadedState.ordinal()));
+        }
+
+        final CharSequence placeholders = TextUtils.join(",",
+                Collections.<CharSequence>nCopies(videoComponents.size(), "?"));
+
+        DbOperationGetVideos op = new DbOperationGetVideos(false, DbStructure.Table.DOWNLOADS, null,
+                DbStructure.Column.USERNAME + "=? AND " +
+                        DbStructure.Column.VIDEO_ID + " IN (" + placeholders + ")" +
+                        (downloadedState == null ? "" : " AND " + DbStructure.Column.DOWNLOADED + "=?"),
+                whereArgs.toArray(new String[0]), null);
         op.setCallback(callback);
         return enqueue(op);
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/download/DownloadCompleteReceiver.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/download/DownloadCompleteReceiver.java
@@ -52,7 +52,14 @@ public class DownloadCompleteReceiver extends RoboBroadcastReceiver {
 
                         if (nm == null || nm.status != DownloadManager.STATUS_SUCCESSFUL) {
                             logger.debug("Download seems failed or cancelled for id : " + id);
-                            environment.getDownloadManager().removeDownloads(id);
+                            final VideoModel downloadEntry = environment.getDatabase().getDownloadEntryByDmId(id, null);
+                            if (downloadEntry != null) {
+                                // This means that the download was either cancelled from the native
+                                // download manager app or the cancel button on download notification
+                                environment.getStorage().removeDownload(downloadEntry);
+                            } else {
+                                environment.getDownloadManager().removeDownloads(id);
+                            }
                             return;
                         } else {
                             logger.debug("Download successful for id : " + id);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/storage/IStorage.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/storage/IStorage.java
@@ -1,9 +1,11 @@
 package org.edx.mobile.module.storage;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.edx.mobile.model.VideoModel;
 import org.edx.mobile.model.api.VideoResponseModel;
+import org.edx.mobile.model.course.CourseComponent;
 import org.edx.mobile.model.course.VideoBlockModel;
 import org.edx.mobile.model.db.DownloadEntry;
 import org.edx.mobile.model.download.NativeDownloadModel;
@@ -65,11 +67,21 @@ public interface IStorage {
      * within a course which are currently being downloaded. Otherwise, returns the download
      * progress of the all the videos being downloaded irrespective of course they belong to.
      *
-     * @param callback Callback to get status of videos download.
      * @param courseId Course's ID.
+     * @param callback Callback to get status of videos download.
      */
     void getDownloadProgressOfCourseVideos(@Nullable String courseId,
                                            DataCallback<NativeDownloadModel> callback);
+
+    /**
+     * Returns the download progress percent of the provided Videos which are currently being
+     * downloaded.
+     *
+     * @param videoComponents List of video components.
+     * @param callback        Callback to get status of videos download.
+     */
+    void getDownloadProgressOfVideos(@NonNull List<CourseComponent> videoComponents,
+                                     DataCallback<NativeDownloadModel> callback);
 
     /**
      * Returns Download Progress percent of all Videos which are currently

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/storage/Storage.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/storage/Storage.java
@@ -3,6 +3,7 @@ package org.edx.mobile.module.storage;
 import android.app.DownloadManager;
 import android.content.Context;
 import android.media.MediaMetadataRetriever;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
@@ -14,6 +15,7 @@ import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.VideoModel;
 import org.edx.mobile.model.api.ProfileModel;
 import org.edx.mobile.model.api.VideoResponseModel;
+import org.edx.mobile.model.course.CourseComponent;
 import org.edx.mobile.model.course.VideoBlockModel;
 import org.edx.mobile.model.db.DownloadEntry;
 import org.edx.mobile.model.download.NativeDownloadModel;
@@ -295,6 +297,29 @@ public class Storage implements IStorage {
                 callback.onFail(ex);
             }
         });
+    }
+
+    @Override
+    public void getDownloadProgressOfVideos(@NonNull List<CourseComponent> videoComponents,
+                                            final DataCallback<NativeDownloadModel> callback) {
+        final IDatabase db = DatabaseFactory.getInstance(DatabaseFactory.TYPE_DATABASE_NATIVE);
+        db.getVideosByVideoIds(videoComponents, DownloadEntry.DownloadedState.DOWNLOADING,
+                new DataCallback<List<VideoModel>>() {
+                    @Override
+                    public void onResult(List<VideoModel> result) {
+                        final long[] dmids = new long[result.size()];
+                        for (int i = 0; i < result.size(); i++) {
+                            dmids[i] = result.get(i).getDmId();
+                        }
+
+                        callback.onResult(dm.getProgressDetailsForDownloads(dmids));
+                    }
+
+                    @Override
+                    public void onFail(Exception ex) {
+                        callback.onFail(ex);
+                    }
+                });
     }
 
     @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/VideoUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/VideoUtil.java
@@ -65,7 +65,7 @@ public class VideoUtil {
      */
     @Nullable
     public static String getPreferredVideoUrlForDownloading(@NonNull VideoData video) {
-        final VideoInfo preferredVideoInfo = video.encodedVideos.getPreferredVideoUrlForDownloading();
+        final VideoInfo preferredVideoInfo = video.encodedVideos.getPreferredVideoInfoForDownloading();
         if (preferredVideoInfo == null || video.onlyOnWeb) {
             return null;
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.v4.view.ViewCompat;
 import android.view.LayoutInflater;
@@ -79,7 +80,6 @@ public class BulkDownloadFragment extends BaseFragment {
     private IEdxEnvironment environment;
     private VideoPrefs prefManager;
     private SwitchState switchState = SwitchState.DEFAULT;
-    private CourseComponent courseComponent;
     private boolean isDeleteScheduled = false;
     private Handler bgThreadHandler;
 
@@ -88,11 +88,15 @@ public class BulkDownloadFragment extends BaseFragment {
      */
     private CourseVideosStatus videosStatus = new CourseVideosStatus();
     /**
-     * List of videos that can be downloaded.
+     * List of videos that need to be downloaded.
+     */
+    private List<CourseComponent> totalDownloadableVideos;
+    /**
+     * List of videos that are remaining for download.
      */
     private List<HasDownloadEntry> remainingVideos = new ArrayList<>();
     /**
-     * List of videos that are currently being downloaded or haven been downloaded.
+     * List of videos that are currently being downloaded or have been downloaded.
      */
     private List<VideoModel> removableVideos = new ArrayList<>();
 
@@ -129,29 +133,28 @@ public class BulkDownloadFragment extends BaseFragment {
         ViewCompat.setImportantForAccessibility(binding.pbDownload, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO);
         ViewCompat.setImportantForAccessibility(binding.swDownload, ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_YES);
         initDownloadSwitch();
-        if (courseComponent != null) {
-            populateViewHolder(courseComponent);
+        if (totalDownloadableVideos != null && videosStatus.courseComponentId != null) {
+            populateViewHolder(videosStatus.courseComponentId, totalDownloadableVideos);
         }
     }
 
-    public void populateViewHolder(@NonNull CourseComponent courseComponent) {
-        this.courseComponent = courseComponent;
-        if (binding == null) return;
+    public void populateViewHolder(@NonNull String componentId,
+                                   @Nullable List<CourseComponent> downloadableVideos) {
+        videosStatus.reset();
+        this.totalDownloadableVideos = downloadableVideos;
+        videosStatus.courseComponentId = componentId;
+        if (binding == null || totalDownloadableVideos == null) return;
         remainingVideos.clear();
         removableVideos.clear();
-        videosStatus.reset();
-        videosStatus.courseId = courseComponent.getCourseId();
 
-        // Get all the videos of this course
-        final List<CourseComponent> allVideosInCourse = courseComponent.getVideos(true);
-        videosStatus.total = allVideosInCourse.size();
+        videosStatus.total = totalDownloadableVideos.size();
 
         // Get all the videos of this course from DB that we have downloaded or are downloading
-        environment.getDatabase().getAllVideosByCourse(courseComponent.getCourseId(),
+        environment.getDatabase().getVideosByVideoIds(totalDownloadableVideos, null,
                 new DataCallback<List<VideoModel>>() {
                     @Override
                     public void onResult(final List<VideoModel> result) {
-                        for (CourseComponent video : allVideosInCourse) {
+                        for (CourseComponent video : totalDownloadableVideos) {
                             boolean foundInDb = false;
                             for (VideoModel dbVideo : result) {
                                 if (video.getId().contentEquals(dbVideo.getVideoId())) {
@@ -193,6 +196,13 @@ public class BulkDownloadFragment extends BaseFragment {
                             }
                         }
 
+                        if (prefManager.getBulkDownloadSwitchState(videosStatus.courseComponentId)
+                                == SwitchState.USER_TURNED_ON && remainingVideos.size() > 0) {
+                            // It means that the switch was turned on by user but either a video was
+                            // deleted by user or a video download was cancelled.
+                            prefManager.setBulkDownloadSwitchState(SwitchState.DEFAULT, videosStatus.courseComponentId);
+                        }
+
                         binding.getRoot().post(new Runnable() {
                             @Override
                             public void run() {
@@ -216,7 +226,7 @@ public class BulkDownloadFragment extends BaseFragment {
     }
 
     private void updateUI() {
-        switchState = prefManager.getBulkDownloadSwitchState(videosStatus.courseId);
+        switchState = prefManager.getBulkDownloadSwitchState(videosStatus.courseComponentId);
 
         if (videosStatus.allVideosDownloaded()) {
             bgThreadHandler.removeCallbacks(PROGRESS_RUNNABLE);
@@ -231,12 +241,6 @@ public class BulkDownloadFragment extends BaseFragment {
             ViewCompat.setImportantForAccessibility(binding.getRoot(), ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO);
             setSwitchAccessibility(R.string.switch_on_all_downloaded);
         } else if (videosStatus.allVideosDownloading()) {
-            // This means that all the videos have been put to downloading without the use of Bulk Download switch
-            if (switchState == SwitchState.USER_TURNED_OFF && !isDeleteScheduled) {
-                switchState = SwitchState.USER_TURNED_ON;
-                prefManager.setBulkDownloadSwitchState(switchState, videosStatus.courseId);
-            }
-
             initDownloadProgressView();
 
             setViewState(FontAwesomeIcons.fa_spinner, Animation.PULSE, R.string.downloading_videos,
@@ -315,13 +319,21 @@ public class BulkDownloadFragment extends BaseFragment {
                 if (videosStatus.allVideosDownloading()) {
                     // Now that all videos have been enqueued to Download manager, enable the Switch and update its state
                     switchState = SwitchState.USER_TURNED_ON;
-                    prefManager.setBulkDownloadSwitchState(switchState, videosStatus.courseId);
+                    prefManager.setBulkDownloadSwitchState(switchState, videosStatus.courseComponentId);
                     setSwitchState();
                 }
                 break;
             case USER_TURNED_OFF:
                 binding.swDownload.setChecked(false);
                 binding.swDownload.setEnabled(true);
+                if ((videosStatus.allVideosDownloading() || videosStatus.allVideosDownloaded())
+                        && !isDeleteScheduled) {
+                    // This means that all the videos have been downloaded or they are currently
+                    // downloading without the use of Bulk Download switch
+                    switchState = SwitchState.USER_TURNED_ON;
+                    prefManager.setBulkDownloadSwitchState(switchState, videosStatus.courseComponentId);
+                    setSwitchState();
+                }
                 break;
             case DEFAULT:
                 binding.swDownload.setChecked(videosStatus.allVideosDownloaded() || videosStatus.allVideosDownloading());
@@ -331,8 +343,7 @@ public class BulkDownloadFragment extends BaseFragment {
     }
 
     private void setSwitchAccessibility(@StringRes int accessibilitySuffixStringRes) {
-        @StringRes
-        final int prefixStringRes = R.string.bulk_download_switch;
+        @StringRes final int prefixStringRes = R.string.bulk_download_switch;
         final Resources resources = binding.swDownload.getResources();
         binding.swDownload.setContentDescription(
                 resources.getString(prefixStringRes) + " " +
@@ -352,7 +363,7 @@ public class BulkDownloadFragment extends BaseFragment {
                     isDeleteScheduled = false;
 
                     switchState = SwitchState.IN_PROCESS;
-                    prefManager.setBulkDownloadSwitchState(switchState, videosStatus.courseId);
+                    prefManager.setBulkDownloadSwitchState(switchState, videosStatus.courseComponentId);
                     setSwitchState();
 
                     // Download all videos
@@ -364,17 +375,17 @@ public class BulkDownloadFragment extends BaseFragment {
                     }
 
                     environment.getAnalyticsRegistry().trackBulkDownloadSwitchOn(
-                            videosStatus.courseId, videosStatus.total, videosStatus.remaining);
+                            videosStatus.courseComponentId, videosStatus.total, videosStatus.remaining);
                 } else {
                     switchState = SwitchState.USER_TURNED_OFF;
-                    prefManager.setBulkDownloadSwitchState(switchState, videosStatus.courseId);
+                    prefManager.setBulkDownloadSwitchState(switchState, videosStatus.courseComponentId);
                     // Delete all videos after a delay
                     startVideosDeletion();
                     bgThreadHandler.removeCallbacks(PROGRESS_RUNNABLE);
                     updateUI();
 
                     environment.getAnalyticsRegistry().trackBulkDownloadSwitchOff(
-                            videosStatus.courseId, videosStatus.total);
+                            videosStatus.courseComponentId, videosStatus.total);
                 }
             }
         });
@@ -419,7 +430,7 @@ public class BulkDownloadFragment extends BaseFragment {
                     }
                 });
             } else {
-                environment.getStorage().getDownloadProgressOfCourseVideos(videosStatus.courseId,
+                environment.getStorage().getDownloadProgressOfVideos(totalDownloadableVideos,
                         new DataCallback<NativeDownloadModel>() {
                             @Override
                             public void onResult(final NativeDownloadModel downloadModel) {
@@ -436,7 +447,7 @@ public class BulkDownloadFragment extends BaseFragment {
                                     final int percentageDownloaded = DownloadUtil.getPercentDownloaded(
                                             videosStatus.totalVideosSize, videosStatus.totalVideosSize - remainingSizeToDownload);
 
-                                    if (videosStatus.allVideosDownloading()) {
+                                    if (videosStatus.allVideosDownloading() && remainingSizeToDownload > 0) {
                                         binding.pbDownload.post(new Runnable() {
                                             @Override
                                             public void run() {
@@ -464,7 +475,10 @@ public class BulkDownloadFragment extends BaseFragment {
     };
 
     /**
-     * @return
+     * Tells if this fragment is attached to an activity that's in foreground and all its class
+     * variables are non-null.
+     *
+     * @return <code>true</code> if the fragment is in a valid state, <code>false</code> otherwise.
      */
     private boolean isValidState() {
         return getActivity() != null && environment != null && downloadListener != null;
@@ -473,7 +487,6 @@ public class BulkDownloadFragment extends BaseFragment {
     @Override
     public void onStart() {
         super.onStart();
-        updateUI();
         EventBus.getDefault().register(this);
     }
 
@@ -484,10 +497,17 @@ public class BulkDownloadFragment extends BaseFragment {
         EventBus.getDefault().unregister(this);
     }
 
+    @Override
+    public void onRevisit() {
+        if (totalDownloadableVideos != null && videosStatus.courseComponentId != null) {
+            populateViewHolder(videosStatus.courseComponentId, totalDownloadableVideos);
+        }
+    }
+
     public void onEvent(BulkVideosDownloadCancelledEvent event) {
         binding.swDownload.setChecked(false);
         switchState = SwitchState.DEFAULT;
-        prefManager.setBulkDownloadSwitchState(switchState, videosStatus.courseId);
+        prefManager.setBulkDownloadSwitchState(switchState, videosStatus.courseComponentId);
         updateUI();
     }
 
@@ -497,7 +517,11 @@ public class BulkDownloadFragment extends BaseFragment {
     }
 
     private class CourseVideosStatus {
-        String courseId;
+        /**
+         * This might be the ID of the course itself or an ID of a component within the course
+         * e.g. a section, subsection, unit or a component.
+         */
+        String courseComponentId;
         int total;
         int downloaded;
         int downloading;
@@ -516,7 +540,7 @@ public class BulkDownloadFragment extends BaseFragment {
         void reset() {
             total = downloaded = downloading = remaining = 0;
             totalVideosSize = remainingVideosSize = 0;
-            courseId = null;
+            courseComponentId = null;
         }
 
         @SuppressLint("DefaultLocale")

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
@@ -243,7 +243,8 @@ public class BulkDownloadFragment extends BaseFragment {
         } else if (videosStatus.allVideosDownloading()) {
             initDownloadProgressView();
 
-            setViewState(FontAwesomeIcons.fa_spinner, Animation.PULSE, R.string.downloading_videos,
+            // TODO: Animation.PULSE causes lag when a spinner stays on screen for a while. Fix in LEARNER-5053
+            setViewState(FontAwesomeIcons.fa_spinner, Animation.SPIN, R.string.downloading_videos,
                     binding.tvSubtitle.getResources().getString(R.string.download_remaining),
                     "remaining_videos_count", videosStatus.remaining + "", "remaining_videos_size",
                     MemoryUtil.format(getContext(), videosStatus.remainingVideosSize));
@@ -257,7 +258,8 @@ public class BulkDownloadFragment extends BaseFragment {
             ViewCompat.setImportantForAccessibility(binding.getRoot(), ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_YES);
             setSwitchAccessibility(R.string.switch_on_all_downloading);
         } else if (switchState == SwitchState.IN_PROCESS) {
-            setViewState(FontAwesomeIcons.fa_spinner, Animation.PULSE, R.string.download_starting,
+            // TODO: Animation.PULSE causes lag when a spinner stays on screen for a while. Fix in LEARNER-5053
+            setViewState(FontAwesomeIcons.fa_spinner, Animation.SPIN, R.string.download_starting,
                     binding.tvSubtitle.getResources().getString(R.string.download_remaining),
                     "remaining_videos_count", videosStatus.remaining + "", "remaining_videos_size",
                     MemoryUtil.format(getContext(), videosStatus.remainingVideosSize));

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
@@ -401,6 +401,8 @@ public class BulkDownloadFragment extends BaseFragment {
     final Runnable DELETION_RUNNABLE = new Runnable() {
         @Override
         public void run() {
+            // Before starting deletion stop showing progress of downloads first
+            bgThreadHandler.removeCallbacks(PROGRESS_RUNNABLE);
             final int deleted = environment.getStorage().removeDownloads(removableVideos);
             isDeleteScheduled = false;
             logger.debug("TOTAL_VIDEOS: " + removableVideos.size() + " - DELETE_VIDEOS: " + deleted);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/NewCourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/NewCourseOutlineFragment.java
@@ -463,6 +463,9 @@ public class NewCourseOutlineFragment extends OfflineSupportBaseFragment
     public void onRevisit() {
         super.onRevisit();
         fetchLastAccessed();
+        if (adapter != null) {
+            adapter.notifyDataSetChanged();
+        }
     }
 
     public void fetchLastAccessed() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/NewCourseOutlineAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/NewCourseOutlineAdapter.java
@@ -605,7 +605,8 @@ public class NewCourseOutlineAdapter extends BaseAdapter {
         switch (state) {
             case DOWNLOADING:
                 row.bulkDownload.setIcon(FontAwesomeIcons.fa_spinner);
-                row.bulkDownload.setIconAnimation(Animation.PULSE);
+                // TODO: Animation.PULSE causes lag when a spinner stays on screen for a while. Fix in LEARNER-5053
+                row.bulkDownload.setIconAnimation(Animation.SPIN);
                 row.bulkDownload.setIconColorResource(R.color.edx_brand_primary_base);
                 break;
             case DOWNLOADED:

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/NewCourseOutlineAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/NewCourseOutlineAdapter.java
@@ -83,6 +83,7 @@ public class NewCourseOutlineAdapter extends BaseAdapter {
     private EnrolledCoursesResponse courseData;
     private DownloadListener downloadListener;
     private boolean isVideoMode;
+    private boolean isOnCourseOutline;
 
     public NewCourseOutlineAdapter(final Context context, Fragment fragment, final EnrolledCoursesResponse courseData,
                                    final IEdxEnvironment environment, DownloadListener listener,
@@ -96,26 +97,26 @@ public class NewCourseOutlineAdapter extends BaseAdapter {
         this.courseData = courseData;
         this.downloadListener = listener;
         this.isVideoMode = isVideoMode;
+        this.isOnCourseOutline = isOnCourseOutline;
         inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         adapterData = new ArrayList();
-        if (isOnCourseOutline) {
-            if (isVideoMode) {
-                // Add bulk video download item
-                adapterData.add(new SectionRow(SectionRow.BULK_DOWNLOAD, null));
-            } else {
-                // Add course card item
-                adapterData.add(new SectionRow(SectionRow.COURSE_CARD, null));
-                // Add certificate item
-                if (courseData.isCertificateEarned() && environment.getConfig().areCertificateLinksEnabled()) {
-                    adapterData.add(new SectionRow(SectionRow.COURSE_CERTIFICATE, null,
-                            new View.OnClickListener() {
-                                @Override
-                                public void onClick(View v) {
-                                    environment.getRouter().showCertificate(context, courseData);
-                                }
-                            }));
-                }
+        if (isOnCourseOutline && !isVideoMode) {
+            // Add course card item
+            adapterData.add(new SectionRow(SectionRow.COURSE_CARD, null));
+            // Add certificate item
+            if (courseData.isCertificateEarned() && environment.getConfig().areCertificateLinksEnabled()) {
+                adapterData.add(new SectionRow(SectionRow.COURSE_CERTIFICATE, null,
+                        new View.OnClickListener() {
+                            @Override
+                            public void onClick(View v) {
+                                environment.getRouter().showCertificate(context, courseData);
+                            }
+                        }));
             }
+        }
+        if (isVideoMode) {
+            // Add bulk video download item
+            adapterData.add(new SectionRow(SectionRow.BULK_DOWNLOAD, null));
         }
     }
 
@@ -223,7 +224,9 @@ public class NewCourseOutlineAdapter extends BaseAdapter {
             case SectionRow.BULK_DOWNLOAD: {
                 if (rootComponent != null) {
                     final BulkDownloadFragment fragment = (BulkDownloadFragment) convertView.getTag();
-                    fragment.populateViewHolder(rootComponent);
+                    fragment.populateViewHolder(
+                            isOnCourseOutline ? rootComponent.getCourseId() : rootComponent.getId(),
+                            rootComponent.getVideos(true));
                 }
                 return convertView;
             }
@@ -823,6 +826,8 @@ public class NewCourseOutlineAdapter extends BaseAdapter {
     public int getPositionByItemId(String itemId) {
         int size = getCount();
         for (int i = 0; i < size; i++) {
+            // Some items might not have a component assigned to them e.g. Bulk Download item
+            if (getItem(i).component == null) continue;
             if (getItem(i).component.getId().equals(itemId))
                 return i;
         }


### PR DESCRIPTION
### Description

[LEARNER-4160](https://openedx.atlassian.net/browse/LEARNER-4160)

- BulkDownloadFragment now accepts list of videos that need to be downloaded in bulk and maintains its state accordingly.
- Database layer has been updated to give back videos based on video ids provided to it.
- Fixed a case when 0.00 B was being shown on Bulk Download view.
- Handle download canceling from outside the app.
- Switch from PULSE animation to SPIN

#### Note

Also fixes [LEARNER-4840](https://openedx.atlassian.net/browse/LEARNER-4840).