### PR TITLE
Configure EULA, TOS & Privacy Policy independently

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
@@ -60,6 +60,7 @@ public class Config {
     private static final String WHITE_LIST_OF_DOMAINS = "WHITE_LIST_OF_DOMAINS";
     private static final String API_URL_VERSION = "API_URL_VERSION";
     private static final String YOUTUBE_PLAYER = "YOUTUBE_PLAYER";
+    private static final String AGREEMENT_URLS = "AGREEMENT_URLS";
 
     // Features
     private static final String USER_PROFILES_ENABLED = "USER_PROFILES_ENABLED";
@@ -517,6 +518,33 @@ public class Config {
         }
     }
 
+    public static class AgreementUrlsConfig {
+        @SerializedName("EULA_URL")
+        private String eulaUrl;
+
+        @SerializedName("TOS_URL")
+        private String tosUrl;
+
+        @SerializedName("PRIVACY_POLICY_URL")
+        private String privacyPolicyUrl;
+
+        public String getEulaUrl() {
+            return eulaUrl;
+        }
+
+        public String getTosUrl() {
+            return tosUrl;
+        }
+
+        public String getPrivacyPolicyUrl() {
+            return privacyPolicyUrl;
+        }
+
+        public boolean isAtleastOneAgreementUrlAvailable() {
+            return !TextUtils.isEmpty(eulaUrl) || !TextUtils.isEmpty(tosUrl) || !TextUtils.isEmpty(privacyPolicyUrl);
+        }
+    }
+
     public static class YoutubePlayerConfig {
         @SerializedName("ENABLED")
         private boolean enabled;
@@ -785,6 +813,16 @@ public class Config {
     }
 
     @NonNull
+    public YoutubePlayerConfig getYoutubePlayerConfig() {
+        return getObjectOrNewInstance(YOUTUBE_PLAYER, YoutubePlayerConfig.class);
+    }
+
+    @NonNull
+    public AgreementUrlsConfig getAgreementUrlsConfig() {
+        return getObjectOrNewInstance(AGREEMENT_URLS, AgreementUrlsConfig.class);
+    }
+
+    @NonNull
     private <T> T getObjectOrNewInstance(@NonNull String key, @NonNull Class<T> cls) {
         JsonElement element = getObject(key);
         if (element != null) {
@@ -799,10 +837,5 @@ public class Config {
                 throw new RuntimeException(e);
             }
         }
-    }
-
-    @NonNull
-    public YoutubePlayerConfig getYoutubePlayerConfig() {
-        return getObjectOrNewInstance(YOUTUBE_PLAYER, YoutubePlayerConfig.class);
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/TextUtils.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/TextUtils.java
@@ -1,14 +1,15 @@
 package org.edx.mobile.util;
 
 import android.content.res.Resources;
-import androidx.annotation.NonNull;
-import androidx.annotation.StringRes;
 import android.text.Html;
 import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.SpannedString;
 import android.text.style.URLSpan;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 
 import org.edx.mobile.R;
 
@@ -62,38 +63,55 @@ public class TextUtils {
      * Generates the license text for displaying in app that includes clickable links to license
      * documents shipped with app.
      *
+     * @param config        Configurations object to use for obtaining agreement URLs in config.
      * @param resources     Resources object to use for obtaining strings from strings.xml.
      * @param licenseTextId Resource ID of the license text.
      * @return License text having clickable links to license documents.
      */
-    public static CharSequence generateLicenseText(@NonNull Resources resources,
+    public static CharSequence generateLicenseText(@NonNull Config config,
+                                                   @NonNull Resources resources,
                                                    @StringRes int licenseTextId) {
         final String platformName = resources.getString(R.string.platform_name);
-        final CharSequence licenseAgreement = ResourceUtil.getFormattedString(resources, R.string.licensing_agreement, "platform_name", platformName);
-        final CharSequence terms = ResourceUtil.getFormattedString(resources, R.string.tos_and_honor_code, "platform_name", platformName);
+        final CharSequence eula = ResourceUtil.getFormattedString(resources, R.string.licensing_agreement, "platform_name", platformName);
+        final CharSequence tos = ResourceUtil.getFormattedString(resources, R.string.tos_and_honor_code, "platform_name", platformName);
         final CharSequence privacyPolicy = resources.getString(R.string.privacy_policy);
 
-        final SpannableString agreementSpan = new SpannableString(licenseAgreement);
-        agreementSpan.setSpan(new URLSpan(TextUtils.createAppUri(
-                resources.getString(R.string.end_user_title),
-                resources.getString(R.string.eula_file_link))),
-                0, licenseAgreement.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-
-        final SpannableString termsSpan = new SpannableString(terms);
-        termsSpan.setSpan(new URLSpan(TextUtils.createAppUri(
-                resources.getString(R.string.terms_of_service_title),
-                resources.getString(R.string.terms_file_link))),
-                0, terms.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-
+        final SpannableString eulaSpan = new SpannableString(eula);
+        final SpannableString tosSpan = new SpannableString(tos);
         final SpannableString privacyPolicySpan = new SpannableString(privacyPolicy);
-        privacyPolicySpan.setSpan(new URLSpan(TextUtils.createAppUri(
-                resources.getString(R.string.privacy_policy_title),
-                resources.getString(R.string.privacy_file_link))),
-                0, privacyPolicy.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+        String eulaUri = resources.getString(R.string.eula_file_link);
+        String tosUri = resources.getString(R.string.terms_file_link);
+        String privacyPolicyUri = resources.getString(R.string.privacy_file_link);
+
+        final Config.AgreementUrlsConfig agreementUrlsConfig = config.getAgreementUrlsConfig();
+        if (agreementUrlsConfig.isAtleastOneAgreementUrlAvailable()) {
+            eulaUri = agreementUrlsConfig.getEulaUrl();
+            tosUri = agreementUrlsConfig.getTosUrl();
+            privacyPolicyUri = agreementUrlsConfig.getPrivacyPolicyUrl();
+        }
+
+        if (!android.text.TextUtils.isEmpty(eulaUri)) {
+            eulaSpan.setSpan(new URLSpan(TextUtils.createAppUri(
+                    resources.getString(R.string.end_user_title), eulaUri)),
+                    0, eula.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
+
+        if (!android.text.TextUtils.isEmpty(tosUri)) {
+            tosSpan.setSpan(new URLSpan(TextUtils.createAppUri(
+                    resources.getString(R.string.terms_of_service_title), tosUri)),
+                    0, tos.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
+
+        if (!android.text.TextUtils.isEmpty(privacyPolicyUri)) {
+            privacyPolicySpan.setSpan(new URLSpan(TextUtils.createAppUri(
+                    resources.getString(R.string.privacy_policy_title), privacyPolicyUri)),
+                    0, privacyPolicy.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
 
         final Map<String, CharSequence> keyValMap = new HashMap<>();
-        keyValMap.put("license", agreementSpan);
-        keyValMap.put("tos_and_honor_code", termsSpan);
+        keyValMap.put("license", eulaSpan);
+        keyValMap.put("tos_and_honor_code", tosSpan);
         keyValMap.put("platform_name", platformName);
         keyValMap.put("privacy_policy", privacyPolicySpan);
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/LoginActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/LoginActivity.java
@@ -147,7 +147,8 @@ public class LoginActivity
         });
 
         activityLoginBinding.endUserAgreementTv.setMovementMethod(LinkMovementMethod.getInstance());
-        activityLoginBinding.endUserAgreementTv.setText(TextUtils.generateLicenseText(getResources(), R.string.by_signing_in));
+        activityLoginBinding.endUserAgreementTv.setText(TextUtils.generateLicenseText(
+                environment.getConfig(), getResources(), R.string.by_signing_in));
 
         environment.getAnalyticsRegistry().trackScreenView(Analytics.Screens.LOGIN);
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -150,7 +150,8 @@ public class RegisterActivity extends BaseFragmentActivity
 
         TextView agreementMessageView = (TextView) findViewById(R.id.by_creating_account_tv);
         agreementMessageView.setMovementMethod(LinkMovementMethod.getInstance());
-        agreementMessageView.setText(org.edx.mobile.util.TextUtils.generateLicenseText(getResources(), R.string.by_creating_account));
+        agreementMessageView.setText(org.edx.mobile.util.TextUtils.generateLicenseText(
+                environment.getConfig(), getResources(), R.string.by_creating_account));
 
         createAccountBtn = (ViewGroup) findViewById(R.id.createAccount_button_layout);
         createAccountBtn.setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
### Description

[LEARNER-7763](https://openedx.atlassian.net/browse/LEARNER-7763)

Links to these agreements can now be provided through configurations. When available, these URLs will always have precedence over the local files we already have in our project.

A catch here is that if we only provide one URL through configurations then only that agreement's text will be clickable and the others won't be clickable even if the local files are available in the project.

### Testing
- [x] `AGREEMENT_URLS` isn't available in the configs
- [x] `AGREEMENT_URLS` is available but is empty in the configs i.e. it has no objects in it
- [x] `AGREEMENT_URLS` is available and has URL for only 1 object e.g. `EULA_URL`
- [x] `AGREEMENT_URLS` is available and has URLs for all 3 objects i.e. `EULA_URL`, `TOS_URL` & `PRIVACY_POLICY_URL`
