### PR TITLE
Normalize non-ASCII characters from User-Agent header

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/interceptor/UserAgentInterceptor.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/interceptor/UserAgentInterceptor.java
@@ -3,6 +3,7 @@ package org.edx.mobile.http.interceptor;
 import android.support.annotation.NonNull;
 
 import java.io.IOException;
+import java.text.Normalizer;
 
 import okhttp3.Interceptor;
 import okhttp3.Response;
@@ -13,7 +14,7 @@ public class UserAgentInterceptor implements Interceptor {
     private final String userAgent;
 
     public UserAgentInterceptor(@NonNull String userAgent) {
-        this.userAgent = userAgent;
+        this.userAgent = Normalizer.normalize(userAgent, Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "");;
     }
 
     @Override


### PR DESCRIPTION
### Description

[LEARNER-6989](https://openedx.atlassian.net/browse/LEARNER-6989)

This is a minor bugfix to replace non-ASCII Unicode characters with ASCII characters. Uses Java built-in Normalizer class, and NFD normalization form.

Before:
```
Dalvik/2.1.0 (Linux; U; Android 9; Pixel Build/PQ1A.190105.004) üniversite/org.edx.mobile/2.17.1
```

After:
```
Dalvik/2.1.0 (Linux; U; Android 9; Pixel Build/PQ1A.190105.004) universite/org.edx.mobile/2.17.1
```

### Notes
- UserAgentInterceptor does not have tests, and I didn't add any to test normalization.

