### PR TITLE
Hotfix Release 2.14.1

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -265,8 +265,8 @@ android {
 
     defaultConfig {
         applicationId "org.edx.mobile"
-        // minimum version is Android 4.0
-        minSdkVersion 14
+        // minimum version is Android 4.1
+        minSdkVersion 16
         targetSdkVersion 21
 
         versionCode getVersionCode()

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.wifi.WifiManager;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.multidex.MultiDexApplication;
 
@@ -148,8 +149,10 @@ public abstract class MainApplication extends MultiDexApplication {
 
         // Force Glide to use our version of OkHttp which now supports TLS 1.2 out-of-the-box for
         // Pre-Lollipop devices
-        Glide.get(this).register(GlideUrl.class, InputStream.class,
-                new OkHttpUrlLoader.Factory(injector.getInstance(OkHttpClientProvider.class).get()));
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            Glide.get(this).register(GlideUrl.class, InputStream.class,
+                    new OkHttpUrlLoader.Factory(injector.getInstance(OkHttpClientProvider.class).get()));
+        }
     }
 
     private void checkIfAppVersionUpgraded(Context context) {


### PR DESCRIPTION
### Description

[LEARNER-5430](https://openedx.atlassian.net/browse/LEARNER-5430)

- Support TLS 1.2 on Pre-lollipop devices
- Force Glide to use our version of OkHttp only on Pre-lollipop devices
- Bump minSdkVersion from 14 to 16