### PR TITLE
Fix the issue of invisibility of tab icons on OS 10.

### DIFF
--- a/android-iconify/src/main/java/com/joanzapata/iconify/IconDrawable.java
+++ b/android-iconify/src/main/java/com/joanzapata/iconify/IconDrawable.java
@@ -418,7 +418,12 @@ public final class IconDrawable extends Drawable implements Animatable {
     }
 
     private void setModulatedAlpha() {
-        paint.setAlpha(((color >> 24) * iconState.alpha) / 255);
+        /* color >>> 24 Returns the alpha component of a color int
+         * For example we have a color #8800ff00, its integer value will be -2013200640
+         * -2013200640 >>> 24 will give us 136 which is the decimal value of hex 88
+         * Ref: https://developer.android.com/reference/android/graphics/Color#alpha(int)
+         */
+        paint.setAlpha(((color >>> 24) * iconState.alpha) / 255);
     }
 
     @Override
@@ -431,7 +436,7 @@ public final class IconDrawable extends Drawable implements Animatable {
     @Override
     @CheckResult
     public int getOpacity() {
-        int baseAlpha = color >> 24;
+        int baseAlpha = color >>> 24;
         if (baseAlpha == 255 && iconState.alpha == 255) return PixelFormat.OPAQUE;
         if (baseAlpha == 0 || iconState.alpha == 0) return PixelFormat.TRANSPARENT;
         return PixelFormat.OPAQUE;


### PR DESCRIPTION
### Description

[LEARNER-7643](https://openedx.atlassian.net/browse/LEARNER-7643)

- Fix the issue of invisibility of tab icons on OS 10.

### Notes
- The issue is fixed by changing the Arithmetic shift right operator to Logical shift right operator
i-e- from '>>' to '>>>'
We were trying to calculate the alpha value from the color Integer which could be done by using the '>>>' operator. '>>' Operator was giving the wrong value.
- With '>>' operator calculated alpha was becoming -1 while alpha possible values are [0..255] in setAlpha() function. On OS 9 and below it fallbacks to 255 which means full alpha while on OS 10 it fallbacks to 0 which means zero alpha or invisibility.

#### Calculations:
For example, we have a color #8800ff00, its integer value will be -2013200640
-2013200640 >>> 24 will give us 136 which is the decimal value of hex 88
Ref: https://developer.android.com/reference/android/graphics/Color#alpha(int)

### Testing
Tested on OS 9 and OS 10.

### Edge Case Test Results:
Alpha values edge case testing has done on Handouts and Announcement Icons and here are the results:


Color code | OS-9  | OS-10
--- | --- | ---
#00ff00 | <img src="https://user-images.githubusercontent.com/25842457/76934416-ef18e200-6910-11ea-9b3b-ea33794b7086.png" width="200">  |  <img src="https://user-images.githubusercontent.com/25842457/76934407-eaecc480-6910-11ea-8444-e38ebdc5b2f7.png" width="200">
#0000ff00 | <img src="https://user-images.githubusercontent.com/25842457/76934419-efb17880-6910-11ea-8552-b19116f1dfd7.png" width="200">  | <img src="https://user-images.githubusercontent.com/25842457/76934421-f0e2a580-6910-11ea-99bf-70f63cf04535.png" width="200">
#5500ff00 | <img src="https://user-images.githubusercontent.com/25842457/76934425-f213d280-6910-11ea-9892-8855882b08b5.png" width="200">  | <img src="https://user-images.githubusercontent.com/25842457/76934427-f2ac6900-6910-11ea-9a32-d9d7cab1791e.png" width="200">


