### PR TITLE
Resolve IllegalStateException crash initiated by YouTube Player

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitNavigationActivity.java
@@ -110,6 +110,21 @@ public class CourseUnitNavigationActivity extends CourseBaseActivity implements
     }
 
     @Override
+    public void onSaveInstanceState(Bundle outState) {
+        /*
+         * If the youtube player is not in a proper state then it throws the IllegalStateException.
+         * To avoid the crash and continue the flow we are catching the exception.
+         *
+         * It may occur when the edX app was in background and user kills the on-device YouTube app.
+         */
+        try {
+            super.onSaveInstanceState(outState);
+        } catch (IllegalStateException e) {
+            logger.error(e);
+        }
+    }
+
+    @Override
     protected void onResume() {
         super.onResume();
         updateUIForOrientation();

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitYoutubePlayerFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitYoutubePlayerFragment.java
@@ -114,8 +114,20 @@ public class CourseUnitYoutubePlayerFragment extends BaseCourseUnitVideoFragment
 
     @Override
     protected void setFullScreen(boolean fullscreen) {
+        /*
+         * If the youtube player is not in a proper state then it throws the IllegalStateException.
+         * To avoid the crash and continue the flow we are reinitializing the player here.
+         *
+         * It may occur when the edX app was in background and user kills the on-device YouTube app.
+         */
         if (youTubePlayer != null) {
-            youTubePlayer.setFullscreen(fullscreen);
+            try {
+                youTubePlayer.setFullscreen(fullscreen);
+            } catch (IllegalStateException e) {
+                logger.error(e);
+                releaseYoutubePlayer();
+                initializeYoutubePlayer();
+            }
         }
     }
 


### PR DESCRIPTION
### Description

[LEARNER-7638](https://openedx.atlassian.net/browse/LEARNER-7638)
- YouTubePlayerSupportFragment throw the "IllegalStateException" when user
  forcefully kill the YouTube app before and moves back in the app.

**Reproduce Steps:**
- Course Dashboard > Play some Youtube video
- Pause the video > tap on "more videos" button
- Select any video from the list, it will load the Youtube interface.
- Kill the YouTube App and moves back to the edx app, it will crash app.