### PR TITLE
Registration Form Validation

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/authentication/LoginService.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/authentication/LoginService.java
@@ -42,15 +42,13 @@ public interface LoginService {
         }
     }
 
-
     /**
-     * Depending on the query parameters for this endpoint, a different action will be triggered
-     * on the server side. In this case, we are using to validate the fields used for the registration.
-     * In case of validation errors in the response body.
+     * This endpoint used to validate the fields used for registration.
+     * In case of validation errors return error messages with associated fields.
      */
     @NonNull
     @FormUrlEncoded
-    @POST(ApiConstants.URL_VALIDATION_REGISTRATION)
+    @POST(ApiConstants.URL_VALIDATE_REGISTRATION_FIELDS)
     Call<JsonObject> validateRegistrationFields(@FieldMap Map<String, String> parameters);
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/authentication/LoginService.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/authentication/LoginService.java
@@ -2,6 +2,7 @@ package org.edx.mobile.authentication;
 
 import androidx.annotation.NonNull;
 
+import com.google.gson.JsonObject;
 import com.google.inject.Inject;
 
 import org.edx.mobile.http.constants.ApiConstants;
@@ -40,6 +41,17 @@ public interface LoginService {
             return retrofit.create(LoginService.class);
         }
     }
+
+
+    /**
+     * Depending on the query parameters for this endpoint, a different action will be triggered
+     * on the server side. In this case, we are using to validate the fields used for the registration.
+     * In case of validation errors in the response body.
+     */
+    @NonNull
+    @FormUrlEncoded
+    @POST(ApiConstants.URL_VALIDATION_REGISTRATION)
+    Call<JsonObject> validateRegistrationFields(@FieldMap Map<String, String> parameters);
 
     /**
      * If there are form validation errors, this call will fail with 400 or 409 error code.

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/constants/ApiConstants.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/constants/ApiConstants.java
@@ -32,7 +32,7 @@ public class ApiConstants {
 
     public static final String URL_REGISTRATION = "/user_api/{" + API_VERSION + "}/account/registration/";
 
-    public static final String URL_VALIDATION_REGISTRATION = "/api/user/v1/validation/registration";
+    public static final String URL_VALIDATE_REGISTRATION_FIELDS = "/api/user/v1/validation/registration";
 
     public static final String URL_ENROLLMENT = "/api/enrollment/v1/enrollment";
 
@@ -41,6 +41,8 @@ public class ApiConstants {
     public static final String TOKEN_TYPE_ACCESS = "access_token";
 
     public static final String TOKEN_TYPE_REFRESH = "refresh_token";
+
+    public static final String VALIDATION_DECISIONS = "validation_decisions";
 
     @StringDef({TOKEN_TYPE_ACCESS, TOKEN_TYPE_REFRESH})
     @Retention(RetentionPolicy.SOURCE)

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/constants/ApiConstants.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/constants/ApiConstants.java
@@ -32,6 +32,8 @@ public class ApiConstants {
 
     public static final String URL_REGISTRATION = "/user_api/{" + API_VERSION + "}/account/registration/";
 
+    public static final String URL_VALIDATION_REGISTRATION = "/api/user/v1/validation/registration";
+
     public static final String URL_ENROLLMENT = "/api/enrollment/v1/enrollment";
 
     public static final String URL_COURSE_OUTLINE = "/api/courses/v1/blocks/?course_id={courseId}&username={username}&depth=all&requested_fields={requested_fields}&student_view_data={student_view_data}&block_counts={block_counts}&nav_depth=3";

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -36,6 +36,7 @@ import org.edx.mobile.base.BaseFragmentActivity;
 import org.edx.mobile.http.HttpStatus;
 import org.edx.mobile.http.HttpStatusException;
 import org.edx.mobile.http.callback.ErrorHandlingCallback;
+import org.edx.mobile.http.constants.ApiConstants;
 import org.edx.mobile.model.api.FormFieldMessageBody;
 import org.edx.mobile.model.api.ProfileModel;
 import org.edx.mobile.model.api.RegisterResponseFieldError;
@@ -190,7 +191,7 @@ public class RegisterActivity extends BaseFragmentActivity
     }
 
     private void validateRegistrationFields() {
-        Bundle parameters = getRegistrationParameter();
+        Bundle parameters = getRegistrationParameters();
         if (parameters == null) {
             return;
         }
@@ -203,9 +204,10 @@ public class RegisterActivity extends BaseFragmentActivity
         validateRegistrationFields.enqueue(new ErrorHandlingCallback<JsonObject>(this) {
             @Override
             protected void onResponse(@NonNull JsonObject responseBody) {
+                // Callback method for a successful HTTP response.
                 final Type stringMapType = new TypeToken<HashMap<String, String>>() {
                 }.getType();
-                final HashMap<String, String> messageBody = new Gson().fromJson(responseBody.get("validation_decisions"), stringMapType);
+                final HashMap<String, String> messageBody = new Gson().fromJson(responseBody.get(ApiConstants.VALIDATION_DECISIONS), stringMapType);
                 if (hasValidationError(messageBody)) {
                     hideProgress();
                 } else {
@@ -391,9 +393,8 @@ public class RegisterActivity extends BaseFragmentActivity
         task.execute();
     }
 
-    private Bundle getRegistrationParameter() {
+    private Bundle getRegistrationParameters() {
         boolean hasError = false;
-        // prepare query (POST body)
         Bundle parameters = new Bundle();
         String email = null, confirm_email = null;
         for (IRegistrationFieldView v : mFieldViews) {


### PR DESCRIPTION
### Description

[LEARNER-7835](https://openedx.atlassian.net/browse/LEARNER-7835)

- Implement validation API for a registration form.
- Validate the registration form using the API: POST `/api/user/v1/validation/registration`.
- The validation API should be hit before the actual registration API.
- The validation API should be initiated upon the click on the Register button.
- If the validation API doesn't return any error in its response, the app should automatically call the registration API and register the learner.
- If the validation API returns an error in its response, the app should not call the registration API and show the error inline with each field that had invalid data.

**How to test this PR**

- [x]  Use some previously used username in the Registration Form, it should give invalid error after hitting validation API.
- [x]  Use some previously used email in the Registration Form, it should give invalid error after hitting validation API.
- [x]  Use an invalid password, i.e without numbers, it should give invalid error after hitting validation API.
- [x]  If validation API returns no invalid form field, then the usual registration flow should work, i.e. Register user and navigation to Home Screen.