### PR TITLE
Android - Fix GoogleOauth2 null pointer exception

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/social/google/GoogleOauth2.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/social/google/GoogleOauth2.java
@@ -140,8 +140,9 @@ public class GoogleOauth2 extends ISocialImpl{
                   // because the user must consent to offline access to their data.  After
                   // consent is granted control is returned to your activity in onActivityResult
                   // and the second call to GoogleAuthUtil.getToken will succeed.
-                
-                activity.startActivityForResult(userRecoverableException.getIntent(), REQUEST_AUTHORIZATION);
+                if (activity != null && userRecoverableException.getIntent() != null) {
+                    activity.startActivityForResult(userRecoverableException.getIntent(), REQUEST_AUTHORIZATION);
+                }
             } catch (GoogleAuthException fatalException) {
                 logger.warn("google auth error occurred");
                 // Some other type of unrecoverable exception has occurred.


### PR DESCRIPTION
### Description

[LEARNER-1761](https://openedx.atlassian.net/browse/LEARNER-1761)


**Reproduction Steps:**
`Activity act = null;`
`act.startActivityForResult(intent, CODE);`

Just execute the above line of code anywhere in the app, it will throw an exception of the same kind we are experiencing in this crash.
