### PR TITLE
 Fix TransactionTooLargeException on unit navigation

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -178,6 +178,15 @@ dependencies {
         transitive = true
     }
 
+    // A utility library for Android to save objects in a Bundle without any boilerplate
+    implementation ('com.evernote:android-state:1.4.1') {
+        exclude group: 'androidx.core'
+    }
+    annotationProcessor 'com.evernote:android-state-processor:1.4.1'
+
+    // A utility library for avoiding TransactionTooLargeException during state saving and restoration
+    implementation 'com.github.livefront:bridge:v1.1.3'
+
     // Branch SDK
     // Check this link for guide to updating Branch integration:
     // https://github.com/BranchMetrics/android-branch-deep-linking

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -7,18 +7,23 @@ import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.wifi.WifiManager;
 import android.os.Build;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.multidex.MultiDexApplication;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.integration.okhttp3.OkHttpUrlLoader;
 import com.bumptech.glide.load.model.GlideUrl;
 import com.crashlytics.android.core.CrashlyticsCore;
+import com.evernote.android.state.StateSaver;
 import com.facebook.FacebookSdk;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.joanzapata.iconify.Iconify;
 import com.joanzapata.iconify.fonts.FontAwesomeModule;
+import com.livefront.bridge.Bridge;
+import com.livefront.bridge.SavedStateHandler;
 import com.newrelic.agent.android.NewRelic;
 
 import org.edx.mobile.BuildConfig;
@@ -169,6 +174,18 @@ public abstract class MainApplication extends MultiDexApplication {
             FacebookSdk.setApplicationId(config.getFacebookConfig().getFacebookAppId());
             FacebookSdk.sdkInitialize(getApplicationContext());
         }
+
+        Bridge.initialize(this, new SavedStateHandler() {
+            @Override
+            public void saveInstanceState(@NonNull Object target, @NonNull Bundle state) {
+                StateSaver.saveInstanceState(target, state);
+            }
+
+            @Override
+            public void restoreInstanceState(@NonNull Object target, @Nullable Bundle state) {
+                StateSaver.restoreInstanceState(target, state);
+            }
+        });
     }
 
     private void checkIfAppVersionUpgraded(Context context) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitFragment.java
@@ -1,15 +1,17 @@
 package org.edx.mobile.view;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 
+import com.evernote.android.state.State;
 import com.google.inject.Inject;
+import com.livefront.bridge.Bridge;
 
+import org.edx.mobile.base.BaseFragment;
 import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.model.course.CourseComponent;
 import org.edx.mobile.view.common.PageViewStateCallback;
 import org.edx.mobile.view.common.RunnableCourseComponent;
-
-import org.edx.mobile.base.BaseFragment;
 
 public abstract class CourseUnitFragment extends BaseFragment implements PageViewStateCallback, RunnableCourseComponent {
     public interface HasComponent {
@@ -18,6 +20,7 @@ public abstract class CourseUnitFragment extends BaseFragment implements PageVie
         void navigatePreviousComponent();
     }
 
+    @State
     protected CourseComponent unit;
     protected HasComponent hasComponentCallback;
 
@@ -27,8 +30,36 @@ public abstract class CourseUnitFragment extends BaseFragment implements PageVie
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        unit = getArguments() == null ? null :
-                (CourseComponent) getArguments().getSerializable(Router.EXTRA_COURSE_UNIT);
+        if (getArguments() != null) {
+            final Bundle args = getArguments();
+            unit = (CourseComponent) getArguments().getSerializable(Router.EXTRA_COURSE_UNIT);
+            if (unit != null) {
+                /*
+                The size of `unit` object could be very big in some courses that have lots of
+                sections/subsections/units in them. So, we need to ensure that this object isn't
+                stored in the fragment's extras otherwise we might encounter
+                TransactionTooLargeException.
+                 */
+                args.putSerializable(Router.EXTRA_COURSE_UNIT, null);
+                setArguments(args);
+            }
+        }
+        /*
+        To retain the `unit` object during fragment recreation, we're relying on the Bridge library
+        which'll write the object to disk and allow us to restore while the fragment is being
+        recreated. Consequently, avoiding the TransactionTooLargeException.
+        More info:
+        - https://medium.com/@mdmasudparvez/android-os-transactiontoolargeexception-on-nougat-solved-3b6e30597345
+        - https://github.com/livefront/bridge
+        - https://openedx.atlassian.net/browse/LEARNER-6680
+        */
+        Bridge.restoreInstanceState(this, savedInstanceState);
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        Bridge.saveInstanceState(this, outState);
     }
 
     @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitVideoFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitVideoFragment.java
