### PR TITLE
Fix video streaming edge case issues

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/EncodedVideos.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/EncodedVideos.java
@@ -5,9 +5,6 @@ import android.webkit.URLUtil;
 
 import com.google.gson.annotations.SerializedName;
 
-import org.edx.mobile.base.MainApplication;
-import org.edx.mobile.util.AppConstants;
-import org.edx.mobile.util.Config;
 import org.edx.mobile.util.VideoUtil;
 
 import java.io.Serializable;
@@ -31,6 +28,11 @@ public class EncodedVideos implements Serializable {
     @SerializedName("youtube")
     public VideoInfo youtube;
 
+    /**
+     * Extract the Preferred {@link VideoInfo} for media playback and to store in database.
+     *
+     * @return Preferred {@link VideoInfo}
+     */
     @Nullable
     public VideoInfo getPreferredVideoInfo() {
         if (isPreferredVideoInfo(hls)) {
@@ -42,19 +44,17 @@ public class EncodedVideos implements Serializable {
         if (isPreferredVideoInfo(mobileHigh)) {
             return mobileHigh;
         }
-        if (new Config(MainApplication.instance()).isUsingVideoPipeline()) {
-            if (fallback != null && URLUtil.isNetworkUrl(fallback.url) &&
-                    VideoUtil.videoHasFormat(fallback.url, AppConstants.VIDEO_FORMAT_M3U8)) {
-                return fallback;
-            }
-        } else {
-            if (isPreferredVideoInfo(fallback)) {
-                return fallback;
-            }
+        if (isPreferredVideoInfo(fallback)) {
+            return fallback;
         }
         return null;
     }
 
+    /**
+     * Extract the Preferred {@link VideoInfo} for media downloading.
+     *
+     * @return Preferred {@link VideoInfo}
+     */
     @Nullable
     public VideoInfo getPreferredVideoInfoForDownloading() {
         if (isPreferredVideoInfo(mobileLow)) {
@@ -63,8 +63,7 @@ public class EncodedVideos implements Serializable {
         if (isPreferredVideoInfo(mobileHigh)) {
             return mobileHigh;
         }
-        if (!new Config(MainApplication.instance()).isUsingVideoPipeline() &&
-                isPreferredVideoInfo(fallback) &&
+        if (isPreferredVideoInfo(fallback) &&
                 !VideoUtil.videoHasFormat(fallback.url, VIDEO_FORMAT_M3U8)) {
             return fallback;
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/VideoBlockModel.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/VideoBlockModel.java
@@ -29,7 +29,7 @@ public class VideoBlockModel extends CourseComponent implements HasDownloadEntry
 
     @Nullable
     public DownloadEntry getDownloadEntry(IStorage storage) {
-        if (data.encodedVideos.getPreferredVideoInfoForDownloading() == null) {
+        if (data.encodedVideos.getPreferredVideoInfo() == null) {
             return null;
         }
         if ( storage != null ) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/DatabaseModelFactory.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/db/DatabaseModelFactory.java
@@ -99,7 +99,7 @@ public class DatabaseModelFactory {
         IBlock root = block.getRoot();
         e.eid = root.getCourseId();
         e.duration = vrm.duration;
-        final VideoInfo preferredVideoInfo = vrm.encodedVideos.getPreferredVideoInfoForDownloading();
+        final VideoInfo preferredVideoInfo = vrm.encodedVideos.getPreferredVideoInfo();
         e.size = preferredVideoInfo.fileSize;
         e.title = block.getDisplayName();
         e.url = preferredVideoInfo.url;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/VideoUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/VideoUtil.java
@@ -2,6 +2,7 @@ package org.edx.mobile.util;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 
 import org.edx.mobile.base.MainApplication;
 import org.edx.mobile.model.course.VideoData;
@@ -65,25 +66,27 @@ public class VideoUtil {
      */
     @Nullable
     public static String getPreferredVideoUrlForDownloading(@NonNull VideoData video) {
+        String preferredVideoUrl = null;
         final VideoInfo preferredVideoInfo = video.encodedVideos.getPreferredVideoInfoForDownloading();
-        if (preferredVideoInfo == null || video.onlyOnWeb) {
-            return null;
-        }
-        if (!videoHasFormat(preferredVideoInfo.url, VIDEO_FORMAT_M3U8)) {
+
+        if (preferredVideoInfo != null &&
+                !TextUtils.isEmpty(preferredVideoInfo.url) &&
+                !video.onlyOnWeb &&
+                !videoHasFormat(preferredVideoInfo.url, VIDEO_FORMAT_M3U8)) {
             return preferredVideoInfo.url;
         }
+
         if (!new Config(MainApplication.instance()).isUsingVideoPipeline()) {
-            /**
-             * If preferred video url for downloading has HLS format and
-             * {@link Config#USING_VIDEO_PIPELINE} feature flag is disabled, try to find some .mp4
-             * format url from {@link VideoData#allSources} urls and consider it for download.
+            /*
+              If {@link Config#USING_VIDEO_PIPELINE} feature flag is disabled, try to find some .mp4
+              format url from {@link VideoData#allSources} urls and consider it for download.
              */
             for (String url : video.allSources) {
                 if (VideoUtil.videoHasFormat(url, AppConstants.VIDEO_FORMAT_MP4)) {
-                    return url;
+                    preferredVideoUrl = url;
                 }
             }
         }
-        return null;
+        return preferredVideoUrl;
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
@@ -227,7 +227,13 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
                                     videosStatus.remainingVideosSize += videoSize;
                                     videosStatus.totalVideosSize += videoSize;
                                 }
-                                remainingVideos.add((VideoBlockModel) video);
+                                /**
+                                 * Assign preferred downloadable url to {@link VideoBlockModel#downloadUrl},
+                                 * to use this url to download. After downloading only downloaded
+                                 * video path will be used for streaming.
+                                 */
+                                videoBlockModel.setDownloadUrl(VideoUtil.getPreferredVideoUrlForDownloading(videoBlockModel.getData()));
+                                remainingVideos.add(videoBlockModel);
                             }
                         }
 


### PR DESCRIPTION
## Description

[LEARNER-6468](https://openedx.atlassian.net/browse/LEARNER-6468)

- Define video encoding priorities for media playback & downloading on both cases pipeline is enabled or not.
- Store and retrieve last played position for the **.M3U8** format videos.
### Notes
- Flowchart as app used to get proffered video URL for media playback and downloading.
![Course-Video-encoding-preference](https://user-images.githubusercontent.com/43750646/60440280-efac0400-9c2d-11e9-8498-1a3c5ec8726b.png)

