### PR TITLE
Handle logged out case for Deeplink & Push Notifications

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/DeepLink.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/DeepLink.kt
@@ -1,9 +1,11 @@
 package org.edx.mobile.deeplink
 
 import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
 import org.json.JSONObject
 
-open class DeepLink(val screenName: String) {
+open class DeepLink(val screenName: String) : Parcelable {
     object Keys {
         const val SCREEN_NAME = "screen_name"
         const val COURSE_ID = "course_id"
@@ -40,5 +42,30 @@ open class DeepLink(val screenName: String) {
 
     override fun toString(): String {
         return "DeepLink(screenName='$screenName', courseId=$courseId, pathId=$pathId, topicID=$topicID, threadID=$threadID)"
+    }
+
+    companion object {
+        @JvmField
+        val CREATOR: Parcelable.Creator<DeepLink> = object : Parcelable.Creator<DeepLink> {
+            override fun createFromParcel(source: Parcel): DeepLink = DeepLink(source)
+            override fun newArray(size: Int): Array<DeepLink?> = arrayOfNulls(size)
+        }
+    }
+
+    constructor(source: Parcel) : this(source.readString()) {
+        this.courseId = source.readString()
+        this.pathId = source.readString()
+        this.topicID = source.readString()
+        this.threadID = source.readString()
+    }
+
+    override fun describeContents() = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) = with(dest) {
+        writeString(screenName)
+        writeString(courseId)
+        writeString(pathId)
+        writeString(topicID)
+        writeString(threadID)
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/DeepLinkManager.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/DeepLinkManager.java
@@ -29,7 +29,7 @@ public class DeepLinkManager {
                     router.showFindCourses(activity, screenName, deepLink.getPathId());
                     break;
                 default:
-                    activity.startActivity(router.getLogInIntent());
+                    activity.startActivity(router.getLogInIntent(deepLink));
                     break;
             }
             return;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/LoginActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/LoginActivity.java
@@ -19,6 +19,8 @@ import org.edx.mobile.R;
 import org.edx.mobile.authentication.AuthResponse;
 import org.edx.mobile.authentication.LoginTask;
 import org.edx.mobile.databinding.ActivityLoginBinding;
+import org.edx.mobile.deeplink.DeepLink;
+import org.edx.mobile.deeplink.DeepLinkManager;
 import org.edx.mobile.exception.LoginErrorMessage;
 import org.edx.mobile.exception.LoginException;
 import org.edx.mobile.http.HttpStatus;
@@ -48,8 +50,16 @@ public class LoginActivity
     LoginPrefs loginPrefs;
 
     @NonNull
-    public static Intent newIntent() {
-        return IntentFactory.newIntentForComponent(LoginActivity.class);
+    public static Intent newIntent(@Nullable DeepLink deepLink) {
+        final Intent intent = IntentFactory.newIntentForComponent(LoginActivity.class);
+        intent.putExtra(Router.EXTRA_DEEP_LINK, deepLink);
+        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+        return intent;
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        this.setIntent(intent);
     }
 
     @NonNull
@@ -279,6 +289,11 @@ public class LoginActivity
     public void onUserLoginSuccess(ProfileModel profile) {
         setResult(RESULT_OK);
         finish();
+        final DeepLink deepLink = getIntent().getParcelableExtra(Router.EXTRA_DEEP_LINK);
+        if (deepLink != null) {
+            DeepLinkManager.onDeepLinkReceived(this, deepLink);
+            return;
+        }
         if (!environment.getConfig().isRegistrationEnabled()) {
             environment.getRouter().showMainDashboard(this);
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
@@ -19,6 +19,7 @@ import org.edx.mobile.R;
 import org.edx.mobile.authentication.LoginAPI;
 import org.edx.mobile.core.IEdxEnvironment;
 import org.edx.mobile.course.CourseDetail;
+import org.edx.mobile.deeplink.DeepLink;
 import org.edx.mobile.deeplink.ScreenDef;
 import org.edx.mobile.discussion.DiscussionComment;
 import org.edx.mobile.discussion.DiscussionThread;
@@ -60,6 +61,7 @@ public class Router {
     public static final String EXTRA_SUBJECT_FILTER = "subject_filter";
     public static final String EXTRA_PATH_ID = "path_id";
     public static final String EXTRA_SCREEN_NAME = "screen_name";
+    public static final String EXTRA_DEEP_LINK = "deep_link";
 
     @Inject
     Config config;
@@ -124,8 +126,13 @@ public class Router {
     }
 
     @NonNull
+    public Intent getLogInIntent(@Nullable DeepLink deepLink) {
+        return LoginActivity.newIntent(deepLink);
+    }
+
+    @NonNull
     public Intent getLogInIntent() {
-        return LoginActivity.newIntent();
+        return getLogInIntent(null);
     }
 
     @NonNull

--- a/OpenEdXMobile/src/test/java/org/edx/mobile/login/LoginActivityTest.java
+++ b/OpenEdXMobile/src/test/java/org/edx/mobile/login/LoginActivityTest.java
@@ -15,7 +15,7 @@ public class LoginActivityTest extends PresenterActivityTest<LoginActivity, Logi
 
     @Before
     public void setup() {
-        startActivity(LoginActivity.newIntent());
+        startActivity(LoginActivity.newIntent(null));
     }
 
     @Test


### PR DESCRIPTION
### Description

[LEARNER-7512](https://openedx.atlassian.net/browse/LEARNER-7512)

In this PR we are handling the logged out case for Deeplink & Push Notifications.
If the user is logged out and deep link wants to redirect the user to the screen which requires user authentication than the user will be redirected to a login screen first and in follow up of logged in user will be redirected to the required screen.