### PR TITLE
Update Facebook login SDK to 5.9.0

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -162,7 +162,7 @@ dependencies {
     implementation 'com.android.support:mediarouter-v7:28.0.0'
     implementation 'com.google.android.gms:play-services-cast-framework:16.2.0'
 
-    implementation 'com.facebook.android:facebook-login:4.41.0'
+    implementation 'com.facebook.android:facebook-login:5.9.0'
     implementation 'com.google.code.gson:gson:2.7'
     implementation 'de.greenrobot:eventbus:2.4.1'
     implementation 'com.squareup.phrase:phrase:1.1.0'


### PR DESCRIPTION
### Description

[LEARNER-7455](https://openedx.atlassian.net/browse/LEARNER-7455)

- Update Facebook login SDK to 5.9.0

**Recommended Testing:**
- Login through facebook.
- Registration through facebook.