### PR TITLE
Fix 'No Activity found' crash for invalid web urls.

### DIFF
--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -30,6 +30,8 @@
     <string name="you_are_now_enrolled">You are now enrolled in this course.</string>
     <!-- Error message shown when dashboard cannot be shown from course detail view -->
     <string name="cannot_show_dashboard">Unable to show dashboard.</string>
+    <!-- Error message shown when browser cannot handle request for given web url -->
+    <string name="cannot_open_url" tools:ignore="MissingTranslation">Unable to open web page.</string>
 
     <!-- Subjects Discovery -->
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/WebViewCourseInfoFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/WebViewCourseInfoFragment.java
@@ -45,8 +45,8 @@ public class WebViewCourseInfoFragment extends BaseWebViewFragment
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        loadUrl(getInitialUrl());
         setWebViewActionListener();
+        loadUrl(getInitialUrl());
         if (null != savedInstanceState) {
             lastClickEnrollCourseId = savedInstanceState.getString(INSTANCE_COURSE_ID);
             lastClickEnrollEmailOptIn = savedInstanceState.getBoolean(INSTANCE_EMAIL_OPT_IN);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/WebViewProgramInfoFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/WebViewProgramInfoFragment.java
@@ -33,8 +33,8 @@ public class WebViewProgramInfoFragment extends BaseWebViewFragment
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        loadUrl(getInitialUrl());
         setWebViewActionListener();
+        loadUrl(getInitialUrl());
     }
 
     public void setWebViewActionListener() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/BrowserUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/BrowserUtil.java
@@ -1,12 +1,15 @@
 package org.edx.mobile.util;
 
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.net.Uri;
 import android.support.v4.app.FragmentActivity;
 import android.text.TextUtils;
+import android.widget.Toast;
 
 import com.google.inject.Inject;
 
+import org.edx.mobile.R;
 import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.logger.Logger;
 import org.edx.mobile.module.analytics.AnalyticsRegistry;
@@ -87,10 +90,17 @@ public class BrowserUtil {
         intent.addCategory(Intent.CATEGORY_BROWSABLE);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.setData(Uri.parse(url));
-        context.startActivity(intent);
+        try {
+            context.startActivity(intent);
+            AnalyticsRegistry analyticsRegistry = environment.getAnalyticsRegistry();
+            analyticsRegistry.trackBrowserLaunched(url);
+        } catch (ActivityNotFoundException e) {
+            Toast.makeText(context, R.string.cannot_open_url, Toast.LENGTH_SHORT).show();
 
-        AnalyticsRegistry analyticsRegistry = environment.getAnalyticsRegistry();
-        analyticsRegistry.trackBrowserLaunched(url);
+            // Send non-fatal exception
+            logger.error(new Exception(String.format("No activity found (browser cannot handle request) for this url: %s, error:\n", url)
+                    + e.getMessage()), true);
+        }
     }
 
     public static boolean isUrlOfHost(String url, String host) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/WebViewDiscoverFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/WebViewDiscoverFragment.java
@@ -55,6 +55,7 @@ public abstract class WebViewDiscoverFragment extends BaseWebViewFragment {
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        setWebViewActionListener();
         // Check for search query in extras
         String searchQueryExtra = null;
         String searchUrl = null;
@@ -74,7 +75,6 @@ public abstract class WebViewDiscoverFragment extends BaseWebViewFragment {
         if (!EventBus.getDefault().isRegistered(this)) {
             EventBus.getDefault().register(this);
         }
-        setWebViewActionListener();
     }
 
     public void setWebViewActionListener() {


### PR DESCRIPTION
### Description

[LEARNER-3191](https://openedx.atlassian.net/browse/LEARNER-3191)

- On analysis of crash logs it seems it occurs when we are unable to recognize particular marketing urls due to null reference of 'actionListener' field exist in 'URLInterceptorWebViewClient.parseRecognizedLinkAndCallListener' callback. In this fix we have make sure to avoid possible scenarios causing this.
- We are showing toast to user if it still happen in some case rather than allowing the app to crash and we are sending crash report to server.

