### PR TITLE
Update Enroll Now Button Message for Professional Education Courses

### DIFF
--- a/OpenEdXMobile/res/values/errors.xml
+++ b/OpenEdXMobile/res/values/errors.xml
@@ -7,6 +7,10 @@
     <!-- Course related error messages -->
     <!-- Error shown when a course's content is invalid or not in the format that we expect -->
     <string name="course_error_content_invalid" tools:ignore="MissingTranslation">Unable to load course content. Try again later.</string>
+    <!-- Title of alert shown when course enrollment request fails -->
+    <string name="enrollment_error_title" tools:ignore="MissingTranslation">Enrollment Error</string>
+    <!-- Error message shown in alert when course enrollment request fails -->
+    <string name="enrollment_error_message" tools:ignore="MissingTranslation">We are unable to enroll you in this course at this time using the {platform_name} mobile application. Please try again on your web browser.</string>
 
     <!-- Network error messages -->
     <!-- Error shown when  user attempts an action but needs an internet connection -->

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseWebViewFindCoursesActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseWebViewFindCoursesActivity.java
@@ -31,6 +31,7 @@ import org.edx.mobile.http.notifications.FullScreenErrorNotification;
 import org.edx.mobile.http.provider.OkHttpClientProvider;
 import org.edx.mobile.interfaces.WebViewStatusListener;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
+import org.edx.mobile.util.ResourceUtil;
 import org.edx.mobile.util.WebViewUtil;
 import org.edx.mobile.view.common.TaskProgressCallback;
 import org.edx.mobile.view.custom.EdxWebView;
@@ -235,7 +236,16 @@ public abstract class BaseWebViewFindCoursesActivity extends BaseFragmentActivit
                     protected void onFailure(@NonNull Throwable error) {
                         isTaskInProgress = false;
                         logger.debug("Error during enroll api call");
-                        showEnrollErrorMessage(courseId, emailOptIn);
+
+                        if (error instanceof HttpStatusException &&
+                                ((HttpStatusException) error).getStatusCode() == HttpStatus.BAD_REQUEST) {
+                            final HashMap<String, CharSequence> params = new HashMap<>();
+                            params.put("platform_name", environment.getConfig().getPlatformName());
+                            final CharSequence message = ResourceUtil.getFormattedString(getResources(), R.string.enrollment_error_message, params);
+                            showAlertDialog(getString(R.string.enrollment_error_title), message.toString());
+                        } else {
+                            showEnrollErrorMessage(courseId, emailOptIn);
+                        }
                     }
                 });
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseWebViewFindCoursesActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseWebViewFindCoursesActivity.java
@@ -61,6 +61,7 @@ public abstract class BaseWebViewFindCoursesActivity extends BaseFragmentActivit
     private boolean lastClickEnrollEmailOptIn;
 
     private FullScreenErrorNotification errorNotification;
+    private URLInterceptorWebViewClient client;
 
     @Inject
     private CourseService courseService;
