### PR TITLE
Fix Issue Fragment has not been attached yet

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -783,10 +783,12 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
     }
 
     private void updateBulkDownloadFragment() {
-        final Fragment bulkDownloadFragment = getChildFragmentManager()
-                .findFragmentByTag("bulk_download");
-        if (bulkDownloadFragment instanceof BulkDownloadFragment) {
-            ((BulkDownloadFragment) bulkDownloadFragment).updateVideoStatus();
+        if (isAdded()) {
+            final Fragment bulkDownloadFragment = getChildFragmentManager()
+                    .findFragmentByTag("bulk_download");
+            if (bulkDownloadFragment instanceof BulkDownloadFragment) {
+                ((BulkDownloadFragment) bulkDownloadFragment).updateVideoStatus();
+            }
         }
     }
 


### PR DESCRIPTION
### Description

[LEARNER-7440](https://openedx.atlassian.net/browse/LEARNER-7440)

- Check parent fragment is added to its activity before performing action on child fragment through fragment manager.

**Reproduction Steps:**
Add the following line of code at the end of the **setUserVisibleHint** method in **CourseOutlineFragment**.

```
updateBulkDownloadFragment();
```
**Note:**
updateBulkDownloadFragment called before fragment added to its activity.

**References:**
https://stackoverflow.com/a/44845661