### PR TITLE
Resolve okhttp3 request builder exception

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/WebViewDiscoverFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/WebViewDiscoverFragment.java
@@ -70,7 +70,7 @@ public abstract class WebViewDiscoverFragment extends BaseWebViewFragment {
         if (searchQueryExtra != null) {
             initSearch(searchQueryExtra);
         } else {
-            loadUrl(searchUrl == null ? getInitialUrl() : searchUrl);
+            loadUrl(searchUrl == null || !URLUtil.isValidUrl(searchUrl) ? getInitialUrl() : searchUrl);
         }
         if (!EventBus.getDefault().isRegistered(this)) {
             EventBus.getDefault().register(this);
@@ -97,7 +97,10 @@ public abstract class WebViewDiscoverFragment extends BaseWebViewFragment {
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
-        outState.putString(INSTANCE_CURRENT_DISCOVER_URL, binding.webview.getUrl());
+        if (URLUtil.isValidUrl(binding.webview.getUrl())) {
+            // Saving the url to maintain the filtered state of the screen if user has applied it
+            outState.putString(INSTANCE_CURRENT_DISCOVER_URL, binding.webview.getUrl());
+        }
         super.onSaveInstanceState(outState);
     }
 


### PR DESCRIPTION
### Description

[LEARNER-7266](https://openedx.atlassian.net/browse/LEARNER-7266)
- Resolve okhttp3 request builder exception due to URL is not valid.
- Store current URL if is valid on onSaveInstanceState.
- Load search URL if is valid.

**Note:** Crash can be reproduce on below **Android 6.0**.
- Check `do not keep activities` from the developer option.
- Open the Course discovery screen that failed to load on first time due to any reason (WebView cleared  on failed to load URL).
- Move the app background.
- Again move the app foreground from background.