### PR TITLE
Update libs for Fabric-Firebase migration

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         classpath "com.newrelic.agent.android:agent-gradle-plugin:5.4.1"
 
         classpath 'com.facebook.testing.screenshot:plugin:0.8.0'
-        classpath 'com.google.gms:google-services:4.0.1'
+        classpath 'com.google.gms:google-services:4.2.0'
     }
 }
 
@@ -130,13 +130,13 @@ dependencies {
     // For the optional Nullable annotation
     implementation "com.android.support:support-annotations:${SUPPORT_LIBRARY_VERSION}"
 
-    implementation "com.google.android.gms:play-services-plus:15.0.1"
-    implementation "com.google.android.gms:play-services-analytics:16.0.1"
-    implementation "com.google.android.gms:play-services-auth:15.0.1"
     implementation "com.google.android.gms:play-services-ads:15.0.1"
+    implementation "com.google.android.gms:play-services-plus:16.0.0"
+    implementation "com.google.android.gms:play-services-analytics:16.0.6"
+    implementation "com.google.android.gms:play-services-auth:16.0.1"
     // Google Firebase
-    implementation "com.google.firebase:firebase-core:16.0.1"
-    implementation "com.google.firebase:firebase-messaging:17.1.0"
+    implementation "com.google.firebase:firebase-core:16.0.6"
+    implementation "com.google.firebase:firebase-messaging:17.3.4"
 
 //    Exo Player
     implementation 'com.google.android.exoplayer:exoplayer:2.9.2'

--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -130,7 +130,6 @@ dependencies {
     // For the optional Nullable annotation
     implementation "com.android.support:support-annotations:${SUPPORT_LIBRARY_VERSION}"
 
-    implementation "com.google.android.gms:play-services-ads:15.0.1"
     implementation "com.google.android.gms:play-services-plus:16.0.0"
     implementation "com.google.android.gms:play-services-analytics:16.0.6"
     implementation "com.google.android.gms:play-services-auth:16.0.1"

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:${GRADLE_PLUGIN_VERSION}"
-        classpath 'com.google.gms:google-services:4.0.1'
+        classpath 'com.google.gms:google-services:4.2.0'
     }
 }
 


### PR DESCRIPTION
### Description

[LEARNER-6805](https://openedx.atlassian.net/browse/LEARNER-6805)

The migration requires updation of all the libraries done in this PR.

### Notes
Google Ads library has also been deleted as part of this PR (cuz it was optional for Branch integration and was causing issues)
Ref: https://docs.branch.io/pages/apps/android/#install-branch

p.s. This library was added in the following Branch integration PR:
https://github.com/edx/edx-app-android/pull/1014/files#diff-6af5ac43a04e3fa22a6796202b30a807R135

### Testing
For the crashes to appear on Firebase console, we'll need to do the following changes:
1 - Enable Firebase in our configs (not the analytics, only Firebase)
2 - Update the `google-services.json` file with the latest one on our online Firebase project

Test crash reported using this PR on:
**Firebase**: https://console.firebase.google.com/project/openedx-mobile/crashlytics/app/android:org.edx.mobile/issues/5c458841f8b88c2963ff20ef?time=last-seven-days&sessionId=5C45880F02F900015FAB85A04911EAE3_DNE_0_v2
**Fabric**: https://fabric.io/edx-inc/android/apps/org.edx.mobile/issues/5c458841f8b88c2963ff20ef?time=last-hour
