### PR TITLE
Add Firebase Performance SDK

### DIFF
--- a/OpenEdXMobile/AndroidManifest.xml
+++ b/OpenEdXMobile/AndroidManifest.xml
@@ -340,6 +340,9 @@
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_color"
             android:resource="@color/edx_brand_primary_accent" />
+        <meta-data
+            android:name="firebase_performance_logcat_enabled"
+            android:value="true" />
 
     </application>
 

--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -132,12 +132,16 @@ dependencies {
     // For the optional Nullable annotation
     implementation "com.android.support:support-annotations:${SUPPORT_LIBRARY_VERSION}"
 
+    // NOTE: Always update the version of google-services and firebase libraries using the ones
+    // provided in this link: https://developers.google.com/android/guides/releases
     implementation "com.google.android.gms:play-services-plus:16.0.0"
-    implementation "com.google.android.gms:play-services-analytics:16.0.6"
+    implementation "com.google.android.gms:play-services-analytics:16.0.8"
     implementation "com.google.android.gms:play-services-auth:16.0.1"
     // Google Firebase
-    implementation "com.google.firebase:firebase-core:16.0.6"
-    implementation "com.google.firebase:firebase-messaging:17.3.4"
+    implementation "com.google.firebase:firebase-core:16.0.9"
+    implementation "com.google.firebase:firebase-messaging:18.0.0"
+    // Add the dependency for the Performance Monitoring library
+    implementation 'com.google.firebase:firebase-perf:17.0.0'
 
 //    Exo Player
     implementation 'com.google.android.exoplayer:exoplayer:2.9.2'
@@ -242,6 +246,8 @@ def firebase = config.get('FIREBASE')
 def firebaseEnabled = firebase?.get('ENABLED')
 if (firebaseEnabled?: false) {
     apply plugin: 'com.google.gms.google-services'
+    // Apply the Performance Monitoring plugin to enable instrumentation
+    apply plugin: 'com.google.firebase.firebase-perf'
 }
 
 android {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/loader/CoursesAsyncLoader.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/loader/CoursesAsyncLoader.java
@@ -58,7 +58,6 @@ public class CoursesAsyncLoader extends AsyncTaskLoader<AsyncTaskResult<List<Enr
         }
 
         result.setResult(enrolledCoursesResponse);
-
         return result;
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:${GRADLE_PLUGIN_VERSION}"
         classpath 'com.google.gms:google-services:4.2.0'
+        // Add the dependency for the Performance Monitoring plugin
+        classpath 'com.google.firebase:perf-plugin:1.2.1'  // Performance Monitoring plugin
     }
 }
 


### PR DESCRIPTION
### Description

[LEARNER-7249](https://openedx.atlassian.net/browse/LEARNER-7249)

### Testing

1. `ENABLED` should be set to `true` inside `FIREBASE` config for the Performance logs to appear on Firebase console.
2. Before testing `google-services.json` file should first be replaced with a test project's `google-services.json` so that the logs don't appear on a prod project.
3. For testing custom perf logs check out the first commit of this PR i.e. https://github.com/edx/edx-app-android/pull/1295/commits/cd7dd933485476cd5bf0708e9b606fcbb67a5a4d (cuz in the 2nd the commit https://github.com/edx/edx-app-android/pull/1295/commits/152186211024f0ddcb56611b2a2e7971d5fe32c1 I've removed custom perf logs code)