### PR TITLE
Add Japanese language support

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,8 +1,7 @@
 [main]
 host = https://www.transifex.com
 type = ANDROID
-lang_map = es_419: es, tr_TR: tr, zh_CN: zh, pt_BR: pt-rBR, fr: fr, de_DE: de-rDE, he: iw, vi: vi
-
+lang_map = es_419: es, tr_TR: tr, zh_CN: zh, pt_BR: pt-rBR, fr: fr, de_DE: de-rDE, he: iw, vi: vi, ja_JP: ja
 
 [edx-mobile-apps.android-app-strings]
 file_filter = OpenEdXMobile/res/values-<lang>/strings.xml

--- a/OpenEdXMobile/res/raw-ja/profiles.json
+++ b/OpenEdXMobile/res/raw-ja/profiles.json
@@ -1,0 +1,59 @@
+{
+    "fields":[
+    {
+              "name" : "account_privacy",
+              "label" : "他の受講者が見ることができるのは：",
+              "type" : "switch",
+              "data_type" : "boolean",
+              "options" : {
+                "values" : [
+                            { "name" : "全プロフィール", "value" : "all_users" },
+                            { "name" : "限定プロフィール",  "value" : "private" }
+                 ]
+              },
+              "instructions" : "限定プロフィールではあなたのユーザー名およびプロフィール写真のみ公開されます。",
+              "accessibility_hint" : "他の人に公開する情報を変更"
+    },
+    {
+              "name" : "year_of_birth",
+              "label" : "誕生年",
+              "type" : "select",
+              "options" : {
+                "range_min" : 1896,
+                "range_max" : 2019,
+                "allows_none" : true,
+                "none_label" : "誕生年なし"
+              },
+              "instructions" : "全プロフィールを公開する場合は誕生年を入力しなければなりません。",
+              "sub_instructions" : "これは公開されません。"
+    },
+    {
+              "name" : "country",
+              "label" : "現在地",
+              "type" : "select",
+              "data_type" : "country",
+              "options" : {
+                "reference" : "countries",
+                "allows_none" : true,
+                "none_label" : "現在地なし"
+              }
+    },
+    {
+              "name" : "language_proficiencies",
+              "label" : "第一言語",
+              "type" : "select",
+              "data_type" : "language",
+              "options" : {
+                "reference" : "languages",
+                "allows_none" : true,
+                "none_label" : "第一言語なし"
+              }
+    },
+    {
+              "name" : "bio",
+              "label" : "自己紹介",
+              "type" : "textarea",
+              "placeholder" : "私が学びたいのは…"
+    }
+    ]
+}

--- a/OpenEdXMobile/res/raw-ja/subjects.json
+++ b/OpenEdXMobile/res/raw-ja/subjects.json
@@ -1,0 +1,182 @@
+[
+    {
+        "name": "Architecture",
+        "image_name": "architecture",
+        "filter": "Architecture",
+        "type": "normal"
+    },
+    {
+        "name": "Art & Culture",
+        "image_name": "art",
+        "filter": "Art & Culture",
+        "type": "normal"
+    },
+    {
+        "name": "Biology & Life Sciences",
+        "image_name": "biology",
+        "filter": "Biology & Life Sciences",
+        "type": "normal"
+    },
+    {
+        "name": "Business & Management",
+        "image_name": "business",
+        "filter": "Business & Management",
+        "type": "popular"
+    },
+    {
+        "name": "Chemistry",
+        "image_name": "chemistry",
+        "filter": "Chemistry",
+        "type": "normal"
+    },
+    {
+        "name": "Communication",
+        "image_name": "communication",
+        "filter": "Communication",
+        "type": "normal"
+    },
+    {
+        "name": "Computer Science",
+        "image_name": "computer_science",
+        "filter": "Computer Science",
+        "type": "popular"
+    },
+    {
+        "name": "Data Analysis & Statistics",
+        "image_name": "data_science",
+        "filter": "Data Analysis & Statistics",
+        "type": "popular"
+    },
+    {
+        "name": "Design",
+        "image_name": "design",
+        "filter": "Design",
+        "type": "normal"
+    },
+    {
+        "name": "Economics & Finance",
+        "image_name": "economics_finance",
+        "filter": "Economics & Finance",
+        "type": "normal"
+    },
+    {
+        "name": "Education & Teacher Training",
+        "image_name": "education",
+        "filter": "Education & Teacher Training",
+        "type": "normal"
+    },
+    {
+        "name": "Electronics",
+        "image_name": "electronics",
+        "filter": "Electronics",
+        "type": "normal"
+    },
+    {
+        "name": "Energy & Earth Sciences",
+        "image_name": "energy",
+        "filter": "Energy & Earth Sciences",
+        "type": "normal"
+    },
+    {
+        "name": "Engineering",
+        "image_name": "engineering",
+        "filter": "Engineering",
+        "type": "normal"
+    },
+    {
+        "name": "Environmental Studies",
+        "image_name": "environmental_studies",
+        "filter": "Environmental Studies",
+        "type": "normal"
+    },
+    {
+        "name": "Ethics",
+        "image_name": "ethics",
+        "filter": "Ethics",
+        "type": "normal"
+    },
+    {
+        "name": "Food & Nutrition",
+        "image_name": "food_nutrition",
+        "filter": "Food & Nutrition",
+        "type": "normal"
+    },
+    {
+        "name": "Health & Safety",
+        "image_name": "health",
+        "filter": "Health & Safety",
+        "type": "normal"
+    },
+    {
+        "name": "History",
+        "image_name": "history",
+        "filter": "History",
+        "type": "normal"
+    },
+    {
+        "name": "Humanities",
+        "image_name": "humanities",
+        "filter": "Humanities",
+        "type": "popular"
+    },
+    {
+        "name": "Language",
+        "image_name": "language",
+        "filter": "Language",
+        "type": "popular"
+    },
+    {
+        "name": "Law",
+        "image_name": "law",
+        "filter": "Law",
+        "type": "normal"
+    },
+    {
+        "name": "Literature",
+        "image_name": "literature",
+        "filter": "Literature",
+        "type": "normal"
+    },
+    {
+        "name": "Math",
+        "image_name": "math",
+        "filter": "Math",
+        "type": "normal"
+    },
+    {
+        "name": "Medicine",
+        "image_name": "medicine",
+        "filter": "Medicine",
+        "type": "normal"
+    },
+    {
+        "name": "Music",
+        "image_name": "music",
+        "filter": "Music",
+        "type": "normal"
+    },
+    {
+        "name": "Philosophy & Ethics",
+        "image_name": "philosophy_ethics",
+        "filter": "Philosophy & Ethics",
+        "type": "normal"
+    },
+    {
+        "name": "Physics",
+        "image_name": "physics",
+        "filter": "Physics",
+        "type": "normal"
+    },
+    {
+        "name": "Science",
+        "image_name": "science",
+        "filter": "Science",
+        "type": "normal"
+    },
+    {
+        "name": "Social Sciences",
+        "image_name": "social_sciences",
+        "filter": "Social Sciences",
+        "type": "normal"
+    }
+]

