### PR TITLE
Update feature flags doc link in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To use a custom configuration in place of the default configuration, you will ne
 
 
 The full set of known keys can be found in the
-`org/edx/mobile/util/Config.java` file or see [additional documentation](<https://openedx.atlassian.net/wiki/display/MA/App+Configuration+Flags>).
+`org/edx/mobile/util/Config.java` file or see [additional documentation](<https://openedx.atlassian.net/wiki/spaces/LEARNER/pages/48792067/App+Configuration+Flags>).
 
 
 Build Variants


### PR DESCRIPTION
The wiki has moved to another space and the previous link was pointing to the wrong space.