### PR TITLE
Android - Implementation of video player's speed controls

### DIFF
--- a/OpenEdXMobile/res/layout/panel_cc_popup.xml
+++ b/OpenEdXMobile/res/layout/panel_cc_popup.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/cc_layout_popup"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -12,10 +11,9 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/row_height_cc_option"
         android:background="@drawable/grey_top_roundedbg"
-        android:gravity="center_vertical|left|start"
-        android:padding="10dp"
-        android:text="@string/lbl_closed_caption"
-        tools:targetApi="17" />
+        android:gravity="start|center_vertical"
+        android:padding="@dimen/widget_margin"
+        android:text="@string/lbl_closed_caption" />
 
     <ListView
         android:id="@+id/cc_list"
@@ -34,10 +32,9 @@
         android:layout_height="@dimen/row_height_cc_option"
         android:layout_below="@id/cc_list"
         android:background="@color/grey_act_background"
-        android:gravity="center_vertical|left|start"
-        android:padding="10dp"
-        android:text="@string/lbl_cc_cancel"
-        tools:targetApi="17" />
+        android:gravity="start|center_vertical"
+        android:padding="@dimen/widget_margin"
+        android:text="@string/lbl_cc_none" />
 
     <View
         android:id="@+id/divider"

--- a/OpenEdXMobile/res/layout/panel_settings_popup.xml
+++ b/OpenEdXMobile/res/layout/panel_settings_popup.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/setting_popup"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -11,11 +10,25 @@
         android:id="@+id/tv_closedcaption"
         style="@style/regular_grey_text"
         android:layout_width="match_parent"
-        android:layout_height="40dp"
-        android:gravity="left|start|center_vertical"
-        android:padding="10dp"
-        android:text="@string/lbl_closed_caption"
+        android:layout_height="@dimen/row_height_cc_option"
         android:background="@drawable/white_rounded_selector"
-        tools:targetApi="17" />
+        android:gravity="start|center_vertical"
+        android:padding="@dimen/widget_margin"
+        android:text="@string/lbl_closed_caption" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/video_player_settings_divider_width"
+        android:background="@color/grey_act_background" />
+
+    <TextView
+        android:id="@+id/tv_video_speed"
+        style="@style/regular_grey_text"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/row_height_cc_option"
+        android:background="@drawable/white_rounded_selector"
+        android:gravity="start|center_vertical"
+        android:padding="@dimen/widget_margin"
+        android:text="@string/lbl_video_speed" />
 
 </LinearLayout>

--- a/OpenEdXMobile/res/layout/panel_speed_popup_dialog_fragment.xml
+++ b/OpenEdXMobile/res/layout/panel_speed_popup_dialog_fragment.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/speed_layout_popup"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="@drawable/white_roundedbg"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/tv_header_speed"
+        style="@style/regular_grey_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/grey_top_roundedbg"
+        android:gravity="start|center_vertical"
+        android:padding="@dimen/widget_margin"
+        android:text="@string/lbl_video_speed" />
+
+    <ListView
+        android:id="@+id/speed_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        android:divider="@color/grey_act_background"
+        android:dividerHeight="@dimen/video_player_settings_divider_width" />
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/video_player_settings_divider_width"
+        android:background="@color/grey_act_background" />
+
+    <TextView
+        android:id="@+id/tv_cancel"
+        style="@style/regular_grey_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/white_roundedbg"
+        android:gravity="start|center_vertical"
+        android:padding="@dimen/widget_margin"
+        android:text="@string/label_cancel" />
+
+</LinearLayout>

--- a/OpenEdXMobile/res/layout/row_dialog_list.xml
+++ b/OpenEdXMobile/res/layout/row_dialog_list.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/row_cc_lang"
+    android:id="@+id/row_list"
     style="@style/regular_grey_text"
     android:layout_width="match_parent"
     android:layout_height="@dimen/row_height_cc_option"
-    android:gravity="center_vertical|left|start"
-    android:padding="10dp"
-    tools:targetApi="17" />
+    android:gravity="start|center_vertical"
+    android:padding="@dimen/widget_margin" />

--- a/OpenEdXMobile/res/values-es/strings.xml
+++ b/OpenEdXMobile/res/values-es/strings.xml
@@ -423,8 +423,9 @@ Si no lo recibe en algunos minutos, asegúrese de revisar su carpeta de spam.</s
   <!--Player Settings-->
   <!--Label for closed captions in video player-->
   <string name="lbl_closed_caption">Sutítulos</string>
-  <!--Label for no closed captions selected-->
-  <string name="lbl_cc_cancel">Ninguno</string>
+  <!--Label for None captions selected-->
+  <string name="lbl_cc_none">Ninguno</string>
+
   <!--Accessibility Label for Video Player-->
   <string name="video_player">Reproductor de video</string>
   <!--Accessibility Label for View on Web button on Video Player top bar-->

