### PR TITLE
Implement deep linking on Program Dashboard

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragment.java
@@ -1,6 +1,7 @@
 package org.edx.mobile.base;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
@@ -43,6 +44,14 @@ public class BaseFragment extends RoboFragment {
      * Defined to mock the behavior of {@link Activity#onRestart() Activity.onRestart} function.
      */
     protected void onRevisit() {
+    }
+
+    /**
+     * Called when a parent activity receives a new intent in its {@link Activity#onNewIntent(Intent)
+     * Activity.onNewIntent} function.
+     * Defined to mock the behavior of {@link Activity#onNewIntent(Intent) Activity.onNewIntent} function.
+     */
+    protected void onNewIntent(Intent intent) {
     }
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseSingleFragmentActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseSingleFragmentActivity.java
@@ -1,5 +1,6 @@
 package org.edx.mobile.base;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
@@ -97,6 +98,15 @@ public abstract class BaseSingleFragmentActivity extends BaseFragmentActivity im
     }
 
     public abstract Fragment getFirstFragment();
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        final BaseFragment baseFragment = (BaseFragment) getSupportFragmentManager().findFragmentByTag(FIRST_FRAG_TAG);
+        if (baseFragment != null) {
+            baseFragment.onNewIntent(intent);
+        }
+    }
 
     protected void showLoadingProgress() {
         if (progressSpinner != null) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/DeepLinkManager.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/DeepLinkManager.java
@@ -33,6 +33,10 @@ public class DeepLinkManager {
                     router.showCourseDashboardTabs(activity, null, courseId, false, screenName);
                     break;
                 }
+                case Screen.PROGRAM: {
+                    router.showMainDashboard(activity, screenName);
+                    break;
+                }
             }
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/Screen.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/Screen.java
@@ -7,4 +7,5 @@ package org.edx.mobile.deeplink;
 public class Screen {
     public static final String COURSE_DASHBOARD = "course_dashboard";
     public static final String COURSE_VIDEOS = "course_videos";
+    public static final String PROGRAM = "program";
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MainDashboardActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MainDashboardActivity.java
@@ -17,6 +17,7 @@ import com.google.inject.Inject;
 
 import org.edx.mobile.BuildConfig;
 import org.edx.mobile.R;
+import org.edx.mobile.deeplink.ScreenDef;
 import org.edx.mobile.event.MainDashboardRefreshEvent;
 import org.edx.mobile.event.NewVersionAvailableEvent;
 import org.edx.mobile.module.notification.NotificationDelegate;
@@ -32,6 +33,8 @@ import java.text.ParseException;
 import de.greenrobot.event.EventBus;
 import roboguice.inject.InjectView;
 
+import static org.edx.mobile.view.Router.EXTRA_SCREEN_NAME;
+
 public class MainDashboardActivity extends OfflineSupportBaseActivity
         implements ToolbarCallbacks {
 
@@ -45,11 +48,12 @@ public class MainDashboardActivity extends OfflineSupportBaseActivity
     @Inject
     private LoginPrefs loginPrefs;
 
-    public static Intent newIntent() {
+    public static Intent newIntent(@ScreenDef String screenName) {
         // These flags will make it so we only have a single instance of this activity,
         // but that instance will not be restarted if it is already running
         return IntentFactory.newIntentForComponent(MainDashboardActivity.class)
-                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                .putExtra(EXTRA_SCREEN_NAME, screenName);
     }
 
     @Override
@@ -112,7 +116,11 @@ public class MainDashboardActivity extends OfflineSupportBaseActivity
 
     @Override
     public Fragment getFirstFragment() {
-        return new MainTabsDashboardFragment();
+        final Fragment fragment = new MainTabsDashboardFragment();
+        final Bundle bundle = new Bundle();
+        bundle.putString(EXTRA_SCREEN_NAME, getIntent().getStringExtra(EXTRA_SCREEN_NAME));
+        fragment.setArguments(bundle);
+        return fragment;
     }
 
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
@@ -123,8 +123,12 @@ public class Router {
         return RegisterActivity.newIntent();
     }
 
-    public void showMainDashboard(Activity sourceActivity) {
-        sourceActivity.startActivity(MainDashboardActivity.newIntent());
+    public void showMainDashboard(@NonNull Activity sourceActivity) {
+        showMainDashboard(sourceActivity, null);
+    }
+
+    public void showMainDashboard(@NonNull Activity sourceActivity, @Nullable @ScreenDef String screenName) {
+        sourceActivity.startActivity(MainDashboardActivity.newIntent(screenName));
     }
 
     public void showCourseDashboardTabs(@NonNull Activity activity,

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/TabsBaseFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/TabsBaseFragment.java
@@ -1,8 +1,10 @@
 package org.edx.mobile.view;
 
+import android.content.Intent;
 import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.ColorRes;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.TabLayout;
 import android.support.v4.content.ContextCompat;
@@ -48,9 +50,24 @@ public abstract class TabsBaseFragment extends BaseFragment {
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        // Handle tab-selection through deep link (if available)
-        if (getArguments() != null && binding != null) {
-            @ScreenDef final String screenName = getArguments().getString(Router.EXTRA_SCREEN_NAME);
+        handleTabSelection(getArguments());
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        handleTabSelection(intent.getExtras());
+    }
+
+    /**
+     * Method to handle the tab-selection of the ViewPager based on screen name {@link Screen}
+     * which may be sent through a deep link.
+     *
+     * @param bundle arguments
+     */
+    private void handleTabSelection(@Nullable Bundle bundle) {
+        if (bundle != null && binding != null) {
+            @ScreenDef String screenName = bundle.getString(Router.EXTRA_SCREEN_NAME);
             if (screenName != null) {
                 final List<FragmentItemModel> fragmentItems = getFragmentItems();
                 for (int i = 0; i < fragmentItems.size(); i++) {
@@ -58,11 +75,14 @@ public abstract class TabsBaseFragment extends BaseFragment {
                     if (screenName.equals(Screen.COURSE_VIDEOS) && item.getIcon() == FontAwesomeIcons.fa_film) {
                         binding.viewPager.setCurrentItem(i);
                         break;
+                    } else if (screenName.equals(Screen.PROGRAM) && item.getIcon() == FontAwesomeIcons.fa_clone) {
+                        binding.viewPager.setCurrentItem(i);
+                        break;
                     }
                 }
                 // Setting this to null, so that upon recreation of the fragment the tab defined in
                 // the deep link is not auto-selected again.
-                getArguments().putString(Router.EXTRA_SCREEN_NAME, null);
+                bundle.putString(Router.EXTRA_SCREEN_NAME, null);
             }
         }
     }


### PR DESCRIPTION
### Description

[LEARNER-7010](https://openedx.atlassian.net/browse/LEARNER-7010)

- Implement the deep linking on Program dashboard.
- Create a custom method named `onNewIntent` in `BaseFragment` that mock the behavior of [Activity.onNewIntent(Intent)](https://developer.android.com/reference/android/app/Activity.html#onNewIntent(android.content.Intent)), and used to pass the data to the fragment.