### PR TITLE
Resolve Crash on CourseOutlineFragment onItemLongClick

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -307,8 +307,8 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
         listView.setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {
             @Override
             public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
-                IconImageView bulkDownload = (IconImageView) view.findViewById(R.id.bulk_download);
-                if (bulkDownload != null && bulkDownload.getIcon() == FontAwesomeIcons.fa_check) {
+                final IconImageView bulkDownloadIcon = (IconImageView) view.findViewById(R.id.bulk_download);
+                if (bulkDownloadIcon != null && bulkDownloadIcon.getIcon() == FontAwesomeIcons.fa_check) {
                     ((AppCompatActivity) getActivity()).startSupportActionMode(deleteModelCallback);
                     listView.setItemChecked(position, true);
                     return true;
@@ -488,7 +488,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
      */
     private void loadData(@NonNull CourseComponent courseComponent) {
         courseComponentId = courseComponent.getId();
-        if (courseData == null)
+        if (courseData == null || getActivity() == null)
             return;
         if (!EventBus.getDefault().isRegistered(this)) {
             EventBus.getDefault().registerSticky(this);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -307,7 +307,8 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
         listView.setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {
             @Override
             public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
-                if (((IconImageView) view.findViewById(R.id.bulk_download)).getIcon() == FontAwesomeIcons.fa_check) {
+                IconImageView bulkDownload = (IconImageView) view.findViewById(R.id.bulk_download);
+                if (bulkDownload != null && bulkDownload.getIcon() == FontAwesomeIcons.fa_check) {
                     ((AppCompatActivity) getActivity()).startSupportActionMode(deleteModelCallback);
                     listView.setItemChecked(position, true);
                     return true;


### PR DESCRIPTION
### Description

[LEARNER-6681](https://openedx.atlassian.net/browse/LEARNER-6681), [LEARNER-6682](https://openedx.atlassian.net/browse/LEARNER-6682)

- Resolve Crash on CourseOutlineFragment onItemLongClick: Can be reproduce by long click on any of item / section header before loading the last access section in Course Outline Screen.
- Resolve Crash on CourseOutlineFragment.setTitle.
