### PR TITLE
Fix webview crash when it tries loading error in some cases

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -169,10 +169,10 @@ dependencies {
      * latest version as a result of dynamic version
      * definitions in the transitive dependencies.
      */
-    implementation ('com.squareup.retrofit2:retrofit:2.1.0') {
+    implementation ('com.squareup.retrofit2:retrofit:2.8.1') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
-    implementation ('com.squareup.retrofit2:converter-gson:2.1.0') {
+    implementation ('com.squareup.retrofit2:converter-gson:2.8.1') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
         exclude group: 'com.google.code.gson', module: 'gson'
     }
@@ -233,7 +233,7 @@ dependencies {
         exclude group: 'com.android.support'
     }
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.12.8'
-    testImplementation ('com.squareup.retrofit2:retrofit-mock:2.1.0') {
+    testImplementation ('com.squareup.retrofit2:retrofit-mock:2.8.1') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
 


### PR DESCRIPTION
### Description

[LEARNER-7715](https://openedx.atlassian.net/browse/LEARNER-7715)

### Fix inspiration: https://github.com/square/retrofit/issues/2359

### Details
The reason why this lib upgrade fixes the issue is cuz the `okhttp3.Response` class required that the builder function include a non-null `message` while creating a `Response` object which `error` function in the `Response` class of `retrofit-2.1.0` didn't do but the fix is available in the latest version of retrofit i.e. `retrofit-2.8.1`.

### Deep dive
`oktthp3.Response` class:
```java
    public Response build() {
      if (request == null) throw new IllegalStateException("request == null");
      if (protocol == null) throw new IllegalStateException("protocol == null");
      if (code < 0) throw new IllegalStateException("code < 0: " + code);
      if (message == null) throw new IllegalStateException("message == null");
      return new Response(this);
    }
```

`retrofit-2.1.0.`'s `Response` class:
```java
  /**
   * Create a synthetic error response with an HTTP status code of {@code code} and {@code body}
   * as the error body.
   */
  public static <T> Response<T> error(int code, ResponseBody body) {
    if (code < 400) throw new IllegalArgumentException("code < 400: " + code);
    return error(body, new okhttp3.Response.Builder() //
        .code(code)
        .protocol(Protocol.HTTP_1_1)
        .request(new Request.Builder().url("http://localhost/").build())
        .build());
  }
```

`retrofit-2.8.1.`'s `Response` class:
```java
  /**
   * Create a synthetic error response with an HTTP status code of {@code code} and {@code body}
   * as the error body.
   */
  public static <T> Response<T> error(int code, ResponseBody body) {
    Objects.requireNonNull(body, "body == null");
    if (code < 400) throw new IllegalArgumentException("code < 400: " + code);
    return error(body, new okhttp3.Response.Builder() //
        .body(new OkHttpCall.NoContentResponseBody(body.contentType(), body.contentLength()))
        .code(code)
        .message("Response.error()")
        .protocol(Protocol.HTTP_1_1)
        .request(new Request.Builder().url("http://localhost/").build())
        .build());
  }
```