### PR TITLE
Fix downloaded videos are not playing in offline mode.

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/receivers/MediaStatusReceiver.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/receivers/MediaStatusReceiver.java
@@ -11,13 +11,13 @@ import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.event.MediaStatusChangeEvent;
 import org.edx.mobile.model.VideoModel;
 import org.edx.mobile.model.db.DownloadEntry;
-import org.edx.mobile.model.download.NativeDownloadModel;
 import org.edx.mobile.module.db.DataCallback;
 import org.edx.mobile.module.db.IDatabase;
 import org.edx.mobile.module.prefs.LoginPrefs;
 import org.edx.mobile.module.prefs.PrefManager;
 import org.edx.mobile.util.FileUtil;
 import org.edx.mobile.util.Sha1Util;
+import org.edx.mobile.util.VideoUtil;
 
 import java.io.File;
 import java.util.List;
@@ -78,7 +78,7 @@ public class MediaStatusReceiver extends RoboBroadcastReceiver {
             public void onResult(List<VideoModel> result) {
                 for (VideoModel videoModel : result) {
                     if (videoModel.getFilePath() != null && videoModel.getFilePath().contains(sdCardPath)) {
-                        updateVideoDownloadState(
+                        VideoUtil.updateVideoDownloadState(db,
                                 videoModel,
                                 DownloadEntry.DownloadedState.ONLINE.ordinal()
                         );
@@ -162,7 +162,7 @@ public class MediaStatusReceiver extends RoboBroadcastReceiver {
                 }
             }
 
-            updateVideoDownloadState(
+            VideoUtil.updateVideoDownloadState(db,
                     videoModel,
                     DownloadEntry.DownloadedState.DOWNLOADED.ordinal()
             );
@@ -204,22 +204,5 @@ public class MediaStatusReceiver extends RoboBroadcastReceiver {
             downloadedFile = new File(videoPath.replace(removableStorageAppDir, externalAppDir));
         }
         return downloadedFile;
-    }
-
-    /**
-     * Utility method to update the downloaded video file info and status in database.
-     *
-     * @param videoModel    Video info need to update in database.
-     * @param downloadState New file status(DOWNLOADED / ONLINE).
-     */
-    public void updateVideoDownloadState(VideoModel videoModel,
-                                         int downloadState) {
-        final NativeDownloadModel dm = new NativeDownloadModel();
-        dm.dmid = videoModel.getDmId();
-        dm.filepath = videoModel.getFilePath();
-        dm.size = videoModel.getSize();
-        dm.downloaded = downloadState;
-        videoModel.setDownloadInfo(dm);
-        db.updateDownloadingVideoInfoByVideoId(videoModel, null);
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/FileUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/FileUtil.java
@@ -1,6 +1,8 @@
 package org.edx.mobile.util;
 
 import android.content.Context;
+import android.media.MediaMetadataRetriever;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
 import android.support.annotation.NonNull;
@@ -246,5 +248,33 @@ public class FileUtil {
         // Don't break the recursion upon encountering an error
         // noinspection ResultOfMethodCallIgnored
         fileOrDirectory.delete();
+    }
+
+    /**
+     * Check that the video file exists on a given file path
+     *
+     * @param context  The current context
+     * @param filepath Video storage file path
+     * @return True if video file exists on a given path
+     */
+    public static boolean isVideoFileExists(@NonNull Context context, @NonNull String filepath) {
+        final File videoFile = new File(filepath);
+        if (videoFile.exists()) {
+            // Inspiration of this solution has taken from the following answer
+            // https://stackoverflow.com/a/34440432
+            final MediaMetadataRetriever retriever = new MediaMetadataRetriever();
+            // If something is wrong with the path or with the video file following code may
+            // throw an exception
+            try {
+                retriever.setDataSource(context, Uri.fromFile(videoFile));
+                final String hasVideo = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_HAS_VIDEO);
+                if ("yes".equals(hasVideo)) {
+                    return true;
+                }
+            } catch (Exception e) {
+                // Ignore exception
+            }
+        }
+        return false;
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/VideoUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/VideoUtil.java
@@ -5,8 +5,11 @@ import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import org.edx.mobile.base.MainApplication;
+import org.edx.mobile.model.VideoModel;
 import org.edx.mobile.model.course.VideoData;
 import org.edx.mobile.model.course.VideoInfo;
+import org.edx.mobile.model.download.NativeDownloadModel;
+import org.edx.mobile.module.db.IDatabase;
 
 import static org.edx.mobile.util.AppConstants.VIDEO_FORMAT_M3U8;
 import static org.edx.mobile.util.AppConstants.VIDEO_FORMAT_MP4;
@@ -88,5 +91,23 @@ public class VideoUtil {
             }
         }
         return preferredVideoUrl;
+    }
+
+    /**
+     * Utility method to update the downloaded video file info and status in database.
+     *
+     * @param db
+     * @param videoModel    Video info need to update in database.
+     * @param downloadState New file status(DOWNLOADED / ONLINE).
+     */
+    public static void updateVideoDownloadState(IDatabase db, VideoModel videoModel,
+                                                int downloadState) {
+        final NativeDownloadModel dm = new NativeDownloadModel();
+        dm.dmid = videoModel.getDmId();
+        dm.filepath = videoModel.getFilePath();
+        dm.size = videoModel.getSize();
+        dm.downloaded = downloadState;
+        videoModel.setDownloadInfo(dm);
+        db.updateDownloadingVideoInfoByVideoId(videoModel, null);
     }
 }


### PR DESCRIPTION
### Description

[LEARNER-7397](https://openedx.atlassian.net/browse/LEARNER-7397)

- Fix downloaded videos are not playing in offline mode.
- This issue occurs when the file is deleted externally.
- If download file deleted or corrupted **externally** or by the **third-party app** then update the database entry against the xBlock video, delete the corrupted file and update the UI accordingly.

**How to reproduce the issue.**
- Download any video file.
- Delete the downloaded file externally.

**How to test:**
- Download any file.
- Check the video status by deleting the download file externally.
- Check the video status by replacing the download file with some non-media file (file name should be the same) externally.

**Ref:** https://stackoverflow.com/a/34440432