### PR TITLE
Add TLS 1.2 protocol to SSL connections

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -157,6 +157,9 @@ dependencies {
     compile 'com.android.support:multidex:1.0.1'
     compile 'com.android.support.constraint:constraint-layout:1.0.2'
     compile 'com.github.bumptech.glide:glide:3.7.0'
+    compile ('com.github.bumptech.glide:okhttp3-integration:1.4.0'){
+        exclude group: 'glide-parent'
+    }
     compile 'de.hdodenhof:circleimageview:2.0.0'
     compile 'uk.co.chrisjenx:calligraphy:2.1.0'
     // Branch SDK

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -9,6 +9,9 @@ import android.net.wifi.WifiManager;
 import android.support.annotation.NonNull;
 import android.support.multidex.MultiDexApplication;
 
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.integration.okhttp3.OkHttpUrlLoader;
+import com.bumptech.glide.load.model.GlideUrl;
 import com.crashlytics.android.core.CrashlyticsCore;
 import com.google.inject.Injector;
 import com.google.inject.Module;
@@ -22,6 +25,7 @@ import org.edx.mobile.core.EdxDefaultModule;
 import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.event.AppUpdatedEvent;
 import org.edx.mobile.event.NewRelicEvent;
+import org.edx.mobile.http.provider.OkHttpClientProvider;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.module.analytics.AnalyticsRegistry;
 import org.edx.mobile.module.analytics.AnswersAnalytics;
@@ -32,6 +36,8 @@ import org.edx.mobile.module.storage.IStorage;
 import org.edx.mobile.receivers.NetworkConnectivityReceiver;
 import org.edx.mobile.util.Config;
 import org.edx.mobile.util.NetworkUtil;
+
+import java.io.InputStream;
 
 import javax.inject.Inject;
 
@@ -139,6 +145,11 @@ public abstract class MainApplication extends MultiDexApplication {
         if (Config.FabricBranchConfig.isBranchEnabled(config.getFabricConfig())) {
             Branch.getAutoInstance(this);
         }
+
+        // Force Glide to use our version of OkHttp which now supports TLS 1.2 out-of-the-box for
+        // Pre-Lollipop devices
+        Glide.get(this).register(GlideUrl.class, InputStream.class,
+                new OkHttpUrlLoader.Factory(injector.getInstance(OkHttpClientProvider.class).get()));
     }
 
     private void checkIfAppVersionUpgraded(Context context) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/provider/OkHttpClientProvider.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/provider/OkHttpClientProvider.java
@@ -18,6 +18,7 @@ import org.edx.mobile.http.authenticator.OauthRefreshTokenAuthenticator;
 import org.edx.mobile.http.interceptor.StaleIfErrorHandlingInterceptor;
 import org.edx.mobile.http.interceptor.StaleIfErrorInterceptor;
 import org.edx.mobile.http.interceptor.UserAgentInterceptor;
+import org.edx.mobile.http.util.Tls12SocketFactory;
 
 import java.io.File;
 import java.util.List;
@@ -98,7 +99,8 @@ public interface OkHttpClientProvider extends Provider<OkHttpClient> {
                     interceptors.add(loggingInterceptor);
                 }
                 builder.authenticator(new OauthRefreshTokenAuthenticator(context));
-                client = builder.build();
+                // Enable TLS 1.2 support
+                client = Tls12SocketFactory.enableTls12OnPreLollipop(builder).build();
                 clients[index] = client;
             }
             return client;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/util/Tls12SocketFactory.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/util/Tls12SocketFactory.java
@@ -1,0 +1,121 @@
+package org.edx.mobile.http.util;
+
+import android.os.Build;
+
+import org.edx.mobile.logger.Logger;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+import okhttp3.ConnectionSpec;
+import okhttp3.OkHttpClient;
+import okhttp3.TlsVersion;
+
+/**
+ * Enables TLS v1.2 when creating SSLSockets.
+ * <p/>
+ * For some reason, android supports TLS v1.2 from API 16, but enables it by
+ * default only from API 20.
+ * <p/>
+ * Note: This class has been copied from OkHttp's official
+ * <a href="https://github.com/square/okhttp/issues/2372#issuecomment-244807676">GitHub Issues page.</a>
+ * <br/>
+ *
+ * @link https://developer.android.com/reference/javax/net/ssl/SSLSocket.html
+ * @see SSLSocketFactory
+ */
+public class Tls12SocketFactory extends SSLSocketFactory {
+    private static final Logger logger = new Logger(Tls12SocketFactory.class);
+    private static final String[] TLS_V12_ONLY = {"TLSv1.2"};
+
+    private final SSLSocketFactory delegate;
+
+    public Tls12SocketFactory(SSLSocketFactory base) {
+        this.delegate = base;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return delegate.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return delegate.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return patch(delegate.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+        return patch(delegate.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return patch(delegate.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket patch(Socket s) {
+        if (s instanceof SSLSocket) {
+            ((SSLSocket) s).setEnabledProtocols(TLS_V12_ONLY);
+        }
+        return s;
+    }
+
+    /**
+     * Enables TLS v1.2 protocol on Pre-Lollipop devices for server sockets.
+     *
+     * @param client The builder object of OkHttpClient.
+     * @return Updated builder object of OkHttpClient with TLS v1.2 enabled on it.
+     */
+    public static OkHttpClient.Builder enableTls12OnPreLollipop(OkHttpClient.Builder client) {
+        if (Build.VERSION.SDK_INT >= 16 && Build.VERSION.SDK_INT < 22) {
+            try {
+                final SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+                sslContext.init(null, null, null);
+                client.sslSocketFactory(new Tls12SocketFactory(sslContext.getSocketFactory()));
+
+                final ConnectionSpec connectionSpec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                        .tlsVersions(TlsVersion.TLS_1_2)
+                        .build();
+
+                final List<ConnectionSpec> specs = new ArrayList<>();
+                specs.add(connectionSpec);
+                specs.add(ConnectionSpec.COMPATIBLE_TLS);
+                specs.add(ConnectionSpec.CLEARTEXT);
+
+                client.connectionSpecs(specs);
+            } catch (NoSuchAlgorithmException e) {
+                logger.error(e);
+            } catch (KeyManagementException e) {
+                logger.error(e);
+            }
+        }
+
+        return client;
+    }
+}


### PR DESCRIPTION
### Description

[LEARNER-5406](https://openedx.atlassian.net/browse/LEARNER-5406)

Add TLS 1.2 protocol to SSL connections for OS versions below 5.0 i.e. below Android Lollipop

FYI @staubina this solves the problem.