### PR TITLE
Show fields error after at least once focus has lost

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/registration/view/RegistrationEditTextView.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/registration/view/RegistrationEditTextView.java
@@ -29,6 +29,7 @@ public class RegistrationEditTextView implements IRegistrationFieldView {
     protected AppCompatEditText mEditText;
     protected TextView mInstructionsTextView;
     protected TextView mErrorTextView;
+    private boolean hasFocusLost = false;
 
     public RegistrationEditTextView(RegistrationFormField field, View view) {
         // create and configure view and save it to an instance variable
@@ -92,11 +93,21 @@ public class RegistrationEditTextView implements IRegistrationFieldView {
                     isChangedByUser = true;
                     return;
                 }
-                isValidInput();
+                // Don't show the error until view has lost the focus at least once
+                if (hasFocusLost) {
+                    isValidInput();
+                }
             }
 
             @Override
             public void afterTextChanged(Editable s) {
+            }
+        });
+
+        mEditText.setOnFocusChangeListener((v, hasFocus) -> {
+            if (!hasFocus) {
+                isValidInput();
+                hasFocusLost = true;
             }
         });
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/registration/view/RegistrationSelectView.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/registration/view/RegistrationSelectView.java
@@ -28,6 +28,7 @@ public class RegistrationSelectView implements IRegistrationFieldView {
     protected TextInputLayout mTextInputLayout;
     private TextView mInstructionsView;
     private TextView mErrorView;
+    private boolean hasFocusLost = false;
 
     public RegistrationSelectView(RegistrationFormField field, View view) {
         // create and configure view and save it to an instance variable
@@ -73,10 +74,13 @@ public class RegistrationSelectView implements IRegistrationFieldView {
 
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
-                if(!mInputView.hasValue(s.toString().trim())){
+                if (!mInputView.hasValue(s.toString().trim())) {
                     mInputView.setSelectedItem(null);
                 }
-                isValidInput();
+                // Don't show the error until view has lost the focus at least once
+                if (hasFocusLost) {
+                    isValidInput();
+                }
             }
 
             @Override
@@ -87,8 +91,11 @@ public class RegistrationSelectView implements IRegistrationFieldView {
         mInputView.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-                if(hasFocus){
+                if (hasFocus) {
                     mInputView.showDropDown();
+                } else {
+                    hasFocusLost = true;
+                    isValidInput();
                 }
             }
         });


### PR DESCRIPTION
## Description

[LEARNER-7780](https://openedx.atlassian.net/browse/LEARNER-7780)

- Hide error on first-time input by the user on registration fields
- show error once the field has lost the focus