--- a/OpenEdXMobile/res/values/dimens.xml
+++ b/OpenEdXMobile/res/values/dimens.xml
@@ -112,6 +112,11 @@
     <dimen name="video_player_seekbar_line_width">4dp</dimen>
     <dimen name="video_player_seekbar_right_margin">6dp</dimen>
     <dimen name="video_player_duration_padding">4dp</dimen>
+    <dimen name="video_player_settings_divider_width">1dp</dimen>
+
+    <!-- Video Player Settings popup dimen values-->
+    <dimen name="settings_popup_height">80dp</dimen>
+    <dimen name="settings_popup_width">150dp</dimen>
 
     <!-- row height for CC language options, NONE option and the header of popup -->
     <dimen name="row_height_cc_option">40dp</dimen>

--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -476,8 +476,10 @@
     <!-- Player Settings -->
     <!-- Label for closed captions in video player -->
     <string name="lbl_closed_caption">Closed Captions</string>
-    <!-- Label for no closed captions selected -->
-    <string name="lbl_cc_cancel">None</string>
+    <!--Label for video playback speed in video player-->
+    <string name="lbl_video_speed" tools:ignore="MissingTranslation">Video Speed</string>
+    <!-- Label for None captions selected -->
+    <string name="lbl_cc_none">None</string>
     <!-- Accessibility Label for Video Player -->
     <string name="video_player">Video Player</string>
     <!-- Accessibility Label for View on Web button on Video Player top bar -->

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
@@ -13,6 +13,7 @@ import org.edx.mobile.model.api.ProfileModel;
 import org.edx.mobile.module.analytics.Analytics;
 import org.edx.mobile.services.EdxCookieManager;
 import org.edx.mobile.user.ProfileImage;
