### PR TITLE
Add more options in the video player for playback speed controls

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
@@ -1,6 +1,7 @@
 package org.edx.mobile.module.prefs;
 
 import android.content.Context;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -95,7 +96,7 @@ public class LoginPrefs {
 
     /**
      * @return User selected video playback speed, returns normal speed
-     * i-e- NORMAL_PLAYBACK_SPEED if user hasn't selected it yet.
+     * i-e- {@link VideoPlaybackSpeed#SPEED_1_0X} if user hasn't selected it yet.
      */
     public float getDefaultPlaybackSpeed() {
         return pref.getFloat(PrefManager.Key.PLAYBACK_SPEED, VideoPlaybackSpeed.SPEED_1_0X.getSpeedValue());

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/prefs/LoginPrefs.java
@@ -61,7 +61,7 @@ public class LoginPrefs {
     public void clear() {
         clearSocialLoginToken();
         setSubtitleLanguage(null);
-        saveDefaultPlaybackSpeed(VideoPlaybackSpeed.NORMAL.getSpeedValue());
+        saveDefaultPlaybackSpeed(VideoPlaybackSpeed.SPEED_1_0X.getSpeedValue());
         pref.put(PrefManager.Key.PROFILE_JSON, null);
         pref.put(PrefManager.Key.AUTH_JSON, null);
         EdxCookieManager.getSharedInstance(MainApplication.instance()).clearWebWiewCookie();
@@ -98,7 +98,7 @@ public class LoginPrefs {
      * i-e- NORMAL_PLAYBACK_SPEED if user hasn't selected it yet.
      */
     public float getDefaultPlaybackSpeed() {
-        return pref.getFloat(PrefManager.Key.PLAYBACK_SPEED, VideoPlaybackSpeed.NORMAL.getSpeedValue());
+        return pref.getFloat(PrefManager.Key.PLAYBACK_SPEED, VideoPlaybackSpeed.SPEED_1_0X.getSpeedValue());
     }
 
     public void saveDefaultPlaybackSpeed(float speed) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/VideoPlaybackSpeed.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/VideoPlaybackSpeed.java
@@ -5,8 +5,9 @@ package org.edx.mobile.util;
  * This enum defines the video playback speed constants for {@link org.edx.mobile.player.VideoPlayer VideoPlayer}
  */
 public enum VideoPlaybackSpeed {
-    SLOW(0.5f), NORMAL(1.0f),
-    FAST(1.5f), VERY_FAST(2.0f);
+    SPEED_0_25X(0.25f), SPEED_0_50X(0.5f), SPEED_0_75X(0.75f),
+    SPEED_1_0X(1.0f), SPEED_1_25X(1.25f), SPEED_1_50X(1.5f),
+    SPEED_1_75X(1.75f), SPEED_2_0X(2.0f);
 
     private final float speedValue;
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/SpeedAdapter.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/adapters/SpeedAdapter.java
@@ -23,7 +23,7 @@ public abstract class SpeedAdapter extends BaseListAdapter<Float> {
     @Override
     public void render(BaseViewHolder tag, Float speed) {
         ViewHolder holder = (ViewHolder) tag;
-        holder.tvSpeed.setText(String.format(Locale.getDefault(), "%.1f x", speed));
+        holder.tvSpeed.setText(String.format(Locale.getDefault(), "%.2f x", speed));
         if (speed == selectedPlaybackSpeed) {
             holder.tvSpeed.setBackgroundResource(R.color.cyan_text_navigation_20);
         } else {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/SpeedDialogFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/SpeedDialogFragment.java
@@ -65,9 +65,9 @@ public class SpeedDialogFragment extends RoboDialogFragment {
         setupWindow();
 
         View view = inflater.inflate(R.layout.panel_speed_popup_dialog_fragment, container, false);
-        float selectedPlaybackSpeed = VideoPlaybackSpeed.NORMAL.getSpeedValue();
+        float selectedPlaybackSpeed = VideoPlaybackSpeed.SPEED_1_0X.getSpeedValue();
         if (getArguments() != null) {
-            selectedPlaybackSpeed = getArguments().getFloat(PLAYBACK_SPEED, VideoPlaybackSpeed.NORMAL.getSpeedValue());
+            selectedPlaybackSpeed = getArguments().getFloat(PLAYBACK_SPEED, VideoPlaybackSpeed.SPEED_1_0X.getSpeedValue());
         }
         SpeedAdapter adapter = new SpeedAdapter(getContext(), environment, selectedPlaybackSpeed) {
             @Override


### PR DESCRIPTION
### Description

[LEARNER-7700](https://openedx.atlassian.net/browse/LEARNER-7700)

- Add more options in the video player for playback speed controls.

**How to test this PR**

- Login into the app.
- Go inside any course.
- Open the video tab and start any video.
- Tap on the setting button on video player.
- Tap on video speed, you should have options, 0.25x, 0.5x, 0.75x, 1.0x, 1.25x, 1.5x, 1.75x, 2.0x.

**Screenshot:**

<img src="https://user-images.githubusercontent.com/43750646/81270399-1f087a00-9064-11ea-8b38-145215983633.png" height="1024"/>