### PR TITLE
Android - Disable programs for KitKat users

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
@@ -2,6 +2,7 @@ package org.edx.mobile.util;
 
 import android.content.Context;
 import android.net.Uri;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
@@ -189,7 +190,8 @@ public class Config {
         private String detailUrlTemplate;
 
         public boolean isEnabled() {
-            return enabled;
+            // TODO Disable program feature for kitkat users, See Jira story LEARNER-6625 for more details.
+            return enabled && Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT ;
         }
 
         public String getUrl() {


### PR DESCRIPTION
### Description

[LEARNER-6625](https://openedx.atlassian.net/browse/LEARNER-6625)

- Add code to disable the Programs tab for the KitKat users.
- Tested on Android KitKat, Lollipop, Oreo.