@@ -115,7 +116,7 @@ public abstract class BaseWebViewFindCoursesActivity extends BaseFragmentActivit
     }
 
     private void setupWebView() {
-        URLInterceptorWebViewClient client = new URLInterceptorWebViewClient(this, webView);
+        client = new URLInterceptorWebViewClient(this, webView);
 
         // if all the links are to be treated as external
         client.setAllLinksAsExternal(isAllLinksExternal());
@@ -130,6 +131,9 @@ public abstract class BaseWebViewFindCoursesActivity extends BaseFragmentActivit
      * @param url The URL to load.
      */
     protected void loadUrl(@NonNull String url) {
+        if (client != null) {
+            client.setLoadingInitialUrl(true);
+        }
         WebViewUtil.loadUrlBasedOnOsVersion(this, webView, url, this, errorNotification, okHttpClientProvider);
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
@@ -45,6 +45,21 @@ public class URLInterceptorWebViewClient extends WebViewClient {
     private IPageStatusListener pageStatusListener;
     private String hostForThisPage = null;
 
+    /**
+     * Tells if the page loading has been finished or not.
+     */
+    private boolean loadingFinished = true;
+    /**
+     * Url will be considered as redirected if it will not be the initial page url requested to load.
+     * For example, in case the server redirects us to another URL or the user clicks a link
+     * on the web-page, it will be considered as a redirect.
+     */
+    private boolean redirect = false;
+    /**
+     * Tells if the currently loading url is the initial page url requested to load.
+     */
+    private boolean loadingInitialUrl = true;
+
     @Inject
     Config config;
     /*
@@ -89,6 +104,14 @@ public class URLInterceptorWebViewClient extends WebViewClient {
         //We need to hide the loading progress if the Page starts rendering.
         webView.setWebChromeClient(new WebChromeClient() {
             public void onProgressChanged(WebView view, int progress) {
+                if (progress > 25) {
+                    /*
+                     * 'loadingInitialUrl is marked to false on 25% progress of initial page load
+                     * to avoid any problematic scenarios e.g. user presses some link available on
+                     * a web page before 'onPageFinished' has been called.
+                     */
+                    loadingInitialUrl = false;
+                }
                 if (progress > 50) {
                     if (pageStatusListener != null) {
                         pageStatusListener.onPagePartiallyLoaded();
@@ -101,6 +124,8 @@ public class URLInterceptorWebViewClient extends WebViewClient {
     @Override
     public void onPageStarted(WebView view, String url, Bitmap favicon) {
         super.onPageStarted(view, url, favicon);
+
+        loadingFinished = false;
 
         // hold on the host of this page, just once
         if (this.hostForThisPage == null && url != null) {
@@ -116,6 +141,13 @@ public class URLInterceptorWebViewClient extends WebViewClient {
     public void onPageFinished(WebView view, String url) {
         super.onPageFinished(view, url);
 
+        loadingInitialUrl = false;
+        if (!redirect) {
+            loadingFinished = true;
+        }
+        redirect = false;
+
+        // Page loading has finished.
         if (pageStatusListener != null) {
             pageStatusListener.onPageFinished();
         }
@@ -141,6 +173,11 @@ public class URLInterceptorWebViewClient extends WebViewClient {
 
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
+        if (!loadingFinished) {
+            redirect = true;
+        }
+        loadingFinished = false;
+
         if (actionListener == null) {
             logger.warn("you have not set IActionLister to this WebViewClient, " +
                     "you might miss some event");
@@ -152,6 +189,13 @@ public class URLInterceptorWebViewClient extends WebViewClient {
         } else if (parseEnrollLinkAndCallActionListener(url)) {
             // we handled this URL
             return true;
+        } else if (redirect && loadingInitialUrl) {
+            // Server has redirected the initial url to other hosting url, in this case no need to
+            // redirect the user to external browser.
+            // Inspiration of this solution has been taken from: https://stackoverflow.com/questions/3149216/how-to-listen-for-a-webview-finishing-loading-a-url/5172952#5172952
+            loadingInitialUrl = false;
+            // Return false means the current WebView handles the url.
+            return false;
         } else if (isAllLinksExternal || isExternalLink(url)) {
             // open URL in external web browser
             // return true means the host application handles the url
@@ -166,6 +210,10 @@ public class URLInterceptorWebViewClient extends WebViewClient {
 
     public void setAllLinksAsExternal(boolean isAllLinksExternal) {
         this.isAllLinksExternal = isAllLinksExternal;
+    }
+
+    public void setLoadingInitialUrl(boolean isLoadingInitialUrl) {
+        this.loadingInitialUrl = isLoadingInitialUrl;
     }
 
     @Override


### PR DESCRIPTION
### Description

[LEARNER-4643](https://openedx.atlassian.net/browse/LEARNER-4643)

Please refer to Jira story for the changes implemented int the PR.
Following issue has also been fixed in the PR.

### Issue
In some of the cases server redirects the page url to other hosting url, we have screens in our app for e.x. Course Detail, Announcements where we are only allowing page urls to render and redirect all other urls to external browser. In these specific cases our page url is rendering in external browser due to server side redirection. 

### Solution
If it will be the redirection from server side within initial page url loading, it will be render within the app.

### Testing
- It must be tested on above and below Marshmallow OS separately.
- Issue fix in done in the common client interceptor used in the code, so whole app web pages should be tested properly.
- App should load all the internal urls withing the app.
- App should load all the external urls to external browser.
