### PR TITLE
Implement deep link for Course Videos screen

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/DeepLinkManager.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/DeepLinkManager.java
@@ -28,9 +28,11 @@ public class DeepLinkManager {
             @ScreenDef final String screenName = paramsJson.getString(KEY_SCREEN_NAME);
             switch (screenName) {
                 case Screen.COURSE_DASHBOARD:
+                case Screen.COURSE_VIDEOS: {
                     final String courseId = paramsJson.getString(KEY_COURSE_ID);
-                    router.showCourseDashboardTabs(activity, null, courseId, false);
+                    router.showCourseDashboardTabs(activity, null, courseId, false, screenName);
                     break;
+                }
             }
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/Screen.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/Screen.java
@@ -6,4 +6,5 @@ package org.edx.mobile.deeplink;
  */
 public class Screen {
     public static final String COURSE_DASHBOARD = "course_dashboard";
+    public static final String COURSE_VIDEOS = "course_videos";
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/ScreenDef.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/ScreenDef.java
@@ -6,12 +6,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 import static org.edx.mobile.deeplink.Screen.COURSE_DASHBOARD;
+import static org.edx.mobile.deeplink.Screen.COURSE_VIDEOS;
 
 /**
  * Denotes that a String parameter, field or method return value is expected
  * to be a String reference (e.g. {@link Screen#COURSE_DASHBOARD}).
  */
 @Retention(RetentionPolicy.SOURCE)
-@StringDef({COURSE_DASHBOARD})
+@StringDef({COURSE_DASHBOARD, COURSE_VIDEOS})
 public @interface ScreenDef {
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardActivity.java
@@ -6,21 +6,25 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 
+import org.edx.mobile.deeplink.ScreenDef;
 import org.edx.mobile.event.CourseDashboardRefreshEvent;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 
 import static org.edx.mobile.view.Router.EXTRA_ANNOUNCEMENTS;
 import static org.edx.mobile.view.Router.EXTRA_COURSE_DATA;
 import static org.edx.mobile.view.Router.EXTRA_COURSE_ID;
+import static org.edx.mobile.view.Router.EXTRA_SCREEN_NAME;
 
 public class CourseTabsDashboardActivity extends OfflineSupportBaseActivity {
     public static Intent newIntent(@NonNull Activity activity,
                                    @Nullable EnrolledCoursesResponse courseData,
-                                   @Nullable String courseId, boolean announcements) {
+                                   @Nullable String courseId, boolean announcements,
+                                   @Nullable @ScreenDef String screenName) {
         Intent intent = new Intent(activity, CourseTabsDashboardActivity.class);
         intent.putExtra(EXTRA_COURSE_DATA, courseData);
         intent.putExtra(EXTRA_COURSE_ID, courseId);
         intent.putExtra(EXTRA_ANNOUNCEMENTS, announcements);
+        intent.putExtra(EXTRA_SCREEN_NAME, screenName);
         intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
         return intent;
     }
@@ -28,8 +32,9 @@ public class CourseTabsDashboardActivity extends OfflineSupportBaseActivity {
     @Override
     public Fragment getFirstFragment() {
         return CourseTabsDashboardFragment.newInstance(
-                (EnrolledCoursesResponse) getIntent().getExtras().getSerializable(EXTRA_COURSE_DATA),
-                getIntent().getStringExtra(EXTRA_COURSE_ID));
+                (EnrolledCoursesResponse) getIntent().getSerializableExtra(EXTRA_COURSE_DATA),
+                getIntent().getStringExtra(EXTRA_COURSE_ID),
+                getIntent().getStringExtra(EXTRA_SCREEN_NAME));
     }
 
     @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardFragment.java
@@ -22,6 +22,7 @@ import com.joanzapata.iconify.fonts.FontAwesomeIcons;
 import org.edx.mobile.R;
 import org.edx.mobile.course.CourseAPI;
 import org.edx.mobile.databinding.FragmentDashboardErrorLayoutBinding;
+import org.edx.mobile.deeplink.ScreenDef;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.model.FragmentItemModel;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
@@ -59,11 +60,14 @@ public class CourseTabsDashboardFragment extends TabsBaseFragment {
     private MenuItem downloadsMenuItem;
 
     @NonNull
-    public static CourseTabsDashboardFragment newInstance(@Nullable EnrolledCoursesResponse courseData, @Nullable String courseId) {
+    public static CourseTabsDashboardFragment newInstance(
+            @Nullable EnrolledCoursesResponse courseData, @Nullable String courseId,
+            @Nullable @ScreenDef String screenName) {
         final CourseTabsDashboardFragment fragment = new CourseTabsDashboardFragment();
         final Bundle bundle = new Bundle();
         bundle.putSerializable(Router.EXTRA_COURSE_DATA, courseData);
         bundle.putSerializable(Router.EXTRA_COURSE_ID, courseId);
+        bundle.putSerializable(Router.EXTRA_SCREEN_NAME, screenName);
         fragment.setArguments(bundle);
         return fragment;
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
@@ -18,6 +18,7 @@ import org.edx.mobile.BuildConfig;
 import org.edx.mobile.R;
 import org.edx.mobile.authentication.LoginAPI;
 import org.edx.mobile.course.CourseDetail;
+import org.edx.mobile.deeplink.ScreenDef;
 import org.edx.mobile.discussion.DiscussionComment;
 import org.edx.mobile.discussion.DiscussionThread;
 import org.edx.mobile.discussion.DiscussionTopic;
@@ -55,6 +56,7 @@ public class Router {
     public static final String EXTRA_IS_ON_COURSE_OUTLINE = "is_on_course_outline";
     public static final String EXTRA_SUBJECT_FILTER = "subject_filter";
     public static final String EXTRA_PATH_ID = "path_id";
+    public static final String EXTRA_SCREEN_NAME = "screen_name";
 
     @Inject
     Config config;
@@ -128,13 +130,14 @@ public class Router {
     public void showCourseDashboardTabs(@NonNull Activity activity,
                                         @Nullable EnrolledCoursesResponse model,
                                         boolean announcements) {
-        showCourseDashboardTabs(activity, model, null, announcements);
+        showCourseDashboardTabs(activity, model, null, announcements, null);
     }
 
     public void showCourseDashboardTabs(@NonNull Activity activity,
                                         @Nullable EnrolledCoursesResponse model,
-                                        @Nullable String courseId, boolean announcements) {
-        activity.startActivity(CourseTabsDashboardActivity.newIntent(activity, model, courseId, announcements));
+                                        @Nullable String courseId, boolean announcements,
+                                        @Nullable @ScreenDef String screenName) {
+        activity.startActivity(CourseTabsDashboardActivity.newIntent(activity, model, courseId, announcements, screenName));
     }
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/TabsBaseFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/TabsBaseFragment.java
@@ -14,11 +14,14 @@ import android.widget.TextView;
 
 import com.google.inject.Inject;
 import com.joanzapata.iconify.IconDrawable;
+import com.joanzapata.iconify.fonts.FontAwesomeIcons;
 
 import org.edx.mobile.R;
 import org.edx.mobile.base.BaseFragment;
 import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.databinding.FragmentTabsBaseBinding;
+import org.edx.mobile.deeplink.Screen;
+import org.edx.mobile.deeplink.ScreenDef;
 import org.edx.mobile.model.FragmentItemModel;
 import org.edx.mobile.view.adapters.FragmentItemPagerAdapter;
 
@@ -40,6 +43,28 @@ public abstract class TabsBaseFragment extends BaseFragment {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_tabs_base, container, false);
         initializeTabs();
         return binding.getRoot();
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        // Handle tab-selection through deep link (if available)
+        if (getArguments() != null && binding != null) {
+            @ScreenDef final String screenName = getArguments().getString(Router.EXTRA_SCREEN_NAME);
+            if (screenName != null) {
+                final List<FragmentItemModel> fragmentItems = getFragmentItems();
+                for (int i = 0; i < fragmentItems.size(); i++) {
+                    final FragmentItemModel item = fragmentItems.get(i);
+                    if (screenName.equals(Screen.COURSE_VIDEOS) && item.getIcon() == FontAwesomeIcons.fa_film) {
+                        binding.viewPager.setCurrentItem(i);
+                        break;
+                    }
+                }
+                // Setting this to null, so that upon recreation of the fragment the tab defined in
+                // the deep link is not auto-selected again.
+                getArguments().putString(Router.EXTRA_SCREEN_NAME, null);
+            }
+        }
     }
 
     private void initializeTabs() {

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/view/CourseTabsDashboardFragmentTest.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/view/CourseTabsDashboardFragmentTest.java
@@ -4,6 +4,7 @@ import android.support.v4.view.ViewPager;
 import android.view.View;
 
 import org.edx.mobile.R;
+import org.edx.mobile.deeplink.Screen;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.junit.Test;
 import org.robolectric.shadows.support.v4.SupportFragmentTestUtil;
@@ -30,7 +31,7 @@ public class CourseTabsDashboardFragmentTest extends UiTest {
      */
     @Test
     public void initializeTest() {
-        CourseTabsDashboardFragment fragment = CourseTabsDashboardFragment.newInstance(getCourseData(), "testsCourseId");
+        CourseTabsDashboardFragment fragment = CourseTabsDashboardFragment.newInstance(getCourseData(), "testsCourseId", Screen.COURSE_DASHBOARD);
         SupportFragmentTestUtil.startVisibleFragment(fragment, RoboFragmentActivity.class, android.R.id.content);
         View view = fragment.getView();
         assertNotNull(view);


### PR DESCRIPTION
### Description

[LEARNER-7008](https://openedx.atlassian.net/browse/LEARNER-7008)

Deep link for changing tabs is now handled in the TabsBaseFragment instead of its child classes for a generic implementation to handle such scenarios in the future where a deep link only wants to open a specific tab in a screen.
