### PR TITLE
Fix crash on tapping expired courses

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/TabsBaseFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/TabsBaseFragment.java
@@ -59,7 +59,9 @@ public abstract class TabsBaseFragment extends BaseFragment {
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         // Enforce to intercept single scrolling direction
-        UiUtil.enforceSingleScrollDirection(binding.viewPager2);
+        if (binding != null) {
+            UiUtil.enforceSingleScrollDirection(binding.viewPager2);
+        }
         handleTabSelection(getArguments());
     }
 


### PR DESCRIPTION
### Description

[LEARNER-7843](https://openedx.atlassian.net/browse/LEARNER-7843)

- Fix crash on tapping expired courses.
- In the case of full-screen error, the recycler view layout binding will be null so just apply the null check before taking action on recycler view.