### PR TITLE
Implement Segment's implementation for Firebase

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -171,7 +171,9 @@ dependencies {
 
     // Segment Library
     implementation 'com.segment.analytics.android:analytics:4.2.6'
-
+    // Segment's Firebase integration
+    implementation 'com.segment.analytics.android.integrations:firebase:1.2.0'
+    // Segment's GA integration
     implementation('com.segment.analytics.android.integrations:google-analytics:1.0.0') {
         exclude module: 'play-services-analytics'
         transitive = true

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -132,10 +132,9 @@ public abstract class MainApplication extends MultiDexApplication {
         // Add Segment as an analytics provider if enabled in the config
         if (config.getSegmentConfig().isEnabled()) {
             analyticsRegistry.addAnalyticsProvider(injector.getInstance(SegmentAnalytics.class));
-        }
-
-        // Add Firebase as an analytics provider if enabled in the config
-        if (config.getFirebaseConfig().isAnalyticsEnabled()) {
+        } else if (config.getFirebaseConfig().isAnalyticsEnabled()) {
+            // Only add Firebase as an analytics provider if enabled in the config and Segment is disabled
+            // because if Segment is enabled, we'll be using Segment's implementation for Firebase
             analyticsRegistry.addAnalyticsProvider(injector.getInstance(FirebaseAnalytics.class));
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ allprojects {
         // The order in which you list these repositories matter.
         google()
         jcenter()
+        maven { url 'https://maven.google.com' }
     }
     project.apply from: "${rootDir}/constants.gradle"
 }


### PR DESCRIPTION
### Description

[LEARNER-7284](https://openedx.atlassian.net/browse/LEARNER-7284)

Following are the requirements that this commit meets:

- Standalone Firebase Analytics implementation is not deleted.
- If Segment is enabled and Firebase Analytics is also enabled in the configs, use the Segment's integration for Firebase Analytics.
- If Segment is disabled and only Firebase Analytics is enabled in the configs, use the standalone Firebase Analytics implementation.

### Testing

To check Firebase analytics in real-time, use DebugView to validate your analytics configuration during development:
https://support.google.com/firebase/answer/7201382?hl=en

### Note

Currently Android and iOS have a slight difference in their Segment + Firebase implementation, parity of which will be achieved as part of the following ticket:

`Mobile Config - Implement feature flag parity for Segment-Firebase implementation`
https://openedx.atlassian.net/browse/LEARNER-7325
