### PR TITLE
Add Find a Course footer properly

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.java
@@ -149,10 +149,10 @@ public class MyCoursesListFragment extends OfflineSupportBaseFragment
             updateDatabaseAfterDownload(newItems);
 
             if (result.getResult().size() > 0) {
-                addFindCoursesFooter();
                 adapter.setItems(newItems);
-                adapter.notifyDataSetChanged();
             }
+            addFindCoursesFooter();
+            adapter.notifyDataSetChanged();
 
             if (adapter.isEmpty() && !environment.getConfig().getCourseDiscoveryConfig().isCourseDiscoveryEnabled()) {
                 errorNotification.showError(R.string.no_courses_to_display,


### PR DESCRIPTION
### Description

[LEARNER-5785](https://openedx.atlassian.net/browse/LEARNER-5785)

Find a Course is now added even when the user doesn't have enrolled in any course.