### PR TITLE
Increasing travis e2e command time out to 30 minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
   # Check if emulator has finished booting
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
-  - travis_wait make e2e
+  - travis_wait 30 make e2e
   # Script to print lint information in logs.
   - ./gradlew lintProdDebug --info
 


### PR DESCRIPTION
### Description

Our travis build often fails due to time out error occurs on`travis_wait make e2e` command whose default waiting time is 20 minutes, we have increased it to 30 minutes to mitigate the situation.

Ref: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
