### PR TITLE
Implement Analytics for Video Speed Controls

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
@@ -83,6 +83,19 @@ public interface Analytics {
                              String courseId, String unitUrl);
 
     /**
+     * This function is used to track the video playback speed changes
+     *
+     * @param videoId
+     * @param currentTime
+     * @param courseId
+     * @param unitUrl
+     * @param oldSpeed
+     * @param newSpeed
+     */
+    void trackVideoSpeed(String videoId, Double currentTime, String courseId,
+                         String unitUrl, float oldSpeed, float newSpeed);
+
+    /**
      * This function is used to track Video Loading
      *
      * @param videoId
@@ -383,6 +396,8 @@ public interface Analytics {
         String USER_ID = "user_id";
         String OLD_TIME = "old_time";
         String NEW_TIME = "new_time";
+        String NEW_SPEED = "new_speed";
+        String OLD_SPEED = "old_speed";
         String SEEK_TYPE = "seek_type";
         String REQUESTED_SKIP_INTERVAL = "requested_skip_interval";
         String MODULE_ID = "module_id";
@@ -458,6 +473,7 @@ public interface Analytics {
         //The seek event name has been changed as per MOB-1273
         String VIDEO_SEEKED = "edx.video.position.changed";
         String TRANSCRIPT_SHOWN = "edx.video.transcript.shown";
+        String VIDEO_PLAYBACK_SPEED_CHANGED = "edx.bi.video.speed.changed";
         String TRANSCRIPT_HIDDEN = "edx.video.transcript.hidden";
         String TRANSCRIPT_LANGUAGE = "edx.bi.video.transcript.language.selected";
         String FULLSREEN_TOGGLED = "edx.bi.video.screen.fullscreen.toggled";
@@ -586,6 +602,7 @@ public interface Analytics {
         String STOPPED_VIDEO = "Stopped Video";
         String SEEK_VIDEO = "Seeked Video";
         String SHOW_TRANSCRIPT = "Show Transcript";
+        String SPEED_CHANGE_VIDEO = "Speed Change Video";
         String HIDE_TRANSCRIPT = "Hide Transcript";
         String VIDEO_DOWNLOADED = "Video Downloaded";
         String BULK_DOWNLOAD_SUBSECTION = "Bulk Download Subsection";

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/AnalyticsRegistry.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/AnalyticsRegistry.java
@@ -197,6 +197,13 @@ public class AnalyticsRegistry implements Analytics {
         }
     }
 
+    public void trackVideoSpeed(String videoId, Double currentTime,
+                                String courseId, String unitUrl, float oldSpeed, float newSpeed) {
+        for (Analytics service : services) {
+            service.trackVideoSpeed(videoId, currentTime, courseId, unitUrl, oldSpeed, newSpeed);
+        }
+    }
+
     @Override
     public void trackVideoSeek(String videoId, Double oldTime, Double newTime,
                                String courseId, String unitUrl, Boolean skipSeek) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/AnswersAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/AnswersAnalytics.java
@@ -58,6 +58,11 @@ public class AnswersAnalytics implements Analytics {
     }
 
     @Override
+    public void trackVideoSpeed(String videoId, Double currentTime, String courseId,
+                                String unitUrl, float oldSpeed, float newSpeed) {
+    }
+
+    @Override
     public void trackHideTranscript(String videoId, Double currentTime, String courseId, String unitUrl) {
 
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/FirebaseAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/FirebaseAnalytics.java
@@ -140,6 +140,27 @@ public class FirebaseAnalytics implements Analytics {
         logFirebaseEvent(event.getName(), event.getBundle());
     }
 
+    /**
+     * This function is used to track the video playback speed changes
+     *
+     * @param videoId
+     * @param currentTime
+     * @param courseId
+     * @param unitUrl
+     * @param oldSpeed
+     * @param newSpeed
+     */
+    @Override
+    public void trackVideoSpeed(String videoId, Double currentTime, String courseId,
+                                String unitUrl, float oldSpeed, float newSpeed) {
+        final FirebaseEvent event = new FirebaseEvent(Events.SPEED_CHANGE_VIDEO,
+                videoId, Values.VIDEO_PLAYBACK_SPEED_CHANGED, currentTime);
+        event.setCourseContext(courseId, unitUrl, Values.VIDEOPLAYER);
+        event.putFloat(Keys.NEW_SPEED, newSpeed);
+        event.putFloat(Keys.OLD_SPEED, oldSpeed);
+        logFirebaseEvent(event.getName(), event.getBundle());
+    }
+
     @Override
     public void trackHideTranscript(String videoId, Double currentTime, String courseId,
                                     String unitUrl) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
