### PR TITLE
Fix crash for Payments screens

### DIFF
--- a/OpenEdXMobile/res/layout/fragment_locked_course_unit.xml
+++ b/OpenEdXMobile/res/layout/fragment_locked_course_unit.xml
@@ -19,7 +19,7 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
-                <android.support.constraint.ConstraintLayout
+                <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:background="@drawable/payment_blue_bg_2"
@@ -62,7 +62,7 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/lock" />
 
-                </android.support.constraint.ConstraintLayout>
+                </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <ImageView
                     android:layout_width="match_parent"

--- a/OpenEdXMobile/res/layout/fragment_payments_info.xml
+++ b/OpenEdXMobile/res/layout/fragment_payments_info.xml
@@ -19,7 +19,7 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
-                <android.support.constraint.ConstraintLayout
+                <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:background="@drawable/payment_blue_bg"
@@ -80,7 +80,7 @@
                         app:layout_constraintTop_toTopOf="@id/tv_header_detail"
                         app:layout_constraintWidth_percent=".35" />
 
-                </android.support.constraint.ConstraintLayout>
+                </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <LinearLayout
                     android:layout_width="match_parent"


### PR DESCRIPTION
### Description

[LEARNER-7714](https://openedx.atlassian.net/browse/LEARNER-7714)

Wrong references of Constraint layout were being used that caused the crash i.e. support variants instead of androidX variants.