--- a/OpenEdXMobile/res/values-ja/errors.xml
+++ b/OpenEdXMobile/res/values-ja/errors.xml
@@ -1,0 +1,84 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <!--An error occurred but we don't know why-->
+  <string name="error_unknown">不明なエラーが生じました。後ほど再試行してください。</string>
+  <!--Course related error messages-->
+  <!--Error shown when a course's content is invalid or not in the format that we expect-->
+  <!--Title of alert shown when course enrollment request fails-->
+  <!--Error message shown in alert when course enrollment request fails-->
+  <!--Error message shown when a course section is not available on mobile-->
+  <!--Network error messages-->
+  <!--Error shown when  user attempts an action but needs an internet connection-->
+  <string name="network_not_connected">インターネットに接続されていません。</string>
+  <!--Concise error shown when user attempts an action but needs an internet connection-->
+  <string name="network_not_connected_short">ネットワーク接続できません</string>
+  <!--Alert dialog title shown when a network request fails-->
+  <string name="reset_no_network_title">接続エラー</string>
+  <!--Alert dialog content shown when a network request fails because the user has no internet connection-->
+  <string name="reset_no_network_message">インターネットに接続されていません。インターネットへの接続設定を確認してください。</string>
+  <!--An error ocurred due to some kind of network failure-->
+  <string name="network_connected_error">接続エラー。インターネットへの接続設定を確認してください。</string>
+  <!--Title of prompt indicating issue loading a video-->
+  <string name="network_error_header">動画の読込ができません</string>
+  <!--Content of prompt indicating issue loading a video-->
+  <string name="network_error_message">インターネットへの接続設定を確認してください</string>
+  <!--The server we are trying to use is not available right now-->
+  <string name="network_service_unavailable">サービスが利用できません。後ほど再試行してください。</string>
+  <!--Login error messages-->
+  <!--Error shown during login when user attempts login without entering a username or e-mail-->
+  <string name="error_enter_email">ユーザー名またはメールアドレスを入力して再試行してください。</string>
+  <!--Error shown during login when user enters an invalid email address-->
+  <string name="error_invalid_email">メールアドレスの書式が正しいか確認して再試行してください。</string>
+  <!--Error shown during login when user attempts login without entering a password-->
+  <string name="error_enter_password">パスワードを入力して再試行してください。</string>
+  <!--Title of alert shown during login when user attempts login via Facebook without having linked their account-->
+  <string name="error_account_not_linked_title_fb"> {platform_name} アカウントと連動していない Facebook アカウント</string>
+  <!--Content of alert shown during login when user attempts login via Facebook without having linked their account-->
+  <string name="error_account_not_linked_desc_fb">あなたの Facebook アカウントが {platform_destination} 上の {platform_name} アカウントと連動しているか確認してください。</string>
+  <!--Content of alert shown during login when user attempts login via Facebook without having linked their account-->
+  <!--Title of alert shown during login when user attempts login via Google without having linked their account-->
+  <string name="error_account_not_linked_title_google" tools:ignore="MissingTranslation"> {platform_name} アカウントと連動していない Google アカウント</string>
+  <!--Content of alert shown during login when user attempts login via Google without having linked their account-->
+  <string name="error_account_not_linked_desc_google" tools:ignore="MissingTranslation">あなたの Google アカウントが {platform_destination} 上の {platform_name} アカウントと連動しているか確認してください。</string>
+  <!--Content of alert shown during login when user attempts login via Google without having linked their account-->
+  <!--Download error messages-->
+  <!--Label shown on video list item whose download failed-->
+  <string name="error_download_failed">ダウンロード失敗</string>
+  <!--Confirmation message shown when attempting to download a large quantity of video data-->
+  <string name="file_size_exceeded">ダウンロードサイズがデバイスの記録装置の空き容量を上回っています。</string>
+  <!--Confirmation message shown when attempting to download a large quantity of video data-->
+  <!--Message shown when user attempts to download a video over cellular data,
+    but has chosen to only allow video downloads over wifi-->
+  <string name="wifi_off_message">現在 ダウンロードは Wi-Fi 接続のみを使用する設定になっています。
+Wi-Fi ネットワークに接続するか、ダウンロードの設定を変更してください。</string>
+  <!--New version available-->
+  <!--Snackbar notification shown when the current version of the app is unsupported-->
+  <string name="app_version_unsupported">あなたが使っている本アプリのバージョンはサポートが終了しています。</string>
+  <!--Snackbar notification shown when the current version of the app is deprecated-->
+  <!--Snackbar notification shown when the current version of the app is outdated-->
+  <string name="app_version_outdated">本アプリには新バージョンがあります。</string>
+  <!--Toast notification for when the user presses the update action button from the Snackbar
+         notifications while no supported app store or browser is installed on the device with which
+         the app could be updated-->
+  <string name="app_version_upgrade_app_store_unavailable" tools:ignore="MissingTranslation">サポートされているアプリストアが見つかりません。</string>
+  <!--Registration Error Messages-->
+  <!--Error prompt shown during registration to indicate an empty field. Argument is a field name-->
+  <string name="error_enter_field">%1$s を入力してください。</string>
+  <!--Error prompt shown during registration to indicate a field missing a selection. Argument is a field name-->
+  <string name="error_select_field">%1$s を選択してください。</string>
+  <!--Error prompt shown during registration when a field entry is too short. Arguments are 1) a field name, 2) a number-->
+  <string name="error_min_length">%1$s は少なくとも %2$d 文字必要です。</string>
+  <!--Error prompt shown during registration when a field entry is too long. Arguments are 1) a field name, 2) a number-->
+  <string name="error_max_length">%1$s は %2$d 文字を超えることはできません。</string>
+  <!--Error message shown when a course hasn't started yet-->
+  <string name="course_not_started" tools:ignore="MissingTranslation">この講座はまだ開始していません。</string>
+  <!--Error message shown when a user's access has expired for a course-->
+  <!--Error message shown when a user can't perform an action on e.g. add a post/response/comment in forums-->
+  <string name="action_not_completed" tools:ignore="MissingTranslation">完了していません。</string>
+  <!--Error dialog message shown when the user try to log in in app with un-supported version-->
+  <string name="app_version_unsupported_login_msg" tools:ignore="MissingTranslation">あなたが使っている本アプリのバージョンはサポートが終了しています。最新バージョンにアップデートしてログインしてください。</string>
+  <!--Error dialog message shown when the user try to register in app with un-supported version-->
+  <string name="app_version_unsupported_register_msg" tools:ignore="MissingTranslation">あなたが使っている本アプリのバージョンはサポートが終了しています。最新バージョンにアップデートして登録してください。</string>
+  <!--Permission Error Messages-->
+  <!--Error message shown when a permission is not granted-->
+</resources>

--- a/OpenEdXMobile/res/values-ja/labels.xml
+++ b/OpenEdXMobile/res/values-ja/labels.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <!--Divider between current time and total time. For example  "2:33/5:10"-->
+  <string name="lbl_slash">/</string>
+  <!--Button allowing user to open a web page corresponding to the current screen in a web browser-->
+  <string name="lbl_view_on_web">ウェブで見る</string>
+  <!--Label indicating that the only course content visible in the app is videos-->
+  <string name="lbl_showing_only_videos">動画のみの利用</string>
+  <!--A button's label that reloads the content on screen-->
+  <string name="lbl_reload" tools:ignore="MissingTranslation">再読み込み</string>
+  <!--Dialog Fragment Labels-->
+  <!--Alert dialog cancel button-->
+  <string name="label_cancel">キャンセル</string>
+  <!--Alert dialog No button-->
+  <string name="label_no">いいえ</string>
+  <!--Alert dialog download button-->
+  <string name="label_download">ダウンロード</string>
+  <!--Alert dialog yes confirmation button-->
+  <string name="label_yes">はい</string>
+  <!--Alert dialog delete confirmation button-->
+  <string name="label_delete">削除</string>
+  <!--Alert dialog okay button-->
+  <string name="label_ok">OK</string>
+  <!--Alert dialog close button-->
+  <string name="label_close">閉じる</string>
+  <!--Alert dialog continue confirmation button-->
+  <string name="label_continue">続ける</string>
+  <!--Alert dialog submit button-->
+  <string name="label_submit">提出</string>
+  <!--Alert dialog send feedback button-->
+  <string name="label_send_feedback">フィードバックを送る</string>
+  <!--Alert dialog maybe later button-->
+  <string name="label_maybe_later">後で</string>
+  <!--Alert dialog rate the app button-->
+  <string name="label_rate_the_app">アプリを評価する</string>
+  <!--Alert dialog and snackbar button for opening an app store to update the app to the latest version-->
+  <string name="label_update">アップデート</string>
+  <!--Done button label-->
+  <string name="label_done" tools:ignore="MissingTranslation">完了</string>
+  <!--Undo button label-->
+  <string name="label_undo" tools:ignore="MissingTranslation">元に戻す</string>
+  <!--Label denoting an error-->
+</resources>

