### PR TITLE
Fix redirection issue exists in course discovery web view.

### DIFF
--- a/OpenEdXMobile/res/layout/activity_find_course_info.xml
+++ b/OpenEdXMobile/res/layout/activity_find_course_info.xml
@@ -11,7 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">>
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <RelativeLayout
             android:id="@+id/content_error_root"

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseWebViewFindCoursesActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseWebViewFindCoursesActivity.java
@@ -128,12 +128,18 @@ public abstract class BaseWebViewFindCoursesActivity extends BaseFragmentActivit
         if (progressWheel != null) {
             progressWheel.setVisibility(View.VISIBLE);
         }
+        if (webView != null) {
+            webView.setVisibility(View.GONE);
+        }
     }
 
     @Override
     public void hideLoadingProgress() {
         if (progressWheel != null) {
             progressWheel.setVisibility(View.GONE);
+        }
+        if (webView != null) {
+            webView.setVisibility(View.VISIBLE);
         }
     }
 


### PR DESCRIPTION
### Description

[LEARNER-6596](https://openedx.atlassian.net/browse/LEARNER-6596)

### Changes

- Avoid app redirection to external browser even if the server redirects the course Info page url many times.
- Avoid user tapping on webpage until the page fully loads, in this case we can avoid many problematic cases.


