### PR TITLE
fix bug: download button is worng when run on android 7.0

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/download/IDownloadManagerImpl.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/download/IDownloadManagerImpl.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -47,8 +48,17 @@ public class IDownloadManagerImpl implements IDownloadManager {
                                 .getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR));
                 long size = c.getLong(c
                         .getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES));
-                String filepath = c.getString(c
-                        .getColumnIndex(DownloadManager.COLUMN_LOCAL_FILENAME));
+                int fileUriIdx = c.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI);
+                String fileUri = c.getString(fileUriIdx);
+                String filepath = null;
+                if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
+                    if (fileUri != null) {
+                        filepath = Uri.parse(fileUri).getPath();
+                    }
+                } else {
+                    int fileNameIdx = c.getColumnIndex(DownloadManager.COLUMN_LOCAL_FILENAME);
+                    filepath = c.getString(fileNameIdx);
+                }
                 int status = c.getInt(c
                         .getColumnIndex(DownloadManager.COLUMN_STATUS));
 


### PR DESCRIPTION
### Description

When I click the download button, the state of this button does not change. I found that running below android 7.0 is completely normal, and running on android 7.0 will not change. I look at the logcat, the error is reported: java.lang.SecurityException: COLUMN_LOCAL_FILENAME is deprecated. I am targeting the error code for the prompt, in the IDownloadManagerImpl class.
 String filepath = c.getString(c
                        .getColumnIndex(DownloadManager.COLUMN_LOCAL_FILENAME));
And DownloadManager.COLUMN_LOCAL_FILENAME is already a deprecated constant. Android apps developed in Android 7.0 or higher will trigger a java.lang.SecurityException when trying to access DownloadManager.COLUMN_LOCAL_FILENAME. Therefore, in order to solve this exception, use the DownloadManager.COLUMN_LOCAL_URI to find the file Uri, then use Uri new a File, and then get the file related information, after running, will not report an error, and can get the normal file name.

[LEARNER-XXXX](https://openedx.atlassian.net/browse/LEARNER-XXXX)

Add a description of your changes here.

### Notes
- Tips: Use the DownloadManager.COLUMN_LOCAL_URI to find the file Uri, then use Uri new a File to get information about the File.

### Testing
- [ ] After testing, it runs normally above or below android 7.0

