### PR TITLE
Remove support for JellyBean in favor of KitKat

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
@@ -13,8 +13,7 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import com.google.inject.Inject;
-
+import org.edx.mobile.base.MainApplication;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.util.BrowserUtil;
 import org.edx.mobile.util.Config;
@@ -60,8 +59,7 @@ public class URLInterceptorWebViewClient extends WebViewClient {
      */
     private boolean loadingInitialUrl = true;
 
-    @Inject
-    Config config;
+    private final Config config;
     /*
     To help a few views (like Announcements) to treat every link as external link and open in
     external web browser.
@@ -70,7 +68,7 @@ public class URLInterceptorWebViewClient extends WebViewClient {
 
     public URLInterceptorWebViewClient(FragmentActivity activity, WebView webView) {
         this.activity = activity;
-        RoboGuice.injectMembers(activity, this);
+        config = RoboGuice.getInjector(MainApplication.instance()).getInstance(Config.class);
         setupWebView(webView);
     }
 

--- a/constants.gradle
+++ b/constants.gradle
@@ -6,7 +6,7 @@ project.ext {
     // API Level that the application will target
     TARGET_SDK_VERSION = 27
     // Minimum API Level required for the application to run
-    MIN_SDK_VERSION = 16
+    MIN_SDK_VERSION = 19
 
     // dummy keystore configuration if not already defined
     if ( !project.properties.containsKey("RELEASE_STORE_FILE")) {


### PR DESCRIPTION
### Description

[LEARNER-6367](https://openedx.atlassian.net/browse/LEARNER-6367)

- Fix injection issue on pre-lollipop devices
- Bump minSdkVersion to KitKat (API Level 19)
