### PR TITLE
Enable `GradleCompatible` lint check

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -420,12 +420,6 @@ android {
         showAll true
         warning 'TypographyQuotes', 'InvalidPackage'
         error 'StopShip', 'ContentDescription'
-        /**
-         * This is a bug that is fixed in the up-coming Android Studio 2.4 release.
-         * Link to issue: https://issuetracker.google.com/issues/37630182
-         */
-        //TODO: Remove GradleCompatible after we upgrade to Android Studio 2.4
-        disable 'GradleCompatible'
     }
 
     productFlavors {


### PR DESCRIPTION
### Description

Reverts commit # 9f204f8 in which this check was disabled.

Now that we are using Android Studio 3.5+ we can safely enable this lint check back again.