### PR TITLE
Fix travis build failure issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: android
 jdk: oraclejdk8
 sudo: required
-dist: precise # For 7.5GB of memory since the emulator requires a big chunk.
+# Use trusty distribution to resolve the adb(requires at least GLIBC_2.16 version) execution failure
+# Reference: https://github.com/atom/atom/issues/14440#issuecomment-302158430
+# Reference: https://docs.travis-ci.com/user/reference/trusty/
+dist: trusty # For 7.5GB of memory since the emulator requires a big chunk.
 env:
   matrix:
     - ANDROID_TARGET=android-27
@@ -15,6 +18,12 @@ android:
     - build-tools-27.0.3
     # The SDK version used to compile the project
     - android-27
+    # Required to define the system image for an Android-21 emulator to use
+    # Reference: https://github.com/travis-ci/travis-ci/issues/6606#issuecomment-257090318
+    - android-21
+    # Defined for adding emulator system image type and android version
+    # (required by trusty distribution) before creating an emulator.
+    - sys-img-armeabi-v7a-android-21
     # Additional components
     - extra-google-m2repository
     - extra-android-m2repository


### PR DESCRIPTION
### Description

[LEARNER-7191](https://openedx.atlassian.net/browse/LEARNER-7191)

- Update the Travis-CI OS version configuration to `trusty(Ubuntu 14.04 LTS)` to resolve the `GLIBC_2.16 not found` issue while executing the `adb` command.
- Define system-image and android SDK (emulator android-21) as per requirement of `trusty`.

Reference:
https://github.com/atom/atom/issues/14440#issuecomment-302158430
https://github.com/travis-ci/travis-ci/issues/6606#issuecomment-257090318