@@ -111,8 +111,8 @@ public class CourseUnitVideoFragment extends CourseUnitFragment
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setRetainInstance(true);
-        unit = getArguments() == null ? null :
-            (VideoBlockModel) getArguments().getSerializable(Router.EXTRA_COURSE_UNIT);
+        // We've already parsed this in the base class, so cast and use that
+        unit = (VideoBlockModel) super.unit;
         hasNextUnit = getArguments().getBoolean(HAS_NEXT_UNIT_ID);
         hasPreviousUnit = getArguments().getBoolean(HAS_PREV_UNIT_ID);
     }

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/test/TestApplication.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/test/TestApplication.java
@@ -1,8 +1,15 @@
 package org.edx.mobile.test;
 
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.evernote.android.state.StateSaver;
 import com.facebook.FacebookSdk;
 import com.joanzapata.iconify.Iconify;
 import com.joanzapata.iconify.fonts.FontAwesomeModule;
+import com.livefront.bridge.Bridge;
+import com.livefront.bridge.SavedStateHandler;
 
 import org.edx.mobile.base.MainApplication;
 
@@ -38,5 +45,18 @@ public class TestApplication extends MainApplication {
         // Initialize to a Fake Application ID as it will not connect to the actual API
         FacebookSdk.setApplicationId("1234567812345678");
         FacebookSdk.sdkInitialize(getApplicationContext());
+
+        // Init Bridge for state saving/restoration
+        Bridge.initialize(this, new SavedStateHandler() {
+            @Override
+            public void saveInstanceState(@NonNull Object target, @NonNull Bundle state) {
+                StateSaver.saveInstanceState(target, state);
+            }
+
+            @Override
+            public void restoreInstanceState(@NonNull Object target, @Nullable Bundle state) {
+                StateSaver.restoreInstanceState(target, state);
+            }
+        });
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ allprojects {
         // The order in which you list these repositories matter.
         google()
         jcenter()
+        maven { url 'https://dl.bintray.com/guardian/android' }
+        maven { url "https://jitpack.io" }
     }
     project.apply from: "${rootDir}/constants.gradle"
 }


### PR DESCRIPTION
### Description

[LEARNER-6680](https://openedx.atlassian.net/browse/LEARNER-6680)

TransactionTooLargeException happens when an Activity/Fragment is in the process of stopping, that means that the Activity/Fragment is trying to send its saved state Bundles to the system OS for safe keeping for restoration later (after a config change or process death) but that one or more of the Bundles it sent is too large (i.e. greater than 1MB).

To avoid this scenario on CourseUnitNavigationActivity, CourseComponent object is now saved on the disk using the Bridge library which allows writing and retrieving it from the disk.

### Note
Inspiration for this fix has been taken after reading this great article:
https://medium.com/@mdmasudparvez/android-os-transactiontoolargeexception-on-nougat-solved-3b6e30597345

### Testing
- **Only test on devices with Android Nougat or above**
- Enable the `Don't keep activities` option in Developer Options on the phone
- Enrol in a course that has lots of sections/subsections/units e.g. https://www.edx.org/course/mechanics-review-mitx-8-mrevx
- Open the unit navigation screen
- Press next/previous 3-4 times and then press Home button
- The app shouldn't crash
- Reopen the app
- App should recreate the screen properly which you were previously on
