### PR TITLE
Resolve InflateException issue in EdxWebView

### DIFF
--- a/OpenEdXMobile/res/values/text_styles.xml
+++ b/OpenEdXMobile/res/values/text_styles.xml
@@ -57,8 +57,8 @@
     </style>
 
     <style name="content_unavailable_layout">
-        <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">match_parent</item>
         <item name="android:layout_gravity">center</item>
         <item name="android:layout_centerInParent">true</item>
         <item name="android:gravity">center</item>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/annotation/Nullable.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/annotation/Nullable.java
@@ -1,0 +1,18 @@
+package org.edx.mobile.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Added as an alternative of {@link roboguice.inject.Nullable} to support injecting of nullable
+ * views using {@link roboguice.inject.InjectView}.
+ * Ref: https://stackoverflow.com/a/29946794
+ */
+@Target({ElementType.FIELD, ElementType.METHOD,
+        ElementType.PARAMETER,
+        ElementType.LOCAL_VARIABLE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Nullable {
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/UiUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/UiUtil.java
@@ -1,6 +1,5 @@
 package org.edx.mobile.util;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -10,6 +9,7 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.RawRes;
+import android.support.v4.app.Fragment;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.util.TypedValue;
 import android.view.View;
@@ -123,5 +123,18 @@ public class UiUtil {
     public static void setSwipeRefreshLayoutColors(@NonNull SwipeRefreshLayout swipeRefreshLayout) {
         swipeRefreshLayout.setColorSchemeResources(R.color.edx_brand_primary_accent,
                 R.color.edx_brand_gray_x_back);
+    }
+
+    /**
+     * Restarts the fragment without destroying the fragment instance.
+     *
+     * @param The fragment to restart.
+     */
+    public static void restartFragment(@Nullable Fragment fragment) {
+        if (fragment != null) {
+            fragment.getFragmentManager().beginTransaction()
+                    .detach(fragment)
+                    .attach(fragment).commitAllowingStateLoss();
+        }
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/AuthenticatedWebViewFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/AuthenticatedWebViewFragment.java
@@ -6,13 +6,20 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.text.TextUtils;
+import android.view.InflateException;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.joanzapata.iconify.fonts.FontAwesomeIcons;
+import com.joanzapata.iconify.widget.IconImageView;
 
 import org.edx.mobile.R;
 import org.edx.mobile.base.BaseFragment;
 import org.edx.mobile.logger.Logger;
+import org.edx.mobile.util.UiUtil;
 import org.edx.mobile.view.custom.AuthenticatedWebView;
 
 import roboguice.inject.InjectView;
@@ -22,16 +29,28 @@ import roboguice.inject.InjectView;
  * Javascript can also be passed in arguments for evaluation.
  */
 public class AuthenticatedWebViewFragment extends BaseFragment {
-    protected final Logger logger = new Logger(getClass().getName());
     public static final String ARG_URL = "ARG_URL";
     public static final String ARG_JAVASCRIPT = "ARG_JAVASCRIPT";
     public static final String ARG_IS_MANUALLY_RELOADABLE = "ARG_IS_MANUALLY_RELOADABLE";
+    protected final Logger logger = new Logger(getClass().getName());
 
+    @org.edx.mobile.annotation.Nullable
     @InjectView(R.id.auth_webview)
     protected AuthenticatedWebView authWebView;
 
+    @org.edx.mobile.annotation.Nullable
     @InjectView(R.id.swipe_container)
     protected SwipeRefreshLayout swipeContainer;
+
+    @org.edx.mobile.annotation.Nullable
+    @InjectView(R.id.content_error_text)
+    protected TextView tvContentError;
+
+    @org.edx.mobile.annotation.Nullable
+    @InjectView(R.id.content_error_action)
+    protected Button btnContentErrorAction;
+
+    private boolean isSystemUpdatingWebView = false;
 
     public static Bundle makeArguments(@NonNull String url, @Nullable String javascript, boolean isManuallyReloadable) {
         final Bundle args = new Bundle();
@@ -62,50 +81,92 @@ public class AuthenticatedWebViewFragment extends BaseFragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_authenticated_webview, container, false);
+        /*
+         * In some cases like system updating the WebView, it is not available for rendering and the
+         * system raises an InflateException. To handle this case we're showing a full-screen error
+         * with reload button.
+         * More info on JIRA story: LEARNER-7267
+         * */
+        try {
+            isSystemUpdatingWebView = false;
+            return inflater.inflate(R.layout.fragment_authenticated_webview, container, false);
+        } catch (InflateException e) {
+            logger.error(e, true);
+            isSystemUpdatingWebView = true;
+            return inflater.inflate(R.layout.content_error, container, false);
+        }
     }
 
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        // Disable the SwipeRefreshLayout by-default to allow the subclasses to provide a proper implementation for it
-        swipeContainer.setEnabled(false);
+        if (!isSystemUpdatingWebView) {
+            // Disable the SwipeRefreshLayout by-default to allow the subclasses to provide a proper implementation for it
+            swipeContainer.setEnabled(false);
+        } else {
+            view.findViewById(R.id.content_error).setVisibility(View.VISIBLE);
+            final IconImageView ivContentError = view.findViewById(R.id.content_error_icon);
+            ivContentError.setIcon(FontAwesomeIcons.fa_exclamation_circle);
+            tvContentError.setText(getString(R.string.error_unknown));
+            btnContentErrorAction.setVisibility(View.VISIBLE);
+            btnContentErrorAction.setText(R.string.lbl_reload);
+            btnContentErrorAction.setOnClickListener(
+                    v -> UiUtil.restartFragment(AuthenticatedWebViewFragment.this));
+        }
     }
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        if (getArguments() != null) {
-            final String url = getArguments().getString(ARG_URL);
-            final String javascript = getArguments().getString(ARG_JAVASCRIPT);
-            final boolean isManuallyReloadable = getArguments().getBoolean(ARG_IS_MANUALLY_RELOADABLE);
+        if (!isSystemUpdatingWebView) {
+            if (getArguments() != null) {
+                final String url = getArguments().getString(ARG_URL);
+                final String javascript = getArguments().getString(ARG_JAVASCRIPT);
+                final boolean isManuallyReloadable = getArguments().getBoolean(ARG_IS_MANUALLY_RELOADABLE);
 
-            authWebView.initWebView(getActivity(), false, isManuallyReloadable);
-            authWebView.loadUrlWithJavascript(true, url, javascript);
+                authWebView.initWebView(getActivity(), false, isManuallyReloadable);
+                authWebView.loadUrlWithJavascript(true, url, javascript);
+            }
         }
     }
 
     @Override
     public void onResume() {
         super.onResume();
-        authWebView.onResume();
+        if (!isSystemUpdatingWebView) {
+            authWebView.onResume();
+        }
     }
 
     @Override
     public void onPause() {
         super.onPause();
-        authWebView.onPause();
+        if (!isSystemUpdatingWebView) {
+            authWebView.onPause();
+        }
     }
 
     @Override
     public void onDestroy() {
         super.onDestroy();
-        authWebView.onDestroy();
+        if (!isSystemUpdatingWebView) {
+            authWebView.onDestroy();
+        }
     }
 
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        authWebView.onDestroyView();
+        if (!isSystemUpdatingWebView) {
+            authWebView.onDestroyView();
+        }
+    }
+
+    /**
+     * @return <code>true</code> if the system is updating the WebView package, <code>false</code>
+     * otherwise.
+     */
+    public boolean isSystemUpdatingWebView() {
+        return isSystemUpdatingWebView;
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesFragment.java
@@ -58,7 +58,9 @@ public class CourseDatesFragment extends AuthenticatedWebViewFragment {
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        EventBus.getDefault().registerSticky(this);
+        if (!EventBus.getDefault().isRegistered(this)) {
+            EventBus.getDefault().registerSticky(this);
+        }
     }
 
     @Override
@@ -70,7 +72,8 @@ public class CourseDatesFragment extends AuthenticatedWebViewFragment {
 
     @SuppressWarnings("unused")
     public void onEvent(NetworkConnectivityChangeEvent event) {
-        OfflineSupportUtils.onNetworkConnectivityChangeEvent(getActivity(), getUserVisibleHint(), authWebView.isShowingError());
+        OfflineSupportUtils.onNetworkConnectivityChangeEvent(getActivity(), getUserVisibleHint(),
+                authWebView != null && authWebView.isShowingError());
     }
 
     @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardFragment.java
@@ -31,6 +31,7 @@ import org.edx.mobile.module.analytics.AnalyticsRegistry;
 import org.edx.mobile.module.db.DataCallback;
 import org.edx.mobile.util.DateUtil;
 import org.edx.mobile.util.NetworkUtil;
+import org.edx.mobile.util.UiUtil;
 import org.edx.mobile.util.images.ShareUtils;
 import org.edx.mobile.view.custom.ProgressWheel;
 
@@ -129,9 +130,7 @@ public class CourseTabsDashboardFragment extends TabsBaseFragment {
             protected void onResponse(@NonNull final EnrolledCoursesResponse course) {
                 if (getActivity() != null) {
                     getArguments().putSerializable(Router.EXTRA_COURSE_DATA, course);
-                    getFragmentManager().beginTransaction()
-                            .detach(CourseTabsDashboardFragment.this)
-                            .attach(CourseTabsDashboardFragment.this).commitAllowingStateLoss();
+                    UiUtil.restartFragment(CourseTabsDashboardFragment.this);
                 }
             }
 
@@ -139,9 +138,7 @@ public class CourseTabsDashboardFragment extends TabsBaseFragment {
             protected void onFailure(@NonNull final Throwable error) {
                 if (getActivity() != null) {
                     getArguments().putBoolean(ARG_COURSE_NOT_FOUND, true);
-                    getFragmentManager().beginTransaction()
-                            .detach(CourseTabsDashboardFragment.this)
-                            .attach(CourseTabsDashboardFragment.this).commitAllowingStateLoss();
+                    UiUtil.restartFragment(CourseTabsDashboardFragment.this);
                     logger.error(new Exception("Invalid Course ID provided via deeplink: " + courseId), true);
                 }
             }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/WebViewProgramFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/WebViewProgramFragment.java
@@ -1,5 +1,6 @@
 package org.edx.mobile.view;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
@@ -12,6 +13,7 @@ import android.webkit.WebView;
 import android.widget.ProgressBar;
 
 import org.edx.mobile.R;
+import org.edx.mobile.annotation.Nullable;
 import org.edx.mobile.event.EnrolledInCourseEvent;
 import org.edx.mobile.event.NetworkConnectivityChangeEvent;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
@@ -24,6 +26,8 @@ import de.greenrobot.event.EventBus;
 import roboguice.inject.InjectView;
 
 public class WebViewProgramFragment extends AuthenticatedWebViewFragment {
+
+    @Nullable
     @InjectView(R.id.loading_indicator)
     private ProgressBar progressWheel;
 
@@ -37,101 +41,109 @@ public class WebViewProgramFragment extends AuthenticatedWebViewFragment {
     }
 
     @Override
-    public void onViewCreated(View view, Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-        EventBus.getDefault().register(this);
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if (!EventBus.getDefault().isRegistered(this)) {
+            EventBus.getDefault().register(this);
+        }
     }
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        authWebView.getWebViewClient().setActionListener(new DefaultActionListener(getActivity(),
-                progressWheel, new DefaultActionListener.EnrollCallback() {
-            @Override
-            public void onResponse(@NonNull EnrolledCoursesResponse course) {
+        if (!isSystemUpdatingWebView()) {
+            authWebView.getWebViewClient().setActionListener(new DefaultActionListener(getActivity(),
+                    progressWheel, new DefaultActionListener.EnrollCallback() {
+                @Override
+                public void onResponse(@NonNull EnrolledCoursesResponse course) {
 
-            }
+                }
 
-            @Override
-            public void onFailure(@NonNull Throwable error) {
+                @Override
+                public void onFailure(@NonNull Throwable error) {
 
-            }
+                }
 
-            @Override
-            public void onUserNotLoggedIn(@NonNull String courseId, boolean emailOptIn) {
+                @Override
+                public void onUserNotLoggedIn(@NonNull String courseId, boolean emailOptIn) {
 
-            }
-        }));
+                }
+            }));
 
-        authWebView.getWebViewClient().setPageStatusListener(new URLInterceptorWebViewClient.IPageStatusListener() {
-            @Override
-            public void onPageStarted() {
-            }
+            authWebView.getWebViewClient().setPageStatusListener(new URLInterceptorWebViewClient.IPageStatusListener() {
+                @Override
+                public void onPageStarted() {
+                }
 
-            @Override
-            public void onPageFinished() {
-                swipeContainer.setRefreshing(false);
-                tryEnablingSwipeContainer();
-            }
+                @Override
+                public void onPageFinished() {
+                    swipeContainer.setRefreshing(false);
+                    tryEnablingSwipeContainer();
+                }
 
-            @Override
-            public void onPageLoadError(WebView view, int errorCode, String description, String failingUrl) {
-                onPageFinished();
-            }
+                @Override
+                public void onPageLoadError(WebView view, int errorCode, String description, String failingUrl) {
+                    onPageFinished();
+                }
 
-            @Override
-            public void onPageLoadError(WebView view, WebResourceRequest request, WebResourceResponse errorResponse, boolean isMainRequestFailure) {
-                onPageFinished();
-            }
+                @Override
+                public void onPageLoadError(WebView view, WebResourceRequest request, WebResourceResponse errorResponse, boolean isMainRequestFailure) {
+                    onPageFinished();
+                }
 
-            @Override
-            public void onPageLoadProgressChanged(WebView webView, int progress) {
+                @Override
+                public void onPageLoadProgressChanged(WebView webView, int progress) {
 
-            }
-        });
+                }
+            });
 
-        tryEnablingSwipeContainer();
-        UiUtil.setSwipeRefreshLayoutColors(swipeContainer);
-        swipeContainer.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
-            @Override
-            public void onRefresh() {
-                // We already have spinner inside the WebView, so we don't need the SwipeRefreshLayout's spinner
-                swipeContainer.setEnabled(false);
-                authWebView.loadUrl(true, authWebView.getWebView().getUrl());
-            }
-        });
+            tryEnablingSwipeContainer();
+            UiUtil.setSwipeRefreshLayoutColors(swipeContainer);
+            swipeContainer.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
+                @Override
+                public void onRefresh() {
+                    // We already have spinner inside the WebView, so we don't need the SwipeRefreshLayout's spinner
+                    swipeContainer.setEnabled(false);
+                    authWebView.loadUrl(true, authWebView.getWebView().getUrl());
+                }
+            });
+        }
     }
 
     @Override
     public void onStart() {
         super.onStart();
-        /*
-        SwipeRefreshLayout intercepts and acts upon the scroll even when its child layout hasn't
-        scrolled to its top, which leads to refresh logic happening and spinner appearing mid-scroll.
-        With the following logic, we are forcing the SwipeRefreshLayout to use the scroll only when
-        the underlying WebView has scrolled to its top.
-        More info can be found on this SO question: https://stackoverflow.com/q/24658428/1402616
-         */
-        swipeContainer.getViewTreeObserver().addOnScrollChangedListener(onScrollChangedListener =
-                new ViewTreeObserver.OnScrollChangedListener() {
-                    @Override
-                    public void onScrollChanged() {
-                        if (!tryEnablingSwipeContainer())
-                            swipeContainer.setEnabled(false);
-                    }
-                });
+        if (!isSystemUpdatingWebView()) {
+            /*
+            SwipeRefreshLayout intercepts and acts upon the scroll even when its child layout hasn't
+            scrolled to its top, which leads to refresh logic happening and spinner appearing mid-scroll.
+            With the following logic, we are forcing the SwipeRefreshLayout to use the scroll only when
+            the underlying WebView has scrolled to its top.
+            More info can be found on this SO question: https://stackoverflow.com/q/24658428/1402616
+             */
+            swipeContainer.getViewTreeObserver().addOnScrollChangedListener(onScrollChangedListener =
+                    new ViewTreeObserver.OnScrollChangedListener() {
+                        @Override
+                        public void onScrollChanged() {
+                            if (!tryEnablingSwipeContainer())
+                                swipeContainer.setEnabled(false);
+                        }
+                    });
+        }
     }
 
     @Override
     public void onStop() {
         super.onStop();
-        swipeContainer.getViewTreeObserver().removeOnScrollChangedListener(onScrollChangedListener);
+        if (!isSystemUpdatingWebView()) {
+            swipeContainer.getViewTreeObserver().removeOnScrollChangedListener(onScrollChangedListener);
+        }
     }
 
     @Override
     public void onResume() {
         super.onResume();
-        if (refreshOnResume) {
+        if (!isSystemUpdatingWebView() && refreshOnResume) {
             refreshOnResume = false;
             // Swipe refresh shouldn't work while the page is refreshing
             swipeContainer.setEnabled(false);
@@ -148,13 +160,14 @@ public class WebViewProgramFragment extends AuthenticatedWebViewFragment {
 
     @SuppressWarnings("unused")
     public void onEvent(NetworkConnectivityChangeEvent event) {
-        if (getActivity() != null) {
+        if (!isSystemUpdatingWebView() && getActivity() != null) {
             if (!tryEnablingSwipeContainer()) {
                 //Disable swipe functionality and hide the loading view
                 swipeContainer.setEnabled(false);
                 swipeContainer.setRefreshing(false);
             }
-            OfflineSupportUtils.onNetworkConnectivityChangeEvent(getActivity(), getUserVisibleHint(), authWebView.isShowingError());
+            OfflineSupportUtils.onNetworkConnectivityChangeEvent(getActivity(), getUserVisibleHint(),
+                    authWebView != null && authWebView.isShowingError());
         }
     }
 
@@ -182,7 +195,7 @@ public class WebViewProgramFragment extends AuthenticatedWebViewFragment {
      * @return <code>true</code> if {@link #swipeContainer} was enabled, <code>false</code> otherwise.
      */
     private boolean tryEnablingSwipeContainer() {
-        if (getActivity() != null) {
+        if (!isSystemUpdatingWebView() && getActivity() != null) {
             if (NetworkUtil.isConnected(getActivity())
                     && !authWebView.isShowingError()
                     && progressWheel.getVisibility() != View.VISIBLE


### PR DESCRIPTION
### Description

[LEARNER-7267](https://openedx.atlassian.net/browse/LEARNER-7267)
- Unable to reproduce the crash, implement the hack solution by handling `InflateException` while `webview` is not available, show full screen error message and allow the user to reload the screen by placing the reload button.
- Create `Nullable` annotation for null able `view` at Runtime to support Roboguice `@InjectView`

**Ref:** https://stackoverflow.com/a/29946794
#### How to test.
- Manually raise the `InflateException`.

**When webview is not available**
![device-2019-06-19-165424](https://user-images.githubusercontent.com/43750646/59763492-26d7f800-92b3-11e9-9f60-2787a0eebc51.png)