--- a/OpenEdXMobile/res/values-ja/strings.xml
+++ b/OpenEdXMobile/res/values-ja/strings.xml
@@ -1,0 +1,578 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <!--Certificates-->
+  <!--Label congratulation user on finishing course-->
+  <string name="course_details_congratulations">おめでとうございます！</string>
+  <!--Message for user who has successfully completed a certificate course-->
+  <string name="course_details_earned_cert">あなたは合格しました。</string>
+  <!--Button that opens a full view of an earned certificate-->
+  <string name="course_details_view_cert_button">修了証を見る</string>
+  <!--Course Discovery-->
+  <!--Enroll Now button text-->
+  <string name="enroll_now_button_text">登録しよう</string>
+  <!--Invitation Only button text-->
+  <!--Effort field name-->
+  <string name="effort_field_name">エフォート：</string>
+  <!--When discovering courses, some courses have an externally hosted video that describes it.
+    In that case, a play icon is shown on top of the course image. This is the content description.-->
+  <string name="go_to_video">動画へ</string>
+  <!--View Course button text text-->
+  <string name="view_course_button_text">講座を見る</string>
+  <!--Floating overlay text shown to user when they succeed at enrolling in a course-->
+  <string name="you_are_now_enrolled">あなたはこの講座に登録中です。</string>
+  <!--Error message shown when dashboard cannot be shown from course detail view-->
+  <string name="cannot_show_dashboard">ダッシュボードが表示できません。</string>
+  <!--Error message shown when browser cannot handle request for given web url-->
+  <!--Subjects Discovery-->
+  <!--Label for browsing courses by a subject-->
+  <!--Button's Label for viewing all subjects-->
+  <!--Label for searching subjects-->
+  <!--Google Cast-->
+  <!--Description of a button that will cast/un-cast the app to a remote device-->
+  <!--Google cast Introduction title-->
+  <!--Text to describe that video is casting on the remote device-->
+  <!--Course Sharing-->
+  <!--Description of button that will open the share course menu-->
+  <string name="share_course_button">講座をシェア</string>
+  <!--Share course-->
+  <string name="share_course_message">私は {platform_name} の講座を受講中です！こちらを見てください：</string>
+  <!--Settings Page-->
+  <!--Label for wifi only switch-->
+  <string name="settings_wifi_top">Wi-Fi 使用ダウンロード</string>
+  <!--Label explaining what wifi only means in detail-->
+  <string name="settings_wifi_bottom">Wi-Fi がオンになっているときだけダウンロード</string>
+  <!--Label for the Download to sd-card setting-->
+  <!--Label explaining the download location setting in detail-->
+  <!--Certificate Page-->
+  <!--Description of button that will open the certificate sharing menu-->
+  <string name="share_certificate_button">修了証をシェア</string>
+  <!--Text that pre-populates your post/email/SMS when sharing certificate-->
+  <string name="share_certificate_message">私は {platform_name} で修了証を獲得しました！{certificate_url}で確認してください：</string>
+  <!--Tab of tab for certicate for finished course-->
+  <string name="tab_label_certificate">修了証</string>
+  <!--Data Usage Dialog-->
+  <!--Alert dialog error message shown when using a feature with a required Internet connection-->
+  <string name="need_data">この機能はインターネット接続が必要です。</string>
+  <!--Login Activity Place Holders-->
+  <!--Hint text for login field-->
+  <string name="email_username">ユーザー名またはメールアドレス</string>
+  <!--Hint text for email address field in reset password dialog-->
+  <string name="email">メールアドレス</string>
+  <!--Hint text for password field-->
+  <string name="password">パスワード</string>
+  <!--Button text allowing user to reset their password-->
+  <string name="forgot_password">パスワードをお忘れですか？</string>
+  <!--Button initiating login process after user enters credentials like username and password-->
+  <string name="login">サインイン</string>
+  <!--Accessible content description of sign in button on Log in screen-->
+  <string name="login_btn">サインインボタン</string>
+  <!--Message shown while waiting for action-->
+  <string name="progress_text">お待ちください</string>
+  <!--Message shown while user waits for response to a sign in request-->
+  <string name="signing_in">サインイン中</string>
+  <!--Message for shown after tapping Sign In-->
+  <string name="error_message">エラーメッセージ</string>
+  <!--Generic error during log in-->
+  <string name="error_heading">ログイン中に以下のエラーが起きました</string>
+  <!--Error during log in.-->
+  <string name="login_failed">ユーザー名またはメールアドレス、パスワードが正しいか確認して再試行してください。</string>
+  <!--License Agreement related string on Login and Regiser screens-->
+  <!--Create account agreement. Followed by list of agreement names like "End User License Agreement"-->
+  <!--Sign In agreement. Followed by list of agreement names like "End User License Agreement"-->
+  <!--Label for End User License Agreement-->
+  <!--Label for Terms of Service and Honor Code-->
+  <!--Label for Privacy Policy-->
+  <string name="login_title">サインイン</string>
+  <!--Accessible content description of close button on Sign in and Sign up screen-->
+  <string name="close">閉じる</string>
+  <!--Accessible content description prefix of dropdowns on Sign up screen, like, country and gender dropdowns-->
+  <string name="dropdown_list_prefix">ドロップダウンリスト</string>
+  <!--Navigation Drawer Labels-->
+  <!--Button text to show user current downloads screen-->
+  <!--Content description for edit profile button-->
+  <string name="open_profile_button">あなたのプロフィールを開く</string>
+  <!--Title of user's course list screen-->
+  <!--Title of user's program list screen-->
+  <!--Title of native Find Courses Screen-->
+  <string name="label_find_courses">講座を探す</string>
+  <!--Title of webview based Find Courses Screen-->
+  <!--Title of Degrees tab on Discovery screen-->
+  <!--Title of Find Courses tab on Main Dashboard screen-->
+  <!--Button allowing users to send an email for feedback-->
+  <string name="label_submit_feedback">フィードバックを送る</string>
+  <!--Toggle switch on state label-->
+  <string name="toggle_turn_on">オン</string>
+  <!--Toggle switch off state label-->
+  <string name="toggle_turn_off">オフ</string>
+  <!--Logout button label-->
+  <string name="logout">ログアウト</string>
+  <!--Settings screen title-->
+  <string name="settings_txt">設定</string>
+  <!--Settings screen version-->
+  <string name="label_version">アプリバージョン</string>
+  <!--Button text to show user Settings screen-->
+  <!--Title of Account screen-->
+  <!--Help Dialog Place Holder messages-->
+  <!--Reset password alert dialog title-->
+  <string name="confirm_dialog_title_help">パスワードを変更</string>
+  <!--Reset password alert dialog message-->
+  <string name="success_dialog_title_help">パスワード変更メールを送信済</string>
+  <!--Reset password alert dialog title-->
+  <string name="title_reset_password_failed">パスワード変更失敗</string>
+  <!--Label for switch controlling whether users permit downloading using cellular data or only wifi-->
+  <string name="wifi_dialog_title_help">通話回線でのダウンロードを許可</string>
+  <!--Password reset sent succesfully alert-->
+  <string name="success_dialog_message_help">登録メールアドレスに、パスワード変更手順についてのメールを送信しました。
+もし数分経ってもメールが見つからない場合は、迷惑メールフォルダを確認してください。</string>
+  <!--Password reset dialog prompt-->
+  <string name="confirm_dialog_message_help">あなたのアカウントに登録しているメールアドレスを入力してください。パスワード変更手順についてのメールをお送りします。</string>
+  <!--Label explaining toggle for cellular data access-->
+  <string name="wifi_dialog_message_help">Wi-Fi 接続が利用できない場合、通話回線を使って動画をダウンロードできるようにします。データ通信料が課金される場合があります。</string>
+  <!--Info message text for to let use know how many videos were deleted-->
+  <plurals name="delete_video_snackbar_msg">
+    <item quantity="other">%s 件の動画を削除済</item>
+  </plurals>
+  <!--Alert dialog title for users with zero rated data-->
+  <string name="leaving_app_data_title">{platform_name} アプリを閉じる</string>
+  <!--Alert dialog content for users with zero rated data-->
+  <string name="leaving_app_data_message">アプリを閉じると、無料で {platform_name} コンテンツを見ることができなくなり、データ通信料が課金される場合があります。</string>
+  <!--Title of agreement users must accept to use the app-->
+  <string name="end_user_title" tools:ignore="MissingTranslation">エンドユーザーライセンス同意書</string>
+  <!--Title of privacy policy users must accept to use the app-->
+  <!--Title of terms of service & honor code users must accept to use the app-->
+  <!--My Courses-->
+  <!--Row of course on dashboard screen-->
+  <string name="courseware_title">講座</string>
+  <!--Row of course on dashboard screen-->
+  <!--NOTE: TODO - not final one-->
+  <string name="courseware_subtitle">動画や課題を見る</string>
+  <!--Row title of videos on dashboard screen-->
+  <!--Row subtitle of videos on dashboard screen-->
+  <!--Row of Discussion on dashboard screen-->
+  <string name="discussion_title">ディスカッション</string>
+  <!--Row of Discussion on dashboard screen-->
+  <!--NOTE: TODO - not final one-->
+  <string name="discussion_subtitle">ディスカッションに参加する</string>
+  <!--Row of Handouts on dashboard screen-->
+  <string name="handouts_title">ハンドアウト</string>
+  <!--Row of Handouts on dashboard screen-->
+  <!--NOTE: TODO - not final one-->
+  <string name="handouts_subtitle">重要な講座情報を探す</string>
+  <!--Row of announcement on dashboard screen-->
+  <string name="announcement_title">お知らせ</string>
+  <!--Title text for the important dates section on the course dashboard-->
+  <!--Title text for the additional resources section on the tabular course dashboard-->
+  <!--Row of announcement on dashboard screen-->
+  <!--NOTE: TODO - not final one-->
+  <string name="announcement_subtitle">最新ニュースを見る</string>
+  <!--Subtitle text describing the important dates section on the course dashboard-->
+  <!--Accessible content description of course name label field-->
+  <string name="course_name">講座名</string>
+  <!--Label indicating new course content has been downloaded-->
+  <string name="new_course_content">新規講座コンテンツ</string>
+  <!--Label for date when course starts-->
+  <!--Label for course that has ended-->
+  <!--Label for date when course is ending-->
+  <!--Label for date when course is expiring in a specific time frame like in 2 days-->
+  <!--Label for date when course is expiring on a specific date like on December 5-->
+  <!--Label for date when course expired a specific time ago like 2 days ago-->
+  <!--Label for date when course expired on a specific date like on November 5-->
+  <!--Course Details-->
+  <!--Accessible content description of label for course content-->
+  <string name="course_content">講座コンテンツ</string>
+  <!--Tab title for course handouts section-->
+  <string name="tab_label_handouts">ハンドアウト</string>
+  <!--Button for last accessed course section. Will be followed by course name-->
+  <string name="last_accessed">最新アクセス</string>
+  <!--Label shown when no courseware content is available-->
+  <string name="no_chapter_text">現在受講できる講座コンテンツはありません。</string>
+  <!--Label shown when no mobile-friendly videos are available in a course-->
+  <!--Label shown when user is enrolled in no courses-->
+  <string name="no_courses_to_display">あなたはまだどの講座にも受講登録をしていないようです。</string>
+  <!--Label shown when no announcements are available for a course-->
+  <string name="no_announcements_to_display">現在この講座からのお知らせはありません。</string>
+  <!--Label shown when no handouts are available for a course-->
+  <string name="no_handouts_to_display">現在この講座のハンドアウトはありません。</string>
+  <!--Label shown when no important dates are available for a course-->
+  <!--Title of the screen where user can delete videos-->
+  <!--Label for a course item's due date for same day-->
+  <!--Label for a course item's due date-->
+  <!--Upgrade banner's description which appears on course outline screen.-->
+  <!--Title upgrade to verified today course outline footer-->
+  <!--Title of place order for course upgrade screen-->
+  <!--Discussion Topics-->
+  <!--Label for the discussion topics page-->
+  <string name="discussion_topics_title">ディスカッショントピック</string>
+  <!--Hint displayed in search view for discussion posts-->
+  <string name="topics_search">全ての投稿を検索</string>
+  <!--Discussion Posts Fragment-->
+  <!--Title for discussion post search results-->
+  <string name="discussion_posts_search_title">検索結果</string>
+  <!--Label for the the filter and sort options for refining the thread list-->
+  <string name="discussion_posts_refine">リファイン：</string>
+  <!--Label for creating a new post-->
+  <string name="discussion_post_create_new_post">新規投稿を作成する</string>
+  <!--Label for creating a new comment-->
+  <!--Discussion posts filter options-->
+  <!--Discussion posts filter for all posts-->
+  <string name="discussion_posts_filter_all_posts">すべての投稿</string>
+  <!--Discussion posts filter for unread posts-->
+  <string name="discussion_posts_filter_unread_posts">未読</string>
+  <!--Discussion posts filter for unanswered posts-->
+  <string name="discussion_posts_filter_unanswered_posts">未回答</string>
+  <!--Discussion posts sort options-->
+  <!--Discussion posts sort by recent activity-->
+  <string name="discussion_posts_sort_recent_activity">最近のディスカッション</string>
+  <!--Discussion posts sort by most activity-->
+  <string name="discussion_posts_sort_most_activity" tools:ignore="MissingTranslation">コメント数</string>
+  <!--Discussion posts sort by most votes-->
+  <string name="discussion_posts_sort_most_votes">投票数</string>
+  <!--Label for the visibility of a discussion post that is only visible to cohort-->
+  <string name="discussion_post_visibility_cohort">この投稿は {cohort} のみ見ることができます。</string>
+  <!--Label for the visibility of a discussion post that is visible to everyone-->
+  <string name="discussion_post_visibility_everyone">この投稿は誰でも見ることができます。</string>
+  <!--Used while constructing the author attribution text for a discussion post e.g. "3 days ago by Brian (Staff)"-->
+  <string name="discussion_post_author_attribution">{author}</string>
+  <!--Used while constructing the author attribution text for an answer response e.g. "Marked as answer 2 days ago by Khalid (Community TA)"-->
+  <string name="discussion_post_marked_as_answer">ベストアンサー</string>
+  <!--Used while constructing the author attribution text for an endorsed response e.g. "Endorsed 2 days ago by Khalid"-->
+  <string name="discussion_post_endorsed">いいね！</string>
+  <!--Used for putting authorLabel into parenthesis e.g. (Community TA) or (Staff)-->
+  <string name="discussion_post_author_label_attribution">({text})</string>
+  <!--Label indicating the number of replies on a post e.g. 47 total-->
+  <string name="discussion_post_total_replies">合計 {total_replies} 件</string>
+  <!--Label indicating the last time a post was updated e.g. Last post: Jun 22, 2016-->
+  <string name="discussion_post_last_interaction_date">最新の投稿：{date}</string>
+  <!--Discussion Responses-->
+  <!--Label for question type discussions that are answered-->
+  <string name="course_discussion_answered_title">回答済みの質問</string>
+  <!--Label for question type discussions that are unanswered-->
+  <string name="course_discussion_unanswered_title">未回答の質問</string>
+  <!--Label for adding a discussion response-->
+  <!--Label for number of discussion responses-->
+  <plurals name="number_responses_or_comments_responses_label">
+    <item quantity="other">返信 %s 件</item>
+  </plurals>
+  <!--Label for number of discussion comments-->
+  <plurals name="number_responses_or_comments_comments_label">
+    <item quantity="other">コメント %s 件</item>
+  </plurals>
+  <!--Label for adding a new comment-->
+  <!--Label for indicating that a response is an answer-->
+  <string name="discussion_responses_answer">解答</string>
+  <!--Label for indicating that a response is endorsed-->
+  <string name="discussion_responses_endorsed">いいね！</string>
+  <!--Label for time span when its less than a second after posting a response/comment-->
+  <string name="just_now">たった今</string>
+  <!--Label for letting the user know his/her response was successfully added-->
+  <string name="discussion_response_posted">あなたの返信が追加されました。</string>
+  <!--Label for letting the user know his/her comment was successfully added-->
+  <string name="discussion_comment_posted">あなたのコメントが追加されました。</string>
+  <!--Discussion Responses Action Bar-->
+  <!--Label to indicate number of votes-->
+  <plurals name="discussion_responses_action_bar_vote_text">
+    <item quantity="other">投票 {quantity} 件</item>
+  </plurals>
+  <!--Label to indicate discussion response is not marked as inappropriate-->
+  <string name="discussion_responses_report_label">報告</string>
+  <!--Label for discussion response that has been marked as inappropriate-->
+  <string name="discussion_responses_reported_label">未報告</string>
+  <!--Title in adding a new comment-->
+  <string name="discussion_add_comment_title">コメントを書く</string>
+  <!--Title when adding a new comment is disabled-->
+  <string name="discussion_add_comment_disabled_title">コメント受付終了</string>
+  <!--Title in showing list of comments-->
+  <string name="discussion_comments">コメント</string>
+  <!--Add comment button title in adding a new comment-->
+  <string name="discussion_add_comment_button_label">コメントを書く</string>
+  <!--Add comment button description for accessibility in adding a new comment-->
+  <string name="discussion_add_comment_button_description">コメントを書くボタン</string>
+  <!--Add your comment placeholder in adding a new comment-->
+  <!--Title in adding a new response-->
+  <string name="discussion_add_response_title">返信を書く</string>
+  <!--Title when adding a new response is disabled-->
+  <string name="discussion_add_response_disabled_title">返信受付終了</string>
+  <!--Add response button title in adding a new response-->
+  <string name="discussion_add_response_button_label">返信を書く</string>
+  <!--Add response button description for accessibility in adding a new response-->
+  <string name="discussion_add_response_button_description">返信を書くボタン</string>
+  <!--Add your response placeholder in adding a new response-->
+  <!--Title placeholder in adding a new post-->
+  <string name="discussion_post_title">件名</string>
+  <!--Label for selected topic when creating a post-->
+  <string name="discussion_add_post_topic_selection">トピック：{topic}</string>
+  <!--Add post button title in adding a new discussion-->
+  <string name="discussion_add_post_button_label" tools:ignore="MissingTranslation">ディスカッションを投稿</string>
+  <!--Add post button description for accessibility in adding a new discussion-->
+  <string name="discussion_add_post_button_description" tools:ignore="MissingTranslation">ディスカッションを投稿ボタン</string>
+  <!--Add post button title in adding a new post-->
+  <string name="discussion_add_question_button_label">質問を投稿</string>
+  <!--Add post button content description for accessibility in adding a new post-->
+  <string name="discussion_add_question_button_description">質問を投稿ボタン</string>
+  <!--Add your post placeholder in adding a new post-->
+  <!--Add your post placeholder in adding a new post-->
+  <!--Question text in adding a new post-->
+  <string name="discussion_question">質問</string>
+  <!--Assessment-->
+  <!--Label showing next unit in a sub-section on assessment navigation bar-->
+  <string name="assessment_next">次へ</string>
+  <!--Label showing previous unit in a sub-section on assessment navigation bar-->
+  <string name="assessment_previous">前へ</string>
+  <!--Label showing assessment only available on website-->
+  <string name="assessment_not_available">この内容はモバイルでは利用できません。</string>
+  <!--Label showing assessment only available on website-->
+  <string name="assessment_explore_on_web">他の内容を見るか、ウェブ上でこの内容をご覧ください。</string>
+  <!--Button to show wiew on web for assessment-->
+  <string name="assessment_view_on_web">ウェブ上で見る</string>
+  <!--Label to show empty assessment-->
+  <string name="assessment_empty">このセクションには教材がありません。</string>
+  <!--Label to show a course will be starting soon-->
+  <string name="assessment_soon">すぐに</string>
+  <!--Label to notify user to rotate device for viewing a video in full screen-->
+  <string name="assessment_rotate_for_fullscreen">全画面表示でこの動画を見るには画面を横向きにしてください。</string>
+  <!--Label showing only youtube is available-->
+  <string name="assessment_only_on_youtube">この動画はYouTubeのみで見ることができます。</string>
+  <!--Label for button to open on youtube-->
+  <string name="assessment_open_on_youtube">YouTubeで動画を見る</string>
+  <!--Video List-->
+  <!--Title of video download screen-->
+  <string name="title_download">ダウンロード</string>
+  <!--Label indicating user has no Internet connection-->
+  <string name="offline_text">オフライン</string>
+  <!--Cancel video download-->
+  <string name="cancel_download">ダウンロードをキャンセル</string>
+  <!--My Downloads-->
+  <!--Button action label to view an item-->
+  <string name="view_button_text">見る</string>
+  <!--Error text when downloading an item fails-->
+  <string name="download_failed_text">ダウンロード失敗</string>
+  <!--Alert dialog title to confirm download of a large quantity of data-->
+  <string name="download_exceed_title">大きなサイズのダウンロード</string>
+  <!--Message shown a single video download begins-->
+  <string name="msg_started_one_video_download">ビデオを１つダウンロード中です</string>
+  <!--When a video download is about to start and we don't know it's file size yet-->
+  <string name="download_pending">ダウンロード中断</string>
+  <!--Error shown when video download fails-->
+  <string name="msg_video_not_downloaded">動画をダウンロードできません</string>
+  <!--Error shown when video download fails-->
+  <string name="msg_video_not_available">この動画は現在見ることができません。後ほど再試行してください。</string>
+  <!--Error shown when video has flag to indicate it is not available for mobile app-->
+  <string name="video_only_on_web_label">この動画は現在ウェブ上でしか見ることができません。ウェブ上で見るにはクリックしてください。</string>
+  <!--Message to indicate the it is not available for mobile app-->
+  <string name="video_only_on_web_short">この動画はモバイル上で見ることができません。</string>
+  <!--Alert dialog title when login fails-->
+  <string name="login_error">サインイン失敗</string>
+  <!--Alert dialog title when login fails due to lack of Internet-->
+  <string name="no_connectivity">接続エラー</string>
+  <!--Bulk Videos Download-->
+  <!--Accessibility label of bulk download switch-->
+  <!--Title for bulk videos download view when in new or partial videos' download state-->
+  <!--Subtitle for bulk videos download view when in new or partial videos' download state-->
+  <!--Title for bulk videos download view when download is starting-->
+  <!--Title for bulk videos download view when in downloading state-->
+  <!--Subtitle for bulk videos download view when in downloading state-->
+  <!--Title for bulk videos download view when in downloaded state-->
+  <!--Accessibility label of bulk download switch, when its state is OFF and no download is happening-->
+  <!--Accessibility label of bulk download switch, when its state is ON and all videos are downloading-->
+  <!--Accessibility label of bulk download switch, when its state is ON and all videos have been downloaded-->
+  <!--Accessibility label of full bulk download view when videos are being downloaded-->
+  <!--Wifi New Message-->
+  <!--Toggle to allow downloads using cellular data-->
+  <string name="allow">許可</string>
+  <!--Toggle to disallow downloads using cellular data-->
+  <string name="do_not_allow">許可しない</string>
+  <!--Player Settings-->
+  <!--Label for closed captions in video player-->
+  <string name="lbl_closed_caption">字幕を閉じる</string>
+  <!--Label for video playback speed in video player-->
+  <!--Label for None captions selected-->
+  <!--Accessibility Label for Video Player-->
+  <string name="video_player">動画プレイヤー</string>
+  <!--Accessibility Label for View on Web button on Video Player top bar-->
+  <string name="video_player_view_on_web">ウェブ上で見る</string>
+  <!--Accessibility Label for Play button of Video Player-->
+  <string name="video_player_play">再生</string>
+  <!--Accessibility Label for Pause button of Video Player-->
+  <string name="video_player_next">次へ</string>
+  <!--Accessibility Label for Previous button of Video Player-->
+  <string name="video_player_previous">前へ</string>
+  <!--Accessibility Label for Pause button of Video Player-->
+  <string name="video_player_pause">一時停止</string>
+  <!--Accessibility Label for Rewind button on Video Player bottom bar-->
+  <string name="video_player_rewind">30秒巻き戻し</string>
+  <!--Accessibility Label for Settings button on Video Player bottom bar-->
+  <string name="video_player_settings">設定</string>
+  <!--Accessibility Label for Entering Fullscreen button on Video Player bottom bar-->
+  <string name="video_player_enter_fullscreen">全画面モード</string>
+  <!--Accessibility Label for Exiting Fullscreen button on Video Player bottom bar-->
+  <string name="video_player_exit_fullscreen">全画面モード解除</string>
+  <!--Button label to bring up course finder-->
+  <string name="find_course_text">新しいチャレンジを探していますか？</string>
+  <!--Button label to bring up course finder-->
+  <string name="find_course_btn_text">講座を探す</string>
+  <!--Message between sign in button and social login buttons-->
+  <string name="or_sign_in_with">またはサインイン</string>
+  <!--Facebook login method-->
+  <string name="facebook_text">Facebook</string>
+  <!--Google login method-->
+  <string name="google_text">Google</string>
+  <!--Prompt allowing user to choose email program-->
+  <string name="email_chooser_header">...を利用してメールを送る</string>
+  <!--Error shown when user attempts to send email, but has no email app-->
+  <string name="email_client_not_present">電子メールソフトがインストールされていません</string>
+  <!--Search for a course prompt-->
+  <!--Search for a program prompt-->
+  <!--Search for a degree prompt-->
+  <!--Landing Activity text-->
+  <!--Prompt leading user to sign in screen-->
+  <string name="already_have_an_account">アカウントをお持ちですか？サインインしてください。</string>
+  <!--Prompt leading user to create account screen-->
+  <string name="sign_up_and_learn">登録申込をして学習を始める</string>
+  <!--In Register screen-->
+  <string name="register_with">登録</string>
+  <string name="or_register_with_email">メールで登録する</string>
+  <!--New Logistration Launch screen text-->
+  <!--Button leading user to create account screen-->
+  <!--Button leading user to log in screen-->
+  <!--Introduction text on the launch screen-->
+  <!--Search view leading user to Find Courses screen from the launch screen upon searching some text-->
+  <!--Registration Screen-->
+  <!--Button text allowing user to show hidden optional registration fields-->
+  <string name="show_optional_text">任意のフィールドを表示する</string>
+  <!--Button text allowing user to hide visible optional registration fields-->
+  <string name="hide_optional_text">任意のフィールドを隠す</string>
+  <!--Button text allowing user create an account-->
+  <string name="create_account_text">アカウントを作成する</string>
+  <!--Accessible content description of create account button on Registration screen-->
+  <string name="create_account_btn">アカウントを作成するボタン</string>
+  <!--Text shown while waiting for registration request-->
+  <string name="creating_account_text">アカウント作成中…</string>
+  <!--Registration screen title-->
+  <string name="register_title">登録</string>
+  <!--Text for successful registration with social token-->
+  <string name="sign_up_with_facebook_ok">Facebookでサインインできました。</string>
+  <string name="sign_up_with_google_ok">Googleでサインインできました。</string>
+  <string name="sign_up_with_social_ok">{platform_name} を使い始めるにはもう少し情報が必要です。</string>
+  <!--Continue registration after social login-->
+  <string name="complete_registration">登録完了</string>
+  <!--Message shown when enrolling in a course fails-->
+  <string name="enrollment_failure">今回この講座に受講登録できませんでした。</string>
+  <!--Alert dialog button allowing user to repeat their attempted action-->
+  <string name="try_again">再試行する</string>
+  <!--Registration error-->
+  <string name="registration_error_title">登録失敗</string>
+  <string name="registration_error_message">ハイライトしてある部分をアップデートして再試行してください。</string>
+  <!--data charges may apply dialog text-->
+  <!--Alert dialog title shown for users whose in app data is zero rated, when they follow a link outside the app-->
+  <string name="open_external_url_title">データ通信料が課金される場合があります</string>
+  <!--Alert dialog content shown for users whose in app data is zero rated, when they follow a link outside the app-->
+  <string name="open_external_url_desc">このリンクはモバイルブラウザで開きます。データ通信料が追加で課金される場合があります。</string>
+  <string name="android">アンドロイド</string>
+  <!--Email subject line when user attempts to submit feedback about the app-->
+  <string name="email_subject">利用者フィードバック</string>
+  <!--Email subject line when a user attempts to submit a review using the app review workflow-->
+  <string name="review_email_subject">カスタマー・レビュー</string>
+  <!--Submit Feedback app version text-->
+  <string name="app_version">アプリバージョン：</string>
+  <!--Submit Feedback android version text-->
+  <string name="android_os_version">Android OS: </string>
+  <!--Submit Feedback android model text-->
+  <string name="android_device_model">デバイス：</string>
+  <!--Submit Feedback feedback text-->
+  <string name="insert_feedback">フィードバック：</string>
+  <!--Notification related-->
+  <!--toggle between subscribe and unsubscribe to course announcement-->
+  <string name="notification_toggle">通知を許可する</string>
+  <!--Placeholder title for course content with no title-->
+  <string name="untitled_block">名称未設定</string>
+  <!--Title for default channel notifications-->
+  <!--Discussion/Forum-->
+  <string name="forum_no_results_for_search_query">“{search_query}” が見つかりません。他の単語またはディスカッション・カテゴリーをお試しください。</string>
+  <string name="forum_no_results_for_all_posts">この講座のディスカッションには投稿がありません。</string>
+  <string name="forum_no_results_for_following">フォロー中の投稿はありません。</string>
+  <string name="forum_no_results_for_filtered_following">フォロー中の投稿はフィルタリング結果に含まれていません。</string>
+  <string name="forum_no_results_in_category">このディスカッション・カテゴリーには投稿がありません。</string>
+  <string name="forum_no_results_with_filter" tools:ignore="MissingTranslation">投稿フィルタを解除</string>
+  <string name="forum_post_i_am_following">フォロー中の投稿</string>
+  <string name="forum_follow">フォロー</string>
+  <string name="forum_unfollow">フォロー解除</string>
+  <!--User Profiles-->
+  <!--Window title for the user profile screen-->
+  <string name="profile_title">プロフィール</string>
+  <!--The accessibility description for the username section-->
+  <string name="profile_username_description">ユーザー名：{username}</string>
+  <!--The accessibility description for the language section-->
+  <string name="profile_language_description">言語：{language}</string>
+  <!--The accessibility description for the location section-->
+  <string name="profile_location_description">現在地：{location}</string>
+  <!--The accessibility description for the "About Me" section-->
+  <string name="profile_about_me_description">自己紹介：{about_me}</string>
+  <!--Label for toolbar icon that launches the edit profile screen for the current user-->
+  <string name="profile_toolbar_edit_button">編集</string>
+  <!--Shown when viewing your own profile and you are not sharing a full profile-->
+  <string name="profile_sharing_limited_by_you">現在、限定プロフィールを公開しています</string>
+  <!--Shown when viewing another user's profile and that user is not sharing a full profile-->
+  <string name="profile_sharing_limited_by_other_user">現在、限定プロフィールを公開しています</string>
+  <!--Shown when viewing your own profile until you have confirmed you are over the age of consent (13 years old)-->
+  <string name="profile_consent_needed_explanation">全プロフィールを公開するには13歳以上でなければなりません。</string>
+  <!--Shown as button below the explanation for age of consent; it launches the edit profile screen-->
+  <string name="profile_consent_needed_edit_button">アカウント設定</string>
+  <!--Shown when viewing your own incomplete profile-->
+  <string name="profile_incomplete_explanation">プロフィールが出来ていないようです。作成しましょう。</string>
+  <!--Shown as button below the explanation for incomplete profile; it launches the edit profile screen-->
+  <string name="profile_incomplete_edit_button">始める</string>
+  <!--This text is shown in place of the "About Me" text if the user has not filled in their "About Me"-->
+  <string name="profile_incomplete_about_me">「自己紹介」情報がありません。</string>
+  <!--Window title for edit profile screen-->
+  <string name="edit_user_profile_title">プロフィールを編集</string>
+  <!--How most profile fields are formatted when viewing the edit screen-->
+  <string name="edit_user_profile_field">{label}: {value}</string>
+  <!--Default placeholder if a profile field is blank-->
+  <string name="edit_user_profile_field_placeholder">選択</string>
+  <!--Button that saves changes to a profile text field-->
+  <string name="edit_user_profile_textarea_submit_button">提出</string>
+  <!--An option that will set the user profile's primary language to the language of their device's configured locale-->
+  <string name="edit_user_profile_current_language">現在の言語：{current_language}</string>
+  <!--An option that will set the user profile's location to the country of their device's configured locale-->
+  <string name="edit_user_profile_current_location">現在地：{current_location}</string>
+  <!--Button label that will open gallery or camera for choosing new profile photo-->
+  <string name="edit_user_profile_change_photo">変更</string>
+  <!--Content Description for change photo button-->
+  <string name="edit_user_profile_change_photo_description">プロフィール写真を変更</string>
+  <!--Button that will open a camera for taking a new profile photo-->
+  <string name="edit_user_profile_take_photo">写真を撮る</string>
+  <!--Button that will open photo gallery for choosing a new profile photo-->
+  <string name="edit_user_profile_choose_photo">写真を選択</string>
+  <!--Button that will open a camera for taking a new profile photo-->
+  <string name="edit_user_profile_remove_photo">写真を削除</string>
+  <!--Title when cropping newly selected profile photo-->
+  <string name="edit_user_profile_photo_crop_title">サイズ変更</string>
+  <!--Button that will exit the crop tool without saving the image-->
+  <string name="edit_user_profile_photo_crop_cancel">キャンセル</string>
+  <!--Button that will confirm the crop region and continue to upload the cropped photo-->
+  <string name="edit_user_profile_photo_crop_save">選ぶ</string>
+  <!--Tab title for section of profile that displays a user's bio-->
+  <string name="profile_tab_bio">概要</string>
+  <!--Tab title for section of profile that lists a user's accomplishments-->
+  <string name="profile_tab_accomplishment">業績</string>
+  <!--Button that will initiate sharing one of a user's accomplishments-->
+  <string name="share_accomplishment_button">業績をシェア</string>
+  <!--Text that pre-populates your post/email/SMS when sharing certificate-->
+  <string name="share_accomplishment_message">{platform_name} でバッジを獲得しました！こちらで確認してください：{badge_url}</string>
+  <!--Question on the app rating dialog-->
+  <string name="rating_dialog_message">アプリを評価する</string>
+  <!--Dialog title for positive app review-->
+  <string name="rate_app_dialog_title">アプリを評価する</string>
+  <!--Dialog message for positive app review-->
+  <string name="rate_app_dialog_message">アプリストアで簡単なレビューを書いて、 {platform_name} アプリについて他の人に伝えよう</string>
+  <!--Dialog title for negative app review-->
+  <string name="feedback_dialog_title">フィードバックを送る</string>
+  <!--Dialog message for negative app review-->
+  <string name="feedback_dialog_message">改善できるようご協力ください！</string>
+  <!--accessibility label for rating bar-->
+  <string name="rating_bar" tools:ignore="MissingTranslation">Rating コントロール</string>
+  <!--accessibility label for rating selection on rating bar-->
+  <string name="rating_bar_selection">星 {num_of_stars} のうち、{rating}</string>
+  <!--Title of the Whats New screen e.g. Version 2.8.1 New Features-->
+  <string name="whats_new_title">バージョン {version_number} 新機能</string>
+</resources>