@@ -226,6 +226,27 @@ public class SegmentAnalytics implements Analytics {
     }
 
     /**
+     * This function is used to track the video playback speed changes
+     *
+     * @param videoId
+     * @param currentTime
+     * @param courseId
+     * @param unitUrl
+     * @param oldSpeed
+     * @param newSpeed
+     */
+    @Override
+    public void trackVideoSpeed(String videoId, Double currentTime, String courseId,
+                                String unitUrl, float oldSpeed, float newSpeed) {
+        SegmentEvent aEvent = getCommonPropertiesWithCurrentTime(currentTime,
+                videoId, Values.VIDEO_PLAYBACK_SPEED_CHANGED);
+        aEvent.setCourseContext(courseId, unitUrl, Values.VIDEOPLAYER);
+        aEvent.data.putValue(Keys.NEW_SPEED, newSpeed);
+        aEvent.data.putValue(Keys.OLD_SPEED, oldSpeed);
+        trackSegmentEvent(Events.SPEED_CHANGE_VIDEO, aEvent.properties);
+    }
+
+    /**
      * This function is used to Hide Transcript
      *
      * @param videoId

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
@@ -1453,9 +1453,14 @@ public class PlayerFragment extends BaseFragment implements IPlayerListener, Ser
         speedDialogFragment = SpeedDialogFragment.getInstance(new SpeedDialogFragment.IListDialogCallback() {
             @Override
             public void onItemClicked(Float speed) {
-                loginPrefs.saveDefaultPlaybackSpeed(speed);
                 if (player != null) {
+                    float oldSpeed = loginPrefs.getDefaultPlaybackSpeed();
+                    loginPrefs.saveDefaultPlaybackSpeed(speed);
                     player.setPlaybackSpeed(speed);
+
+                    environment.getAnalyticsRegistry().trackVideoSpeed(videoEntry.videoId,
+                            player.getCurrentPosition() / AppConstants.MILLISECONDS_PER_SECOND,
+                            videoEntry.eid, videoEntry.lmsUrl, oldSpeed, speed);
                 }
             }
 


### PR DESCRIPTION
### Description

[LEARNER-7296](https://openedx.atlassian.net/browse/LEARNER-7296)
- Implement Analytics for Video Speed Controls
- Track playback speed change event.

**Note**
Sample Json to track the video speed changes event.

`Displayname: Speed Change Video`

``` 
Data: [
  "data": [
    "code": mobile,
    "current_time": 2.805422222222222,
    "new_speed": 0.0,
    "old_speed": 0.5,
    "module_id": block-v1: HarvardX+SKY101x+3T2018+type@video+block@6d7db10b87c14b02888bcfe9b55a85d2
  ],
  "category": "",
  "device-orientation": "portrait",
  "name": "edx.bi.video.speed.changed",
  "label": "",
  "context": [
    "app_name": "edx.mobileapp.iOS",
    "component": "videoplayer",
    "open_in_browser_url": "https: www.testurl.com",
    "course_id": "course-v1: HarvardX+SKY101x+3T2018"
  ],
  "user_id": 1041740
]

```