### PR TITLE
Update Gradle Plugin and libraries.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ android:
     - tools
     - platform-tools
     # The BuildTools version used
-    - build-tools-27.0.3
+    - build-tools-28.0.3
     # The SDK version used to compile the project
-    - android-27
+    - android-28
     # Required to define the system image for an Android-21 emulator to use
     # Reference: https://github.com/travis-ci/travis-ci/issues/6606#issuecomment-257090318
     - android-21

--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -17,6 +17,7 @@ buildscript {
         classpath "com.newrelic.agent.android:agent-gradle-plugin:5.4.1"
 
 //        TODO : Need to update when available, ( In order to resolve "variant.getConnectedInstrumentTest()" warning)
+//        Reference : https://github.com/facebook/screenshot-tests-for-android/issues/210
         classpath 'com.facebook.testing.screenshot:plugin:0.8.0'
         classpath 'com.google.gms:google-services:4.2.0'
     }

--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -16,6 +16,7 @@ buildscript {
         //Included for NewRelic
         classpath "com.newrelic.agent.android:agent-gradle-plugin:5.4.1"
 
+//        TODO : Need to update when available, ( In order to resolve "variant.getConnectedInstrumentTest()" warning)
         classpath 'com.facebook.testing.screenshot:plugin:0.8.0'
         classpath 'com.google.gms:google-services:4.2.0'
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/third_party/subscaleview/SubsamplingScaleImageView.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/third_party/subscaleview/SubsamplingScaleImageView.java
@@ -74,7 +74,7 @@ import java.util.concurrent.Executor;
  * s prefixes - coordinates, translations and distances measured in source image pixels (scaled)
  */
 
-// TODO - Update the class/Library to resolve the warning of WrongThread (currently suppress) as part of https://openedx.atlassian.net/browse/LEARNER-7207
+// TODO - Update this legacy library code as part of https://openedx.atlassian.net/browse/LEARNER-7207, currently we are just suppressing the WrongThread warnings
 @SuppressWarnings("unused")
 public class SubsamplingScaleImageView extends View {
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/third_party/subscaleview/SubsamplingScaleImageView.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/third_party/subscaleview/SubsamplingScaleImageView.java
@@ -16,6 +16,7 @@ limitations under the License.
 
 package org.edx.mobile.third_party.subscaleview;
 
+import android.annotation.SuppressLint;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.database.Cursor;
@@ -72,6 +73,8 @@ import java.util.concurrent.Executor;
  * v prefixes - coordinates, translations and distances measured in screen (view) pixels
  * s prefixes - coordinates, translations and distances measured in source image pixels (scaled)
  */
+
+// TODO - Update the class/Library to resolve the warning of WrongThread (currently suppress) as part of https://openedx.atlassian.net/browse/LEARNER-7207
 @SuppressWarnings("unused")
 public class SubsamplingScaleImageView extends View {
 
@@ -1436,6 +1439,7 @@ public class SubsamplingScaleImageView extends View {
                     Point dimensions = decoder.init(context, source);
                     int sWidth = dimensions.x;
                     int sHeight = dimensions.y;
+                    @SuppressLint("WrongThread")
                     int exifOrientation = view.getExifOrientation(sourceUri);
                     if (view.sRegion != null) {
                         sWidth = view.sRegion.width();
@@ -1505,6 +1509,7 @@ public class SubsamplingScaleImageView extends View {
             tile.loading = true;
         }
 
+        @SuppressLint("WrongThread")
         @Override
         protected Bitmap doInBackground(Void... params) {
             try {
@@ -1583,6 +1588,7 @@ public class SubsamplingScaleImageView extends View {
             this.preview = preview;
         }
 
+        @SuppressLint("WrongThread")
         @Override
         protected Integer doInBackground(Void... params) {
             try {

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project is meant to be built using Android Studio. It can also be built fro
 
         git clone https://github.com/edx/edx-app-android
 
-2. Setup the Android Studio. The latest tested Android Studio version is v3.1.3, you can download it from [the previous versions archive](https://developer.android.com/studio/archive).
+2. Setup the Android Studio. The latest tested Android Studio version is v3.3.2, you can download it from [the previous versions archive](https://developer.android.com/studio/archive). (You can find further details to run the project on the said version of Android Studio on this [PR](https://github.com/edx/edx-app-android/pull/1264).
 
 3. Open Android Studio and choose **Open an Existing Android Studio Project**
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,25 +22,29 @@ buildscript {
 }
 
 // task that creates 'artifacts' directory
-task createBuildArtifactsDirectory << { task ->
-    def hashPipe = new ByteArrayOutputStream()
-    task.project.exec {
-        commandLine = ['git', 'rev-parse', '--verify', 'HEAD']
-        standardOutput = hashPipe
-    }
+task createBuildArtifactsDirectory { task ->
+    doLast {
+        def hashPipe = new ByteArrayOutputStream()
+        task.project.exec {
+            commandLine = ['git', 'rev-parse', '--verify', 'HEAD']
+            standardOutput = hashPipe
+        }
 
-    def destDir = "artifacts"
-    task.project.exec {
-        commandLine = ['mkdir', '-p', destDir]
+        def destDir = "artifacts"
+        task.project.exec {
+            commandLine = ['mkdir', '-p', destDir]
+        }
     }
 }
 
 // Copies unit test reports to the 'artifacts' directory
-task copyUnitTestBuildArtifacts << { task ->
-    // copy unit test reports
-    def srcPath = "OpenEdXMobile/build/reports"
-    task.project.exec {
-        commandLine = ['cp', '-R', srcPath, 'artifacts']
+task copyUnitTestBuildArtifacts { task ->
+    doLast {
+        // copy unit test reports
+        def srcPath = "OpenEdXMobile/build/reports"
+        task.project.exec {
+            commandLine = ['cp', '-R', srcPath, 'artifacts']
+        }
     }
 }
 copyUnitTestBuildArtifacts.dependsOn createBuildArtifactsDirectory
@@ -55,15 +59,16 @@ task copyLintBuildArtifacts(type: Copy) {
 copyLintBuildArtifacts.dependsOn createBuildArtifactsDirectory
 
 // Copies acceptance test reports to the 'artifacts' directory
-task copyAcceptanceTestBuildArtifacts << { task ->
-    // copy acceptance test reports
-    srcPath = "AcceptanceTests/Test-Reports"
-    task.project.exec {
-        commandLine = ['cp', '-R', srcPath, 'artifacts']
+task copyAcceptanceTestBuildArtifacts { task ->
+    doLast {
+        // copy acceptance test reports
+        srcPath = "AcceptanceTests/Test-Reports"
+        task.project.exec {
+            commandLine = ['cp', '-R', srcPath, 'artifacts']
+        }
     }
 }
 copyAcceptanceTestBuildArtifacts.dependsOn createBuildArtifactsDirectory
-
 
 // Disables preDex which reduces the amount of memory required to build an APK. This is important
 // for CI where there is a memory limit. PreDex is also not useful in CI where a new build is

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -22,7 +22,7 @@ subprojects {
         // get picked up. We only have one buildSrc plugin
         // so it doesn't really matter, but if we ever get more
         // we should figure this out
-        compile 'org.codehaus.groovy:groovy-all:2.4.12'
+        compile 'org.codehaus.groovy:groovy-all:2.4.15'
         compile gradleApi()
         compile 'org.yaml:snakeyaml:1.14'
     }

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -30,4 +30,5 @@ def edXAppPluginSetup(url) {
 
 edXAppPluginSetup('https://github.com/edx/edx-app-gradle-plugin')
 
-include "plugins/edx-app-gradle-plugin"
+include "plugins"
+project(':plugins').projectDir = file('plugins/edx-app-gradle-plugin')

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -10,13 +10,13 @@ buildscript {
     }
 }
 
-def edXAppPluginSetup(url, ref) {
+def edXAppPluginSetup(url) {
     def buildSrc = new File(rootProject.projectDir, 'plugins')
     buildSrc.mkdirs()
     def dest = new File(buildSrc, "edx-app-gradle-plugin")
 
     if(!dest.exists()) {
-        Grgit.clone(dir: dest, uri: url, refToCheckout : ref)
+        Grgit.clone(dir: dest, uri: url)
     }
 
     def grgit = Grgit.open(dir : dest)
@@ -26,9 +26,8 @@ def edXAppPluginSetup(url, ref) {
     catch(GrgitException e) {
         println("Could not fetch latest version of app gradle plugin. This is probably due to lack of an internet connection. Skipping")
     }
-    grgit.checkout(branch : ref)
 }
 
-edXAppPluginSetup('https://github.com/edx/edx-app-gradle-plugin', '2e0516c8b3c4e0d60bff01491bc66c9f0f2eedf4')
+edXAppPluginSetup('https://github.com/edx/edx-app-gradle-plugin')
 
 include "plugins/edx-app-gradle-plugin"

--- a/constants.gradle
+++ b/constants.gradle
@@ -1,8 +1,8 @@
 project.ext {
-    GRADLE_PLUGIN_VERSION = "3.1.3"
-    BUILD_TOOLS_VERSION = "27.0.3"
-    SUPPORT_LIBRARY_VERSION = "27.1.1"
-    COMPILE_SDK_VERSION = 27
+    GRADLE_PLUGIN_VERSION = "3.3.2"
+    BUILD_TOOLS_VERSION = "28.0.3"
+    SUPPORT_LIBRARY_VERSION = "28.0.0"
+    COMPILE_SDK_VERSION = 28
     // API Level that the application will target
     TARGET_SDK_VERSION = 27
     // Minimum API Level required for the application to run

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 09 10:07:57 AMT 2018
+#Fri Mar 29 16:29:25 PKT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
### Description

[LEARNER-6873](https://openedx.atlassian.net/browse/LEARNER-6873)
- Update Gradle plugin, and Libraries
- Update Code to get latest commit for the **edx-app-gradle-plugin** to resolve issue `Could not read script '/home/travis/build/edx/edx-app-android/OpenEdXMobile/edx.properties' as it does not exist` after upgrading gradle plugin
- Update Gradle deprecated code
-  Suppress WrongThread warning to make travis build successful
- Update Android Studio version to 3.3.2 in README.md

#### Gradle update reference doc:
https://developer.android.com/studio/releases/gradle-plugin.html#updating-plugin
https://developer.android.com/studio/build

### Android Studio and Tools
This PR has been built on latest android studio and tools available at the time that are:

- Android Studio: 3.3.2
- Android SDK Tools: 26.1.1
- Android SDK Platform-Tools: 28.0.1

### Update plugin + libraries

- Update Gradle Plugin version to 3.3.2
- Update Gradle version(distribution) to 4.10.1
- Update build tools to 28.0.3 for both app and Travis config.
- Update Support library version to 28.0.0
- Update Compile SDK version to 28
- Update groovy version to 2.4.15 in order to use with gradle plugin 3.3.2
### Follow up stories:
https://openedx.atlassian.net/browse/LEARNER-7207