--- a/OpenEdXMobile/res/values/errors.xml
+++ b/OpenEdXMobile/res/values/errors.xml
@@ -6,7 +6,7 @@
 
     <!-- Course related error messages -->
     <!-- Error shown when a course's content is invalid or not in the format that we expect -->
-    <string name="course_error_content_invalid">Unable to load course content. Try again later.</string>
+    <string name="course_error_content_invalid" tools:ignore="MissingTranslation">Unable to load course content. Try again later.</string>
     <!-- Title of alert shown when course enrollment request fails -->
     <string name="enrollment_error_title" tools:ignore="MissingTranslation">Enrollment Error</string>
     <!-- Error message shown in alert when course enrollment request fails -->

--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -18,7 +18,7 @@
     <!-- Enroll Now button text-->
     <string name="enroll_now_button_text">Enroll now</string>
     <!-- Invitation Only button text-->
-    <string name="invitation_only_button_text">Invitation only</string>
+    <string name="invitation_only_button_text" tools:ignore="MissingTranslation">Invitation only</string>
     <!-- Effort field name -->
     <string name="effort_field_name">Effort:</string>
     <!-- When discovering courses, some courses have an externally hosted video that describes it.
@@ -113,9 +113,9 @@
     <!-- Label for End User License Agreement -->
     <string name="licensing_agreement" tools:ignore="MissingTranslation">{platform_name} End User License Agreement</string>
     <!-- Label for Terms of Service and Honor Code -->
