### PR TITLE
Crash on getting videoID

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/services/VideoDownloadHelper.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/services/VideoDownloadHelper.java
@@ -154,11 +154,13 @@ public class VideoDownloadHelper {
     }
 
     public void downloadVideo(DownloadEntry downloadEntry, final FragmentActivity activity, final DownloadManagerCallback callback) {
-        List<DownloadEntry> downloadEntries = new ArrayList<>();
-        downloadEntries.add(downloadEntry);
-        startDownload(downloadEntries, activity, callback);
-        analyticsRegistry.trackSingleVideoDownload(downloadEntry.getVideoId(),
-                downloadEntry.getEnrollmentId(), downloadEntry.getVideoUrl());
+        if (downloadEntry != null) {
+            List<DownloadEntry> downloadEntries = new ArrayList<>();
+            downloadEntries.add(downloadEntry);
+            startDownload(downloadEntries, activity, callback);
+            analyticsRegistry.trackSingleVideoDownload(downloadEntry.getVideoId(),
+                    downloadEntry.getEnrollmentId(), downloadEntry.getVideoUrl());
+        }
     }
 
     private void startDownload(List<DownloadEntry> downloadList,


### PR DESCRIPTION


### Description

-  [LEARNER-6683](https://openedx.atlassian.net/browse/LEARNER-6683)
-  While trying to get video ID from downloadEntry app crash because of downloadEntry object was null