### PR TITLE
Crash fix of null activity on TabsBaseFragment.java

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/TabsBaseFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/TabsBaseFragment.java
@@ -163,7 +163,9 @@ public abstract class TabsBaseFragment extends BaseFragment {
             public void onPageSelected(int position) {
                 super.onPageSelected(position);
                 final FragmentItemModel item = fragmentItems.get(position);
-                getActivity().setTitle(item.getTitle());
+                if (getActivity() != null) {
+                    getActivity().setTitle(item.getTitle());
+                }
                 if (item.getListener() != null) {
                     item.getListener().onFragmentSelected();
                 }


### PR DESCRIPTION
### Description

[LEARNER-7918](https://openedx.atlassian.net/browse/LEARNER-7918)

- Add activity null check before setting toolbar title in TabsBaseFragment.java