### PR TITLE
Update Travis config to run builds on all Pull Requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ after_script:
 
 branches:
   only:
-    - /.*/
+    - master
 
 # Enable caching to speed up the build
 cache:
@@ -74,11 +74,11 @@ before_install:
 sudo: required
 after_success:
   - codecov
-  - if [ $TRAVIS_BRANCH == "master" ]; then
-      pip install virtualenv;
-      virtualenv ~/env;
-      source ~/env/bin/activate;
-      pip install transifex-client;
-      sudo echo $'[https://www.transifex.com]\nhostname = https://www.transifex.com\nusername = '"$TRANSIFEX_USER"$'\npassword = '"$TRANSIFEX_PASSWORD"$'\ntoken = '"$TRANSIFEX_API_TOKEN"$'\n' > ~/.transifexrc;
-      tx push --source --no-interactive;
-      fi
+  - pip install virtualenv
+  - virtualenv ~/env
+  - source ~/env/bin/activate
+  # Install Transifex client and push strings to Transifex
+  # Reference: https://docs.transifex.com/integrations/github#section-integrating-with-travis-ci
+  - pip install transifex-client
+  - sudo echo $'[https://www.transifex.com]\nhostname = https://www.transifex.com\nusername = '"$TRANSIFEX_USER"$'\npassword = '"$TRANSIFEX_PASSWORD"$'\ntoken = '"$TRANSIFEX_API_TOKEN"$'\n' > ~/.transifexrc
+  - tx push --source --no-interactive


### PR DESCRIPTION
### Description

[LEARNER-4338](https://openedx.atlassian.net/browse/LEARNER-4338)

Reverts: [LEARNER-2367](https://openedx.atlassian.net/browse/LEARNER-2367) (PR https://github.com/edx/edx-app-android/pull/997)

Due to this change, Travis will checkout current master and put all of the changes done in a PR on top of it through a commit and run tests on it. This will be valid for all PRs i.e. internal and externals (OSPRs).

**Note: Following change in Travis's setting has also been done:**

Before | After
--- | ---
<img width="549" alt="screen shot 2018-05-17 at 2 30 28 pm" src="https://user-images.githubusercontent.com/1710804/40170441-e7ea9284-59e1-11e8-9aae-cebddec11111.png"> | <img width="547" alt="screen shot 2018-05-17 at 2 29 50 pm" src="https://user-images.githubusercontent.com/1710804/40170447-ebe0831c-59e1-11e8-9a82-5bf4389b5025.png">


