### PR TITLE
Fix issue: Fix FragmentTransaction IllegalStateException

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/UiUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/UiUtil.java
@@ -152,7 +152,7 @@ public class UiUtil {
             final Fragment fragment = fragmentManager.findFragmentByTag(tag);
             if (fragment != null) {
                 fragmentManager.beginTransaction().remove(fragment)
-                        .commit();
+                        .commitAllowingStateLoss();
             }
         }
     }


### PR DESCRIPTION
# Description

- Fix FragmentTransaction IllegalStateException
- Allowing fragment to lose its state if fragment onSaveInstanceState
method has been called on transaction commit time.


[LEARNER-7439](https://openedx.atlassian.net/browse/LEARNER-7439)

**Reproduction Steps:**
Add the following function in the CourseOutlineFragment class
```
    @Override
    public void onStop() {
        super.onStop();
        UiUtil.removeFragmentByTag(CourseOutlineFragment.this, "bulk_download");
    }
```

**Note:**
`onStop` callback calls after `onSaveInstanceState` callback

**References:** 

https://developer.android.com/reference/android/app/FragmentTransaction.html#commit()

https://medium.com/@bendaniel10/a-possible-way-to-safely-perform-fragment-transactions-after-activity-onsaveinstancestate-651d4bcb410b