### PR TITLE
User Profile Screen | Crash Fix

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/PresenterFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/PresenterFragment.java
@@ -25,7 +25,6 @@ public abstract class PresenterFragment<P extends Presenter<V>, V> extends BaseF
     @Override
     @CallSuper
     public void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
         if(getParentFragment() == null) {
             // retain instance is inherited through the fragment tree
             // so don't need it for fragments with parents
@@ -40,6 +39,9 @@ public abstract class PresenterFragment<P extends Presenter<V>, V> extends BaseF
                 presenter = createPresenter();
             }
         }
+        // We are having life cycle issues/crash in low memory case when this fragment recreates.
+        // To fix that, its better to call super.onCreate() once the presenter is created. Ref: LEARNER-2519.
+        super.onCreate(savedInstanceState);
     }
 
     @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/StaticFragmentPagerAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/StaticFragmentPagerAdapter.java
@@ -25,8 +25,14 @@ public class StaticFragmentPagerAdapter extends FragmentPagerAdapter {
     @NonNull
     private final Map<Integer, Fragment> positionToFragment = new HashMap<>();
 
-    public StaticFragmentPagerAdapter(@NonNull FragmentManager manager, @NonNull FragmentItemModel... items) {
+    private FragmentLifecycleCallbacks fragmentLifecycleCallbacks;
+    public interface FragmentLifecycleCallbacks {
+        void onFragmentInstantiate();
+    }
+
+    public StaticFragmentPagerAdapter(@NonNull FragmentManager manager, FragmentLifecycleCallbacks fragmentLifecycleCallbacks, @NonNull FragmentItemModel... items) {
         super(manager);
+        this.fragmentLifecycleCallbacks = fragmentLifecycleCallbacks;
         setItems(Arrays.asList(items));
     }
 
@@ -58,6 +64,9 @@ public class StaticFragmentPagerAdapter extends FragmentPagerAdapter {
     public Fragment instantiateItem(ViewGroup container, int position) {
         final Fragment fragment = (Fragment)super.instantiateItem(container, position);
         positionToFragment.put(position, fragment);
+        if (fragmentLifecycleCallbacks != null) {
+            fragmentLifecycleCallbacks.onFragmentInstantiate();
+        }
         return fragment;
     }
 


### PR DESCRIPTION
[LEARNER-2519](https://openedx.atlassian.net/browse/LEARNER-2519)

when user mobile phone is at low memory then if user is on User Profile Screen and press home button then on return back by pressing home button app crash moreover if user go edit section and then press back it also crash on low memory this can be achived by enabling Don't keep activities in Developer Options 
Now this issue resolved

@miankhalid  @farhan 