### PR TITLE
LEARNER-4793 - Remove problematic check which was causing the issues.

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
@@ -48,8 +48,6 @@ import java.util.Map;
 
 import de.greenrobot.event.EventBus;
 
-import static org.edx.mobile.util.DownloadUtil.isDownloadSizeWithinLimit;
-
 public class BulkDownloadFragment extends BaseFragment {
     protected final Logger logger = new Logger(getClass().getName());
 
@@ -370,11 +368,6 @@ public class BulkDownloadFragment extends BaseFragment {
 
                     // Download all videos
                     downloadListener.download(remainingVideos);
-                    // Video download process on bulk download view needs to be delayed when the
-                    // confirmation dialog for videos' size above 1 GB is shown.
-                    if (isDownloadSizeWithinLimit(videosStatus.remainingVideosSize, MemoryUtil.GB)) {
-                        onEvent((BulkVideosDownloadStartedEvent) null);
-                    }
 
                     environment.getAnalyticsRegistry().trackBulkDownloadSwitchOn(
                             videosStatus.courseComponentId, videosStatus.total, videosStatus.remaining);


### PR DESCRIPTION
[LEARNER-4793](https://openedx.atlassian.net/browse/LEARNER-4793)

### Description

Remove problematic check which was causing the issues.
Due to the this check there were possible scenarios in which user tried to start bulk download but it didn’t get actually started due to no internet connectivity or other reason and we were still firing the
‘BulkVideosDownloadStartedEvent’ event.
