### PR TITLE
Fix Crash incase of Japanese whatsnew

### DIFF
--- a/OpenEdXMobile/res/raw-ja/whats_new.json
+++ b/OpenEdXMobile/res/raw-ja/whats_new.json
@@ -1,29 +1,31 @@
-{
-  "version":"2.21",
-  "messages":[
-    {
-      "platforms":[
-        "android"
-      ],
-      "image":"screen_1",
-      "title":"Chromecastのサポート",
-      "message":"大きな画面でコースの動画を視聴したいですか？ Chromecastのサポートを追加しました。できるようになりました！"
-    },
-    {
-      "platforms":[
-        "android"
-      ],
-      "image":"screen_2",
-      "title":"YouTubeプレーヤー",
-      "message":"YouTubeコースの動画を見るためにアプリを離れるのにうんざりしていませんか？アプリ内プレーヤーで動画を視聴できるようになりました。"
-    },
-    {
-      "platforms":[
-        "android"
-      ],
-      "image":"screen_3",
-      "title":"Microsoftログイン",
-      "message":"これで、Microsoftアカウントで登録またはログインできます."
-    }
-  ]
-},
+[
+  {
+    "version": "2.21",
+    "messages": [
+      {
+        "platforms": [
+          "android"
+        ],
+        "image": "screen_1",
+        "title": "Chromecastのサポート",
+        "message": "大きな画面でコースの動画を視聴したいですか？ Chromecastのサポートを追加しました。できるようになりました！"
+      },
+      {
+        "platforms": [
+          "android"
+        ],
+        "image": "screen_2",
+        "title": "YouTubeプレーヤー",
+        "message": "YouTubeコースの動画を見るためにアプリを離れるのにうんざりしていませんか？アプリ内プレーヤーで動画を視聴できるようになりました。"
+      },
+      {
+        "platforms": [
+          "android"
+        ],
+        "image": "screen_3",
+        "title": "Microsoftログイン",
+        "message": "これで、Microsoftアカウントで登録またはログインできます."
+      }
+    ]
+  }
+]


### PR DESCRIPTION
### Description

[LEARNER-7716](https://openedx.atlassian.net/browse/LEARNER-7716)

- Fix crash happens when whats new screen is being displayed and device’s language is set to Japanese language.
 
**Steps to Reproduce**
- Change device language to Japanese
- App will crash when whatsnew screen will be presented
