### PR TITLE
Resolve PlayerFragment Recursive Exception issue

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
@@ -395,6 +395,7 @@ public class PlayerFragment extends BaseFragment implements IPlayerListener, Ser
         if(player!=null){
             handler.removeMessages(MSG_TYPE_TICK);
             freezePlayer();
+            removeSubtitleCallBack();
         }
     }
 
@@ -405,7 +406,6 @@ public class PlayerFragment extends BaseFragment implements IPlayerListener, Ser
             if (player!=null) {
                 // reset player when user goes back, and there is no state saving happened
                 player.reset();
-                removeSubtitleCallBack();
 
                 // release the player instance
                 player.release();


### PR DESCRIPTION
### Description

[LEARNER-6948](https://openedx.atlassian.net/browse/LEARNER-6948)

- Resolve Recursive Exception issue.
- Exception occurs while navigating to the other video from the video player screen and print the exception logs recursively even after closing all the activities until force close the app. Recursion thread reduce the app performance when user navigating to the other video back and forth.