### PR TITLE
Resolve FragmentManager.java line#1454 issue

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java
@@ -188,8 +188,14 @@ public class CourseOutlineAdapter extends BaseAdapter {
                     final Activity activity = parentFragment.getActivity();
                     if (activity != null && ((RoboAppCompatActivity) activity).isInForeground()) {
                         final BulkDownloadFragment fragment = new BulkDownloadFragment(downloadListener, environment);
-                        parentFragment.getChildFragmentManager().
-                                beginTransaction().replace(convertView.getId(), fragment).commit();
+                        final View finalConvertView = convertView;
+                        // Wait until the convertView has attached with the parent view.
+                        // Using commitNowAllowingStateLoss() method here because there is
+                        // chance transaction could have happened even the fragments state
+                        // is saved.
+                        convertView.post(() -> parentFragment.getChildFragmentManager().
+                                beginTransaction().replace(finalConvertView.getId(), fragment).
+                                commitNowAllowingStateLoss());
                         convertView.setTag(fragment);
                     }
                     break;


### PR DESCRIPTION
### Description

[LEARNER-7297](https://openedx.atlassian.net/browse/LEARNER-7297)
- Resolve FragmentManager.java line#1454 issue
- Wait before replacing the BulkDownloadFragment until container attached with the parent view

**Steps to reproduce:** 
Issue can be reproduce by calling the `commitNow()` method instated of `commit()` method on [this line](https://github.com/edx/edx-app-android/blob/master/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/CourseOutlineAdapter.java#L192)