### PR TITLE
Decode HTML entities in Video Transcripts

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
@@ -55,6 +55,7 @@ import org.edx.mobile.util.BrowserUtil;
 import org.edx.mobile.util.DeviceSettingUtil;
 import org.edx.mobile.util.NetworkUtil;
 import org.edx.mobile.util.OrientationDetector;
+import org.edx.mobile.util.TextUtils;
 import org.edx.mobile.util.UiUtil;
 import org.edx.mobile.util.Version;
 import org.edx.mobile.view.dialog.CCLanguageDialogFragment;
@@ -1285,7 +1286,7 @@ public class PlayerFragment extends BaseFragment implements IPlayerListener, Ser
                     if(temp.length()==0){
                         subTitlesTv.setVisibility(View.GONE);
                     }else{
-                        subTitlesTv.setText(temp);
+                        subTitlesTv.setText(TextUtils.formatHtml(temp));
                         subTitlesTv.setVisibility(View.VISIBLE);
                     }
                 }else{

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/TextUtils.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/TextUtils.java
@@ -3,15 +3,18 @@ package org.edx.mobile.util;
 import android.content.res.Resources;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
+import android.text.Html;
 import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
+import android.text.SpannedString;
 import android.text.style.URLSpan;
 
 import org.edx.mobile.R;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static org.edx.mobile.view.dialog.WebViewActivity.PARAM_INTENT_FILE_LINK;
 
@@ -94,5 +97,40 @@ public class TextUtils {
         keyValMap.put("privacy_policy", privacyPolicySpan);
 
         return ResourceUtil.getFormattedString(resources, licenseTextId, keyValMap);
+    }
+
+    /**
+     * Returns displayable styled text from the provided HTML string.
+     * <br/>
+     * Note: Also handles the case when a String has multiple HTML entities that translate to one
+     * character e.g. {@literal &amp;#39;} which is essentially an apostrophe that should normally
+     * occur as {@literal &#39;}
+     *
+     * @param html The source string having HTML content.
+     * @return Formatted HTML.
+     */
+    @NonNull
+    public static Spanned formatHtml(@NonNull String html) {
+        final String REGEX = "(&#?[a-zA-Z0-9]+;)";
+        final Pattern PATTERN = Pattern.compile(REGEX);
+
+        Spanned formattedHtml = new SpannedString(html);
+        String previousHtml = null;
+
+        // Break the loop if there isn't an HTML entity in the text or when all the HTML entities
+        // have been decoded. Also break the loop in the special case when a String having the
+        // same format as an HTML entity is left but it isn't essentially a decodable HTML entity
+        // e.g. &#asdfasd;
+        while (PATTERN.matcher(html).find() && !html.equals(previousHtml)) {
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                formattedHtml = Html.fromHtml(html, Html.FROM_HTML_MODE_LEGACY);
+            } else {
+                formattedHtml = Html.fromHtml(html);
+            }
+            previousHtml = html;
+            html = formattedHtml.toString();
+        }
+
+        return formattedHtml;
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/TranscriptAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/TranscriptAdapter.java
@@ -12,6 +12,7 @@ import com.google.inject.Inject;
 
 import org.edx.mobile.R;
 import org.edx.mobile.core.IEdxEnvironment;
+import org.edx.mobile.util.TextUtils;
 
 import subtitleFile.Caption;
 
@@ -33,7 +34,7 @@ public class TranscriptAdapter extends BaseListAdapter<Caption> {
         if (captionText.endsWith("<br />")) {
             captionText = captionText.substring(0, captionText.length() - 6);
         }
-        viewHolder.transcriptTv.setText(captionText);
+        viewHolder.transcriptTv.setText(TextUtils.formatHtml(captionText));
         final int position = getPosition(model);
         if (isSelected(position)) {
             viewHolder.transcriptTv.setTextColor(SELECTED_TRANSCRIPT_COLOR);


### PR DESCRIPTION
### Description

[LEARNER-5190](https://openedx.atlassian.net/browse/LEARNER-5190)

Before | After
-- | --
<img width="400" src="https://user-images.githubusercontent.com/1710804/40353148-36528288-5dca-11e8-80e0-786e3a78cfd2.png" /> | <img width="400" src="https://user-images.githubusercontent.com/1710804/40353161-3dd5f332-5dca-11e8-9eb2-bac889f45e0d.png" />

**NOTE:** For now, we aren't handling the case where the server sends multiple HTML entities for representing a single character i.e. `&amp;#39;` for an apostrophe. More details  about it can be found here:
https://openedx.atlassian.net/browse/LEARNER-506?focusedCommentId=321093&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-321093

⬆️ **The case has been handled in the commit #** 476f101.

### Extra

Great site to look for HTML entities:
https://www.rapidtables.com/web/html/html-codes.html