### PR TITLE
Bump Facebook SDK version from 4.36.0 to 4.41.0

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -142,7 +142,7 @@ dependencies {
 //    Exo Player
     implementation 'com.google.android.exoplayer:exoplayer:2.9.2'
 
-    implementation 'com.facebook.android:facebook-login:4.36.0'
+    implementation 'com.facebook.android:facebook-login:4.41.0'
     implementation 'com.google.code.gson:gson:2.7'
     implementation 'de.greenrobot:eventbus:2.4.1'
     implementation 'com.squareup.phrase:phrase:1.1.0'


### PR DESCRIPTION
### Description

[LEARNER-7227](https://openedx.atlassian.net/browse/LEARNER-7227)

Updated Fb SDK version from 4.36.0 to 4.41.0.

SDK change log:
https://developers.facebook.com/docs/android/change-log-4x

SDK upgrade guide:
https://developers.facebook.com/docs/android/upgrading-4x

Graph API change log:
https://developers.facebook.com/docs/graph-api/changelog

p.s. More details can be found on the mentioned ticket.

### Testing
- [x] Fb login is working
- [x] Fb register is working
