### PR TITLE
Update video completion status on server

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseAPI.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseAPI.java
@@ -42,6 +42,7 @@ import org.edx.mobile.model.course.VideoInfo;
 import org.edx.mobile.module.prefs.UserPrefs;
 import org.edx.mobile.util.Config;
 import org.edx.mobile.view.common.TaskProgressCallback;
+import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -90,6 +91,14 @@ public class CourseAPI {
     @NonNull
     public Call<List<EnrolledCoursesResponse>> getEnrolledCourses() {
         return courseService.getEnrolledCourses(getUsername(), config.getOrganizationCode());
+    }
+
+    /**
+     * @return Server response on video completion.
+     */
+    @NonNull
+    public Call<JSONObject> markBlocksCompletion(@NonNull String courseId, @NonNull String[] blockIds) {
+        return courseService.markBlocksCompletion(new CourseService.BlocksCompletionBody(getUsername(), courseId, blockIds));
     }
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseService.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseService.java
@@ -15,8 +15,10 @@ import org.edx.mobile.model.api.SyncLastAccessedSubsectionResponse;
 import org.edx.mobile.model.api.VideoResponseModel;
 import org.edx.mobile.model.course.CourseStructureV1Model;
 import org.edx.mobile.view.common.TaskProgressCallback;
+import org.json.JSONObject;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 
 import de.greenrobot.event.EventBus;
@@ -126,6 +128,23 @@ public interface CourseService {
             @Header("Cache-Control") String cacheControlHeaderParam,
             @Query("username") final String username,
             @Query("course_id") final String courseId);
+
+    @POST("/api/completion/v1/completion-batch")
+    Call<JSONObject> markBlocksCompletion(@Body BlocksCompletionBody completionBody);
+
+    final class BlocksCompletionBody {
+        @NonNull String username;
+        @NonNull String courseKey;
+        @NonNull HashMap<String, String> blocks = new HashMap<>();
+
+        public BlocksCompletionBody(@NonNull String username, @NonNull String courseKey, @NonNull String[] blockIds) {
+            this.username = username;
+            this.courseKey = courseKey;
+            for (int index = 0; index < blockIds.length; index++) {
+                blocks.put(blockIds[index], "1");
+            }
+        }
+    }
 
     final class SyncLastAccessedSubsectionBody {
         @NonNull


### PR DESCRIPTION
Apps do not read progress for all the mobile accessible courses videos implemented

### Description

[LEARNER-5783](https://openedx.atlassian.net/browse/LEARNER-5783)

when user complete video fom mobile then there are no call to server to update their progress to watch video completly now this issue resolved