### PR TITLE
Add openedx-release to openedx.yaml

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -4,7 +4,7 @@
 nick: andr
 oeps: {}
 owner: edx/edx-mobile-push
+openedx-release: {ref: release/latest}
 tags:
   - mobile
   - android
-track-pulls: true


### PR DESCRIPTION
### Description

This will allow us to tag the mobile apps for Open edX releases.

### Notes
- Example: Use example.sandbox.edx.org to test against
- Example: This PR will not address x,y, and z, because of a, b, and c.
- Example: Feature is behind a flag
- Example: Why I didn't add any tests

### Testing
- [ ] i18n
- [ ] RTL
- [ ] safecommit shows 0 violations
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Analytics
- [ ] Performance
- [ ] Database migrations are backwards-compatible