+import org.edx.mobile.util.VideoPlaybackSpeed;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -59,6 +60,7 @@ public class LoginPrefs {
     public void clear() {
         clearSocialLoginToken();
         setSubtitleLanguage(null);
+        saveDefaultPlaybackSpeed(VideoPlaybackSpeed.NORMAL.getSpeedValue());
         pref.put(PrefManager.Key.PROFILE_JSON, null);
         pref.put(PrefManager.Key.AUTH_JSON, null);
         EdxCookieManager.getSharedInstance(MainApplication.instance()).clearWebWiewCookie();
@@ -88,6 +90,18 @@ public class LoginPrefs {
 
     public void setSubtitleLanguage(@Nullable String language) {
         pref.put(PrefManager.Key.TRANSCRIPT_LANGUAGE, language);
+    }
+
+    /**
+     * @return User selected video playback speed, returns normal speed
+     * i-e- NORMAL_PLAYBACK_SPEED if user hasn't selected it yet.
+     */
+    public float getDefaultPlaybackSpeed() {
+        return pref.getFloat(PrefManager.Key.PLAYBACK_SPEED, VideoPlaybackSpeed.NORMAL.getSpeedValue());
+    }
+
+    public void saveDefaultPlaybackSpeed(float speed) {
+        pref.put(PrefManager.Key.PLAYBACK_SPEED, speed);
     }
 
     @Nullable

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/PrefManager.java
@@ -282,6 +282,7 @@ public class PrefManager {
         public static final String DOWNLOAD_ONLY_ON_WIFI = "download_only_on_wifi";
         public static final String DOWNLOAD_OFF_WIFI_SHOW_DIALOG_FLAG = "download_off_wifi_dialog_flag";
         public static final String TRANSCRIPT_LANGUAGE = "transcript_language";
+        public static final String PLAYBACK_SPEED = "playback_speed";
         public static final String ANALYTICS_KEY_BACKEND = "segment_backend";
         public static final String SPEED_TEST_KBPS = "speed_test_kbps";
         public static final String APP_VERSION_NAME = "app_version_name";

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerListener.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerListener.java
@@ -44,6 +44,7 @@ public interface PlayerListener extends Serializable {
     void setNextPreviousListeners(View.OnClickListener next, View.OnClickListener prev);
     void callSettings(Point p);
     void callPlayerSeeked(long previousPos, long nextPos, boolean isRewindClicked);
+    void setPlaybackSpeed(float speed);
     PlayerController getController();
     boolean isReset();
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/player/VideoPlayer.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/player/VideoPlayer.java
@@ -7,6 +7,7 @@ import android.view.View.OnClickListener;
 
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayerFactory;
+import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.Timeline;
@@ -181,9 +182,6 @@ public class VideoPlayer implements Player.EventListener, AnalyticsListener, Pla
 
                 if (playWhenReady) {
                     state = PlayerState.PLAYING;
-                    if (seekToWhenPrepared > 0) {
-                        seekTo(seekToWhenPrepared);
-                    }
                 }
                 break;
             case Player.STATE_ENDED:
@@ -542,6 +540,9 @@ public class VideoPlayer implements Player.EventListener, AnalyticsListener, Pla
                 || state == PlayerState.STOPPED
                 || state == PlayerState.LAGGING
                 || state == PlayerState.PLAYBACK_COMPLETE) {
+            if (seekToWhenPrepared > 0) {
+                seekTo(seekToWhenPrepared);
+            }
             exoPlayer.setPlayWhenReady(true);
             if (callback != null) {
                 // mark playing
@@ -717,6 +718,13 @@ public class VideoPlayer implements Player.EventListener, AnalyticsListener, Pla
     public void callPlayerSeeked(long previousPos, long nextPos, boolean isRewindClicked) {
         if (callback != null) {
             callback.callPlayerSeeked(previousPos, nextPos, isRewindClicked);
+        }
+    }
+
+    @Override
+    public void setPlaybackSpeed(float speed) {
+        if (exoPlayer != null) {
+            exoPlayer.setPlaybackParameters(new PlaybackParameters(speed));
         }
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/VideoPlaybackSpeed.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/VideoPlaybackSpeed.java
@@ -1,0 +1,21 @@
+package org.edx.mobile.util;
+
+
+/**
+ * This enum defines the video playback speed constants for {@link org.edx.mobile.player.VideoPlayer VideoPlayer}
+ */
+public enum VideoPlaybackSpeed {
+    SLOW(0.5f), NORMAL(1.0f),
+    FAST(1.5f), VERY_FAST(2.0f);
+
+    private final float speedValue;
+
+    // Constructor
+    VideoPlaybackSpeed(final float speedValue) {
+        this.speedValue = speedValue;
+    }
+
+    public float getSpeedValue() {
+        return this.speedValue;
+    }
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/ClosedCaptionAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/ClosedCaptionAdapter.java
@@ -15,7 +15,7 @@ public abstract class ClosedCaptionAdapter extends BaseListAdapter<HashMap<Strin
     //public int selectedPosition = -1;
     public String selectedLanguage;
     public ClosedCaptionAdapter(Context context, IEdxEnvironment environment) {
-        super(context, R.layout.row_cc_list, environment);
+        super(context, R.layout.row_dialog_list, environment);
     }
 
     @Override
@@ -41,7 +41,7 @@ public abstract class ClosedCaptionAdapter extends BaseListAdapter<HashMap<Strin
     public BaseViewHolder getTag(View convertView) {
         ViewHolder holder = new ViewHolder();
         holder.tv_ccLang = (TextView) convertView
-                .findViewById(R.id.row_cc_lang);
+                .findViewById(R.id.row_list);
 
         return holder;
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/SpeedAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/SpeedAdapter.java
@@ -1,0 +1,61 @@
+package org.edx.mobile.view.adapters;
+
+import android.content.Context;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.TextView;
+
+import org.edx.mobile.R;
+import org.edx.mobile.core.IEdxEnvironment;
+
+import java.util.Locale;
+
+
+public abstract class SpeedAdapter extends BaseListAdapter<Float> {
+
+    private final float selectedPlaybackSpeed;
+
+    public SpeedAdapter(Context context, IEdxEnvironment environment, float selectedPlaybackSpeed) {
+        super(context, R.layout.row_dialog_list, environment);
+        this.selectedPlaybackSpeed = selectedPlaybackSpeed;
+    }
+
+    @Override
+    public void render(BaseViewHolder tag, Float speed) {
+        ViewHolder holder = (ViewHolder) tag;
+        holder.tvSpeed.setText(String.format(Locale.getDefault(), "%.1f x", speed));
+        if (speed == selectedPlaybackSpeed) {
+            holder.tvSpeed.setBackgroundResource(R.color.cyan_text_navigation_20);
+        } else {
+            holder.tvSpeed.setBackgroundResource(R.drawable.list_item_overlay_selector);
+        }
+
+        if ((getCount() - 1) == holder.position) {
+            // this is last item in the list, so bottom corners must be rounded
+            if (speed == selectedPlaybackSpeed) {
+                holder.tvSpeed.setBackgroundResource(R.color.cyan_text_navigation_20);
+            } else {
+                holder.tvSpeed.setBackgroundResource(R.drawable.white_bottom_rounded_selector);
+            }
+        }
+    }
+
+    @Override
+    public BaseViewHolder getTag(View convertView) {
+        ViewHolder holder = new ViewHolder();
+        holder.tvSpeed = (TextView) convertView.findViewById(R.id.row_list);
+        return holder;
+    }
+
+    private static class ViewHolder extends BaseViewHolder {
+        TextView tvSpeed;
+    }
+
+    @Override
+    public void onItemClick(AdapterView<?> arg0, View arg1, int position,
+                            long arg3) {
+        onItemClicked(getItem(position));
+    }
+
+    public abstract void onItemClicked(Float speed);
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CCLanguageDialogFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CCLanguageDialogFragment.java
@@ -85,7 +85,7 @@ public class CCLanguageDialogFragment extends RoboDialogFragment {
 
 
             TextView tvNone = (TextView) v.findViewById(R.id.tv_cc_cancel);
-            final String tvNoneTxt = getString(R.string.lbl_cc_cancel);
+            final String tvNoneTxt = getString(R.string.lbl_cc_none);
             if(langSelected!=null){
                 if(langSelected.equalsIgnoreCase(tvNoneTxt)){
                     tvNone.setBackgroundResource(R.color.cyan_text_navigation_20);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/SpeedDialogFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/SpeedDialogFragment.java
@@ -1,0 +1,96 @@
+package org.edx.mobile.view.dialog;
+
+import android.app.DialogFragment;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import com.google.inject.Inject;
+
+import org.edx.mobile.R;
+import org.edx.mobile.core.IEdxEnvironment;
+import org.edx.mobile.util.VideoPlaybackSpeed;
+import org.edx.mobile.view.adapters.SpeedAdapter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import roboguice.fragment.RoboDialogFragment;
+
+public class SpeedDialogFragment extends RoboDialogFragment {
+
+    public interface IListDialogCallback {
+        void onItemClicked(Float speed);
+
+        void onCancelClicked();
+    }
+
+    public static final String PLAYBACK_SPEED = "playback_speed";
+    private IListDialogCallback callback;
+    private List<Float> speeds;
+
+    @Inject
+    IEdxEnvironment environment;
+
+    private void setupWindow() {
+        setStyle(DialogFragment.STYLE_NO_FRAME, android.R.style.Theme_Holo_Dialog);
+        getDialog().getWindow().setBackgroundDrawableResource(android.R.color.transparent);
+    }
+
+    public SpeedDialogFragment() {
+        speeds = new ArrayList<>();
+        for (VideoPlaybackSpeed playbackSpeed : VideoPlaybackSpeed.values()) {
+            speeds.add(playbackSpeed.getSpeedValue());
+        }
+    }
+
+    public static SpeedDialogFragment getInstance(IListDialogCallback callback,
+                                                  float selectedPlaybackSpeed) {
+        SpeedDialogFragment speedDialogFragment = new SpeedDialogFragment();
+        speedDialogFragment.callback = callback;
+        Bundle args = new Bundle();
+        args.putFloat(PLAYBACK_SPEED, selectedPlaybackSpeed);
+        speedDialogFragment.setArguments(args);
+        return speedDialogFragment;
+    }
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        setupWindow();
+
+        View view = inflater.inflate(R.layout.panel_speed_popup_dialog_fragment, container, false);
+        float selectedPlaybackSpeed = VideoPlaybackSpeed.NORMAL.getSpeedValue();
+        if (getArguments() != null) {
+            selectedPlaybackSpeed = getArguments().getFloat(PLAYBACK_SPEED, VideoPlaybackSpeed.NORMAL.getSpeedValue());
+        }
+        SpeedAdapter adapter = new SpeedAdapter(getContext(), environment, selectedPlaybackSpeed) {
+            @Override
+            public void onItemClicked(Float speed) {
+                if (callback != null) {
+                    callback.onItemClicked(speed);
+                }
+                dismiss();
+            }
+        };
+        adapter.setItems(speeds);
+        ListView list = (ListView) view.findViewById(R.id.speed_list);
+        list.setAdapter(adapter);
+        list.setOnItemClickListener(adapter);
+
+        TextView tvCancel = (TextView) view.findViewById(R.id.tv_cancel);
+        tvCancel.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (callback != null) {
+                    callback.onCancelClicked();
+                }
+            }
+        });
+        return view;
+    }
+}


### PR DESCRIPTION
### Description

[LEARNER-6850](https://openedx.atlassian.net/browse/LEARNER-6850)

- Video speed option should appear on settings menu of video player.
- Video playback speed control menu should appear on selection of Video speed option.
- Video playback speed can be 0.5x, 1.0x, 1.5x and 2.0x.

### Notes
- The video is lagging on some devices because Optimization is disabled for debug apk, So need to use signed apk for proper testing.

https://google.github.io/ExoPlayer/faqs.html#why-doesnt-setplaybackparameters-work-properly-on-some-devices  

### Testing

- [ ] Use signed apk. 

### Screenshots

Settings | Video Speed Dialog
--- | ---
![settings_video_speed](https://user-images.githubusercontent.com/1710804/54283767-804bcf00-45c0-11e9-9c30-971964d3cf28.png) | ![video_speed_dialog](https://user-images.githubusercontent.com/1710804/54283278-80979a80-45bf-11e9-8a04-a0c530c9bde5.png)


