### PR TITLE
Discussions - Resolve comment text cut issue

### DIFF
--- a/OpenEdXMobile/res/layout/row_discussion_comments_response.xml
+++ b/OpenEdXMobile/res/layout/row_discussion_comments_response.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -20,32 +19,20 @@
         android:orientation="vertical"
         android:padding="@dimen/discussion_responses_box_padding">
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <include layout="@layout/row_discussion_user_profile" />
-
-            <Space
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:layout_weight="1" />
-
-            <TextView
-                android:id="@+id/discussion_comment_count_report_text_view"
-                style="@style/discussion_responses_small_text"
-                android:layout_gravity="end"
-                android:background="?android:selectableItemBackground"
-                android:clickable="true"
-                android:padding="@dimen/discussion_responses_box_padding"
-                tools:text="8 comments" />
-
-        </LinearLayout>
+        <include layout="@layout/row_discussion_user_profile" />
 
         <TextView
             android:id="@+id/discussion_comment_body"
             style="@style/discussion_regular_text"
             tools:text="This is the text of a response." />
+
+        <TextView
+            android:id="@+id/discussion_comment_count_report_text_view"
+            style="@style/discussion_responses_small_text"
+            android:layout_gravity="end|right"
+            android:background="?android:selectableItemBackground"
+            android:clickable="true"
+            android:padding="@dimen/discussion_responses_box_padding"
+            tools:text="8 comments" />
     </LinearLayout>
 </android.support.v7.widget.CardView>


### PR DESCRIPTION
## Description

[MA-2673](https://openedx.atlassian.net/browse/MA-2673)

when the username was large then comment text used to be cut and did not show complete text so by placing text at bottom resolve the issue because it was not fit in a single row with username 
