### PR TITLE
RC v2.20.7 | Payments v2

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/CropImageView.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/CropImageView.java
@@ -8,6 +8,7 @@ import android.graphics.PointF;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.Region;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 
@@ -108,7 +109,13 @@ public class CropImageView extends org.edx.mobile.third_party.subscaleview.Subsa
         mRectF.set((float) canvas.getWidth() / 2 - radius, (float) canvas.getHeight() / 2 - radius, (float) canvas.getWidth() / 2 + radius, (float) canvas.getHeight() / 2 + radius);
         circleSelectionPath.reset();
         circleSelectionPath.addOval(mRectF, Path.Direction.CW);
-        canvas.clipPath(circleSelectionPath, Region.Op.XOR);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            canvas.clipOutPath(circleSelectionPath);
+        } else {
+            canvas.clipPath(circleSelectionPath, Region.Op.XOR);
+        }
+
         canvas.drawRect(0, 0, canvas.getWidth(), canvas.getHeight(), backgroundPaint);
         // Canvas did not save and called restore due to which app crashes, so we have to save first then call restore
         canvas.save();


### PR DESCRIPTION
### Description

[LEARNER-7662](https://openedx.atlassian.net/browse/LEARNER-7662)

- Part ways from the use of deprecated parameters of Region.Op enumeration.
- Using Region.Op.DIFFERENCE instead of Region.Op.XOR now because in our
case it is giving the same results in clipping.

**Ref:** 
https://developer.android.com/reference/android/graphics/Canvas#clipPath(android.graphics.Path,%20android.graphics.Region.Op)
**Reference for graphical understanding of Region.Op parameters:**
https://android.okhelp.cz/drawbitmap-clippath-union-difference-intersect-replace-xor-android-example/