### PR TITLE
Fix issue `Reload banner doesn't disappear after switch on the internet`

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/notifications/SnackbarErrorNotification.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/notifications/SnackbarErrorNotification.java
@@ -74,7 +74,11 @@ public class SnackbarErrorNotification extends ErrorNotification {
                 @Override
                 public void onDismissed(Snackbar transientBottomBar, int event) {
                     super.onDismissed(transientBottomBar, event);
-                    snackbar = null;
+                    // Check if visible snackbar instance & dismissed snackbar instance are same, cuz
+                    // receiving `onDismissed` callback for other instances too.
+                    if (snackbar == transientBottomBar) {
+                        snackbar = null;
+                    }
                 }
             });
             // By applying the listener to the button like we have done below, the Snackbar


### PR DESCRIPTION
### Description
[LEARNER-7842](https://openedx.atlassian.net/browse/LEARNER-7842)

- Fix issue **Reload banner doesn't disappear after switch on the internet**
- The callback `onDismissed` also received for other instances too, just check visible `snackbar` instance & dismissed `snackbar` instances are the same before releasing the currently visible `snackbar` instance.
- The issue only reproducible on lower-end devices e.g KitKat, Lolipop.