-    <string name="tos_and_honor_code">{platform_name} Terms of Service and Honor Code</string>
+    <string name="tos_and_honor_code" tools:ignore="MissingTranslation">{platform_name} Terms of Service and Honor Code</string>
     <!-- Label for Privacy Policy -->
-    <string name="privacy_policy">Privacy Policy</string>
+    <string name="privacy_policy" tools:ignore="MissingTranslation">Privacy Policy</string>
 
     <string name="login_title">Sign In</string>
     <!-- Accessible content description of close button on Sign in and Sign up screen -->
@@ -125,17 +125,17 @@
 
     <!-- Navigation Drawer Labels -->
     <!-- Button text to show user current downloads screen -->
-    <string name="label_current_downloads">View current downloads</string>
+    <string name="label_current_downloads" tools:ignore="MissingTranslation">View current downloads</string>
     <!-- Content description for edit profile button -->
     <string name="open_profile_button">Open your profile</string>
     <!-- Title of user's course list screen -->
-    <string name="label_my_courses">Courses</string>
+    <string name="label_my_courses" tools:ignore="MissingTranslation">Courses</string>
     <!-- Title of user's program list screen -->
     <string name="label_my_programs" tools:ignore="MissingTranslation">Programs</string>
     <!-- Title of native Find Courses Screen -->
     <string name="label_find_courses">Find Courses</string>
     <!-- Title of webview based Find Courses Screen -->
