### PR TITLE
Make HttpStatusException more meaningful

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/HttpStatusException.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/HttpStatusException.java
@@ -17,6 +17,8 @@ public class HttpStatusException extends Exception {
      * @param response The error response.
      */
     public HttpStatusException(@NonNull final Response response) {
+        // Populate the message argument of the parent exception with all the response data we have
+        super(response.toString());
         this.response = response;
     }
 


### PR DESCRIPTION
### Description

[LEARNER-2489](https://openedx.atlassian.net/browse/LEARNER-2489)

By the calling the Exception class's constructor (requiring a String arg) with the response provided to HttpStatusException, we are essentially making the exception object more meaningful with the Http call's response details.

This will ultimately help us in identifying what caused a server call to fail on Crashlytics.