### PR TITLE
[WIP] Fix TransactionTooLargeException exception on unit navigation

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/CourseComponent.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/CourseComponent.java
@@ -1,5 +1,6 @@
 package org.edx.mobile.model.course;
 
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
 import org.edx.mobile.R;
@@ -35,6 +36,24 @@ public class CourseComponent implements IBlock, IPathNode {
     private String courseId;
     private String format;
     private String dueDate;
+
+    public void prepareBundleData(@NonNull CourseComponent courseComponent) {
+        this.id = courseComponent.id;
+        this.blockId = courseComponent.blockId;
+        this.type = courseComponent.type;
+        this.name = courseComponent.name;
+        this.graded = courseComponent.graded;
+        this.multiDevice = courseComponent.multiDevice;
+        this.blockUrl = courseComponent.blockUrl;
+        this.webUrl = courseComponent.webUrl;
+        this.blockCount = courseComponent.blockCount;
+        this.parent = null;
+        this.root = null;  // FIXME: it is being used in code so can't be null
+        this.children = courseComponent.children;
+        this.courseId = courseComponent.courseId;
+        this.format = courseComponent.format;
+        this.dueDate = courseComponent.dueDate;
+    }
 
     public CourseComponent(){}
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/VideoBlockModel.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/VideoBlockModel.java
@@ -1,5 +1,6 @@
 package org.edx.mobile.model.course;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.edx.mobile.model.db.DownloadEntry;
@@ -14,9 +15,19 @@ public class VideoBlockModel extends CourseComponent implements HasDownloadEntry
     private VideoData data;
     private String downloadUrl;
 
+    public VideoBlockModel() {
+    }
+
     public VideoBlockModel(BlockModel blockModel, CourseComponent parent){
         super(blockModel,parent);
         this.data = (VideoData)blockModel.data;
+    }
+
+    public void prepareBundleData(@NonNull VideoBlockModel videoBlockModel) {
+        super.prepareBundleData(videoBlockModel);
+        this.downloadEntry = videoBlockModel.downloadEntry;
+        this.data = videoBlockModel.data;
+        this.downloadUrl = videoBlockModel.downloadUrl;
     }
 
     @Nullable

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitVideoFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitVideoFragment.java
@@ -2,7 +2,6 @@ package org.edx.mobile.view;
 
 import android.content.Intent;
 import android.content.res.Configuration;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
@@ -94,9 +93,12 @@ public class CourseUnitVideoFragment extends CourseUnitFragment
     public static CourseUnitVideoFragment newInstance(VideoBlockModel unit, boolean hasNextUnit, boolean hasPreviousUnit) {
         CourseUnitVideoFragment f = new CourseUnitVideoFragment();
 
+        final VideoBlockModel bundleUnit = new VideoBlockModel();
+        bundleUnit.prepareBundleData(unit);
+
         // Supply num input as an argument.
         Bundle args = new Bundle();
-        args.putSerializable(Router.EXTRA_COURSE_UNIT, unit);
+        args.putSerializable(Router.EXTRA_COURSE_UNIT, bundleUnit);
         args.putBoolean(HAS_NEXT_UNIT_ID, hasNextUnit);
         args.putBoolean(HAS_PREV_UNIT_ID, hasPreviousUnit);
         f.setArguments(args);
@@ -111,8 +113,9 @@ public class CourseUnitVideoFragment extends CourseUnitFragment
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setRetainInstance(true);
-        unit = getArguments() == null ? null :
-            (VideoBlockModel) getArguments().getSerializable(Router.EXTRA_COURSE_UNIT);
+//        unit = getArguments() == null ? null :
+//            (VideoBlockModel) getArguments().getSerializable(Router.EXTRA_COURSE_UNIT);
+        unit = (VideoBlockModel) super.unit;
         hasNextUnit = getArguments().getBoolean(HAS_NEXT_UNIT_ID);
         hasPreviousUnit = getArguments().getBoolean(HAS_PREV_UNIT_ID);
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitWebViewFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitWebViewFragment.java
@@ -14,7 +14,6 @@ import android.webkit.WebView;
 import org.edx.mobile.R;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.course.CourseComponent;
-import org.edx.mobile.model.course.HtmlBlockModel;
 import org.edx.mobile.services.ViewPagerDownloadManager;
 import org.edx.mobile.view.custom.AuthenticatedWebView;
 import org.edx.mobile.view.custom.URLInterceptorWebViewClient;
@@ -30,7 +29,7 @@ public class CourseUnitWebViewFragment extends CourseUnitFragment {
     @InjectView(R.id.swipe_container)
     protected SwipeRefreshLayout swipeContainer;
 
-    public static CourseUnitWebViewFragment newInstance(HtmlBlockModel unit) {
+    public static CourseUnitWebViewFragment newInstance(CourseComponent unit) {
         CourseUnitWebViewFragment fragment = new CourseUnitWebViewFragment();
         Bundle args = new Bundle();
         args.putSerializable(Router.EXTRA_COURSE_UNIT, unit);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseUnitPagerAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseUnitPagerAdapter.java
@@ -57,25 +57,28 @@ public class CourseUnitPagerAdapter extends FragmentStatePagerAdapter {
 
     @Override
     public Fragment getItem(int pos) {
-        CourseComponent unit = getUnit(pos);
+        final CourseComponent unit = getUnit(pos);
+        final CourseComponent bundleUnit = new CourseComponent();
+        bundleUnit.prepareBundleData(unit);
+
         CourseUnitFragment unitFragment;
         //FIXME - for the video, let's ignore studentViewMultiDevice for now
         if (isCourseUnitVideo(unit)) {
             unitFragment = CourseUnitVideoFragment.newInstance((VideoBlockModel) unit, (pos < unitList.size()), (pos > 0));
         } else if (unit instanceof VideoBlockModel && ((VideoBlockModel) unit).getData().encodedVideos.getYoutubeVideoInfo() != null) {
-            unitFragment = CourseUnitOnlyOnYoutubeFragment.newInstance(unit);
+            unitFragment = CourseUnitOnlyOnYoutubeFragment.newInstance(bundleUnit);
         } else if (config.isDiscussionsEnabled() && unit instanceof DiscussionBlockModel) {
-            unitFragment = CourseUnitDiscussionFragment.newInstance(unit, courseData);
+            unitFragment = CourseUnitDiscussionFragment.newInstance(bundleUnit, courseData);
         } else if (!unit.isMultiDevice()) {
-            unitFragment = CourseUnitMobileNotSupportedFragment.newInstance(unit);
+            unitFragment = CourseUnitMobileNotSupportedFragment.newInstance(bundleUnit);
         } else if (unit.getType() != BlockType.VIDEO &&
                 unit.getType() != BlockType.HTML &&
                 unit.getType() != BlockType.OTHERS &&
                 unit.getType() != BlockType.DISCUSSION &&
                 unit.getType() != BlockType.PROBLEM) {
-            unitFragment = CourseUnitEmptyFragment.newInstance(unit);
+            unitFragment = CourseUnitEmptyFragment.newInstance(bundleUnit);
         } else if (unit instanceof HtmlBlockModel) {
-            unitFragment = CourseUnitWebViewFragment.newInstance((HtmlBlockModel) unit);
+            unitFragment = CourseUnitWebViewFragment.newInstance(bundleUnit);
         }
 
         //fallback


### PR DESCRIPTION
### Description

[LEARNER-6680](https://openedx.atlassian.net/browse/LEARNER-6680)

TransactionTooLargeException happens when an Activity/Fragment is in the process of stopping, that means that the Activity/Fragment is trying to send its saved state Bundles to the system OS for safe keeping for restoration later (after a config change or process death) but that one or more of the Bundles it sent is too large (i.e. greater than 1MB).

To avoid this scenario we can restrict un-required data to pass in the "course_unit" extra to not make
the bundle size exceed over 1MB. Currently, there are some issues in the data filtering which need to be fixed in the PR.

### Relevant PR (alternate solution implemented):
https://github.com/edx/edx-app-android/pull/1167

### PR Status:
This PR is on hold, we can come back to this PR in future if it required.