-    <string name="label_discover">Discover</string>
+    <string name="label_discover" tools:ignore="MissingTranslation">Discover</string>
     <!-- Title of Degrees tab on Discovery screen -->
     <string name="label_degrees" tools:ignore="MissingTranslation">Degrees</string>
     <!-- Title of Find Courses tab on Main Dashboard screen -->
@@ -153,9 +153,9 @@
     <!-- Settings screen version -->
     <string name="label_version">App Version</string>
     <!-- Button text to show user Settings screen -->
-    <string name="label_settings">Settings</string>
+    <string name="label_settings" tools:ignore="MissingTranslation">Settings</string>
     <!-- Title of Account screen -->
-    <string name="title_account">Account</string>
+    <string name="title_account" tools:ignore="MissingTranslation">Account</string>
 
     <!-- Help Dialog Place Holder messages -->
     <!-- Reset password alert dialog title -->
@@ -187,7 +187,7 @@
     <!-- Title of privacy policy users must accept to use the app -->
     <string name="privacy_policy_title" translatable="false">@string/privacy_policy</string>
     <!-- Title of terms of service & honor code users must accept to use the app -->
-    <string name="terms_of_service_title">Terms of Service</string>
+    <string name="terms_of_service_title" tools:ignore="MissingTranslation">Terms of Service</string>
 
     <!-- My Courses -->
     <!-- Row of course on dashboard screen -->
