### PR TITLE
Fix Crash while moving to splash screen after force logout

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/MyCoursesListFragment.kt
@@ -144,7 +144,7 @@ class MyCoursesListFragment : OfflineSupportBaseFragment(), RefreshListener {
                     loadData(showProgress = true, fromCache = false)
                 } else {
                     when {
-                        response.code() == HttpStatus.UNAUTHORIZED -> {
+                        response.code() == HttpStatus.UNAUTHORIZED && context != null -> {
                             environment.router?.forceLogout(context,
                                     environment.analyticsRegistry,
                                     environment.notificationDelegate)


### PR DESCRIPTION
### Description

[LEARNER-7920](https://openedx.atlassian.net/browse/LEARNER-7920)

- Fix Crash while moving to splash screen after force logout
- Unable to reproduce the crash, as per logs context is null used to start the new activity so add context null check.