### PR TITLE
Added for x64 bit architecture support

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -316,6 +316,9 @@ android {
         // Enabling multidex support.
         multiDexEnabled true
 
+        //Added for x64 bit architecture support
+        ndk.abiFilters 'armeabi-v7a','arm64-v8a','x86','x86_64'
+
         def platformName = config.get('PLATFORM_NAME')
         resValue "string", "platform_name", platformName
 

--- a/android-iconify-fontawesome/build.gradle
+++ b/android-iconify-fontawesome/build.gradle
@@ -6,6 +6,9 @@ android {
 
     defaultConfig {
         minSdkVersion MIN_SDK_VERSION
+
+        //Added for x64 bit architecture support
+        ndk.abiFilters 'armeabi-v7a','arm64-v8a','x86','x86_64'
     }
 
     compileOptions {

--- a/android-iconify/build.gradle
+++ b/android-iconify/build.gradle
@@ -7,6 +7,9 @@ android {
     defaultConfig {
         minSdkVersion MIN_SDK_VERSION
         consumerProguardFiles 'proguard-rules.txt'
+
+        //Added for x64 bit architecture support
+        ndk.abiFilters 'armeabi-v7a','arm64-v8a','x86','x86_64'
     }
 
     compileOptions {


### PR DESCRIPTION
### Description

[LEARNER-7399](https://openedx.atlassian.net/browse/LEARNER-7399)

Added "ndk.abiFilters 'armeabi-v7a','arm64-v8a','x86','x86_64'" in every library or project gradle. It will create respective folders for x64 during apk packaging.

For further information please visit -->https://developer.android.com/ndk/guides/abis