@@ -196,9 +196,9 @@
     <!-- NOTE: TODO - not final one -->
     <string name="courseware_subtitle">Access videos and assignments</string>
     <!-- Row title of videos on dashboard screen -->
-    <string name="videos_title">Videos</string>
+    <string name="videos_title" tools:ignore="MissingTranslation">Videos</string>
     <!-- Row subtitle of videos on dashboard screen -->
-    <string name="videos_subtitle">Watch course videos</string>
+    <string name="videos_subtitle" tools:ignore="MissingTranslation">Watch course videos</string>
     <!-- Row of Discussion on dashboard screen -->
     <string name="discussion_title">Discussion</string>
     <!-- Row of Discussion on dashboard screen -->
@@ -212,24 +212,24 @@
     <!-- Row of announcement on dashboard screen -->
     <string name="announcement_title">Announcements</string>
     <!-- Title text for the important dates section on the course dashboard  -->
-    <string name="course_dates_title">Important Dates</string>
+    <string name="course_dates_title" tools:ignore="MissingTranslation">Important Dates</string>
     <!-- Title text for the additional resources section on the tabular course dashboard  -->
-    <string name="resources_title">Resources</string>
+    <string name="resources_title" tools:ignore="MissingTranslation">Resources</string>
     <!-- Row of announcement on dashboard screen -->
     <!-- NOTE: TODO - not final one -->
     <string name="announcement_subtitle">Keep up with the latest news</string>
     <!-- Subtitle text describing the important dates section on the course dashboard -->
-    <string name="course_dates_subtitle">Keep track of deadlines and stay on track</string>
+    <string name="course_dates_subtitle" tools:ignore="MissingTranslation">Keep track of deadlines and stay on track</string>
     <!-- Accessible content description of course name label field -->
     <string name="course_name">Course Name</string>
     <!-- Label indicating new course content has been downloaded -->
     <string name="new_course_content">New Course Content</string>
     <!-- Label for date when course starts -->
