### PR TITLE
Resolve App crashed on launching in OS v8.0.0.

### DIFF
--- a/OpenEdXMobile/AndroidManifest.xml
+++ b/OpenEdXMobile/AndroidManifest.xml
@@ -42,7 +42,7 @@
             android:name="org.edx.mobile.view.SplashActivity"
             android:label="@string/app_shortcut_name"
             android:screenOrientation="portrait"
-            android:theme="@android:style/Theme.NoDisplay">
+            android:theme="@style/AppTheme.NoDisplayTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/OpenEdXMobile/res/values/styles.xml
+++ b/OpenEdXMobile/res/values/styles.xml
@@ -45,6 +45,10 @@
         </item>
     </style>
 
+    <style name="AppTheme.NoDisplayTheme" parent="android:style/Theme.NoDisplay">
+        <item name="android:windowIsTranslucent">false</item>
+    </style>
+
     <style name="AppTheme.Launch" parent="AppTheme.NoActionBar">
         <item name="android:windowBackground">@drawable/launch_background</item>
     </style>


### PR DESCRIPTION
### Description

[LEARNER-6595](https://openedx.atlassian.net/browse/LEARNER-6595)

- Create new style named **NoDisplayTheme** parent **android:style/Theme.NoDisplay**, that overrides the windowIsTranslucent attribute/property.
- Tested on Android Kitkat, Lollipop, and Oreo.