### PR TITLE
Ignore the logging of branch sdk errors occurred due to no internet.

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/SplashActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/SplashActivity.java
@@ -8,6 +8,7 @@ import org.edx.mobile.base.MainApplication;
 import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.util.Config;
+import org.edx.mobile.util.NetworkUtil;
 import org.json.JSONObject;
 
 import io.branch.referral.Branch;
@@ -61,8 +62,11 @@ public class SplashActivity extends Activity {
                         // params are the deep linked params associated with the link that the user
                         // clicked -> was re-directed to this app params will be empty if no data found
                     } else {
-                        logger.error(new Exception("Branch not configured properly, error:\n"
-                                + error.getMessage()), true);
+                        // Ignore the logging of errors occurred due to lack of network connectivity
+                        if (NetworkUtil.isConnected(getApplicationContext())) {
+                            logger.error(new Exception("Branch not configured properly, error:\n"
+                                    + error.getMessage()), true);
+                        }
                     }
                 }
             }, this.getIntent().getData(), this);


### PR DESCRIPTION
### Description

[LEARNER-4839](https://openedx.atlassian.net/browse/LEARNER-4839)

Please refer to Jira Story and Crashlytics for more details of internet connectivity error avoided to log in this PR.