-    <string name="label_starting">Starting {date}</string>
+    <string name="label_starting" tools:ignore="MissingTranslation">Starting {date}</string>
     <!-- Label for course that has ended -->
-    <string name="label_ended">Ended {date}</string>
+    <string name="label_ended" tools:ignore="MissingTranslation">Ended {date}</string>
     <!-- Label for date when course is ending -->
-    <string name="label_ending">Ending {date}</string>
+    <string name="label_ending" tools:ignore="MissingTranslation">Ending {date}</string>
 
     <!-- Label for date when course is expiring in a specific time frame like in 2 days -->
     <string name="label_expires" tools:ignore="MissingTranslation">Course access expires {date}</string>
@@ -250,7 +250,7 @@
     <!-- Label shown when no courseware content is available -->
     <string name="no_chapter_text">No course content is currently available.</string>
     <!-- Label shown when no mobile-friendly videos are available in a course -->
-    <string name="no_videos_text">This course does not include any videos.</string>
+    <string name="no_videos_text" tools:ignore="MissingTranslation">This course does not include any videos.</string>
     <!-- Label shown when user is enrolled in no courses -->
     <string name="no_courses_to_display">It looks like you are not enrolled in any courses yet.</string>
     <!-- Label shown when no announcements are available for a course -->
@@ -258,13 +258,13 @@
     <!-- Label shown when no handouts are available for a course -->
     <string name="no_handouts_to_display">There are currently no handouts for this course.</string>
     <!-- Label shown when no important dates are available for a course -->
-    <string name="no_course_dates_to_display">Course dates are not currently available.</string>
+    <string name="no_course_dates_to_display" tools:ignore="MissingTranslation">Course dates are not currently available.</string>
     <!-- Title of the screen where user can delete videos -->
-    <string name="delete_videos_title">Delete Videos</string>
+    <string name="delete_videos_title" tools:ignore="MissingTranslation">Delete Videos</string>
     <!-- Label for a course item's due date for same day -->
-    <string name="due_date_today">due today at {due_date}</string>
+    <string name="due_date_today" tools:ignore="MissingTranslation">due today at {due_date}</string>
     <!-- Label for a course item's due date -->
-    <string name="due_date_past_future">due {due_date}</string>
+    <string name="due_date_past_future" tools:ignore="MissingTranslation">due {due_date}</string>
     <!-- Upgrade banner's description which appears on course outline screen. -->
     <string name="upgrade_banner_description" tools:ignore="MissingTranslation">Complete assessments on the go toward a certificate!</string>
     <!-- Title upgrade to verified today course outline footer -->
@@ -460,30 +460,30 @@
 
     <!-- Bulk Videos Download -->
     <!-- Accessibility label of bulk download switch -->
-    <string name="bulk_download_switch">Bulk videos download switch.</string>
+    <string name="bulk_download_switch" tools:ignore="MissingTranslation">Bulk videos download switch.</string>
     <!-- Title for bulk videos download view when in new or partial videos' download state -->
-    <string name="download_to_device">Download to Device</string>
+    <string name="download_to_device" tools:ignore="MissingTranslation">Download to Device</string>
     <!-- Subtitle for bulk videos download view when in new or partial videos' download state -->
     <plurals name="download_total">
         <item quantity="one">{total_videos_count} Video, {total_videos_size} total</item>
         <item quantity="other">{total_videos_count} Videos, {total_videos_size} total</item>
     </plurals>
     <!-- Title for bulk videos download view when download is starting -->
-    <string name="download_starting">Starting Download…</string>
+    <string name="download_starting" tools:ignore="MissingTranslation">Starting Download…</string>
     <!-- Title for bulk videos download view when in downloading state -->
-    <string name="downloading_videos">Downloading Videos…</string>
+    <string name="downloading_videos" tools:ignore="MissingTranslation">Downloading Videos…</string>
     <!-- Subtitle for bulk videos download view when in downloading state -->
-    <string name="download_remaining">{remaining_videos_count} Remaining, {remaining_videos_size} total</string>
+    <string name="download_remaining" tools:ignore="MissingTranslation">{remaining_videos_count} Remaining, {remaining_videos_size} total</string>
     <!-- Title for bulk videos download view when in downloaded state -->
-    <string name="download_complete">All Videos Downloaded</string>
+    <string name="download_complete" tools:ignore="MissingTranslation">All Videos Downloaded</string>
     <!-- Accessibility label of bulk download switch, when its state is OFF and no download is happening -->
-    <string name="switch_off_no_downloading">Toggling the switch on, will download all videos of this course.</string>
+    <string name="switch_off_no_downloading" tools:ignore="MissingTranslation">Toggling the switch on, will download all videos of this course.</string>
     <!-- Accessibility label of bulk download switch, when its state is ON and all videos are downloading -->
-    <string name="switch_on_all_downloading">Toggling the switch off, will cancel downloading of all videos and will delete all downloaded videos of this course.</string>
+    <string name="switch_on_all_downloading" tools:ignore="MissingTranslation">Toggling the switch off, will cancel downloading of all videos and will delete all downloaded videos of this course.</string>
     <!-- Accessibility label of bulk download switch, when its state is ON and all videos have been downloaded -->
-    <string name="switch_on_all_downloaded">Toggling the switch off, will delete all downloaded videos of this course.</string>
+    <string name="switch_on_all_downloaded" tools:ignore="MissingTranslation">Toggling the switch off, will delete all downloaded videos of this course.</string>
     <!-- Accessibility label of full bulk download view when videos are being downloaded -->
-    <string name="view_downloads">Double tap to view current downloads.</string>
+    <string name="view_downloads" tools:ignore="MissingTranslation">Double tap to view current downloads.</string>
 
     <!-- Wifi New Message -->
     <!-- Toggle to allow downloads using cellular data -->
@@ -534,7 +534,7 @@
     <!-- Error shown when user attempts to send email, but has no email app -->
     <string name="email_client_not_present">No e-mail clients installed</string>
     <!-- Search for a course prompt -->
-    <string name="search_for_courses">Search for courses</string>
+    <string name="search_for_courses" tools:ignore="MissingTranslation">Search for courses</string>
     <!-- Search for a program prompt -->
     <string name="search_for_programs" tools:ignore="MissingTranslation">Search for programs</string>
     <!-- Search for a degree prompt -->
@@ -551,13 +551,13 @@
 
     <!-- New Logistration Launch screen text -->
     <!-- Button leading user to create account screen -->
-    <string name="launch_register">Create your Account</string>
+    <string name="launch_register" tools:ignore="MissingTranslation">Create your Account</string>
     <!-- Button leading user to log in screen -->
-    <string name="launch_login">Log In</string>
+    <string name="launch_login" tools:ignore="MissingTranslation">Log In</string>
     <!-- Introduction text on the launch screen -->
     <string name="launch_text" tools:ignore="MissingTranslation">Courses from the world’s best universities in your pocket.</string>
     <!-- Search view leading user to Find Courses screen from the launch screen upon searching some text -->
-    <string name="launch_search_courses">Search Courses</string>
+    <string name="launch_search_courses" tools:ignore="MissingTranslation">Search Courses</string>
 
     <!-- Registration Screen -->
     <!-- Button text allowing user to show hidden optional registration fields -->

--- a/transifex_utils/core/constants.py
+++ b/transifex_utils/core/constants.py
@@ -13,6 +13,7 @@ languages = {
     'de_DE': 'de-rDE',
     'he': 'iw',
     'vi': 'vi',
+    'ja_JP': 'ja',
 }
 
 SUBJECTS_JSON = "subjects.json"


### PR DESCRIPTION
### Description

[LEARNER-7347](https://openedx.atlassian.net/browse/LEARNER-7347)

Japanese language support has been added in this PR. All Resources are downloaded from [Transifex](https://www.transifex.com/open-edx/edx-mobile-apps/content/).

**Notes**
If Japanese translation of any string is missing then the English version of the string will be displayed.

**How to test this PR**
Change the android device language to Japanese. 

- [ ]  App should work properly. It does not crash in any case.
- [ ]  UI shouldn't appear distorted.