### PR TITLE
Remove unnecessary permission READ_PHONE_STATE

### DIFF
--- a/OpenEdXMobile/AndroidManifest.xml
+++ b/OpenEdXMobile/AndroidManifest.xml
@@ -22,9 +22,6 @@
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
 
-    <!-- Required by app for TelephonyManager to determine mobile network carrier ID -->
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-
     <!-- Sticky broadcast passing a message from one screen and display on another -->
     <uses-permission android:name="android.permission.BROADCAST_STICKY" />
 


### PR DESCRIPTION
### Description

[LEARNER-5919](https://openedx.atlassian.net/browse/LEARNER-5919)

Currently, we are only using the TelephonyManager class's `getNetworkOperator` function which doesn't require the `android.permission.READ_PHONE_STATE permission`.

**Usage in code: org/edx/mobile/util/NetworkUtil.java:99**