### PR TITLE
Implement feature flag parity for Segment-Firebase

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
@@ -46,7 +46,7 @@ public class SegmentAnalytics implements Analytics {
                 .flushQueueSize(queueSize)
                 .flushInterval(flushInterval, TimeUnit.SECONDS)
                 .logLevel(debugging ? com.segment.analytics.Analytics.LogLevel.VERBOSE : com.segment.analytics.Analytics.LogLevel.NONE);
-        if (config.getFirebaseConfig().isAnalyticsEnabled()) {
+        if (config.getFirebaseConfig().isAnalyticsSourceSegment()) {
             // If Segment & Firebase Analytics are enabled, we'll use Segment's Firebase integration
             builder = builder.use(FirebaseIntegration.FACTORY);
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
@@ -545,18 +545,31 @@ public class Config {
         @SerializedName("ENABLED")
         private boolean mEnabled;
 
-        @SerializedName("ANALYTICS_ENABLED")
-        private boolean mAnalyticsEnabled;
+        @SerializedName("ANALYTICS_SOURCE")
+        private AnalyticsSource mAnalyticsSource;
 
         @SerializedName("CLOUD_MESSAGING_ENABLED")
         private boolean mCloudMessagingEnabled;
+
+        public enum AnalyticsSource {
+            @SerializedName("segment")
+            SEGMENT,
+            @SerializedName("firebase")
+            FIREBASE,
+            @SerializedName("none")
+            NONE
+        }
 
         public boolean isEnabled() {
             return mEnabled;
         }
 
-        public boolean isAnalyticsEnabled() {
-            return mEnabled && mAnalyticsEnabled;
+        public boolean isAnalyticsSourceSegment() {
+            return mEnabled && mAnalyticsSource == AnalyticsSource.SEGMENT;
+        }
+
+        public boolean isAnalyticsSourceFirebase() {
+            return mEnabled && mAnalyticsSource == AnalyticsSource.FIREBASE;
         }
 
         public boolean areNotificationsEnabled() {


### PR DESCRIPTION
### Description

[LEARNER-7374](https://openedx.atlassian.net/browse/LEARNER-7374)
- Implement feature flag parity with IOS for Segment-Firebase implementation
- Initialize FirebaseApp before subscribe/unsubscribe to/from the topics when Firebase is enable.