### PR TITLE
Add Course Reset Dates banner on CourseOutlineFragment.java

### DIFF
--- a/OpenEdXMobile/res/drawable/blue_border_white_roundedbg.xml
+++ b/OpenEdXMobile/res/drawable/blue_border_white_roundedbg.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <solid android:color="@android:color/white" />
+    <stroke
+        android:width="@dimen/edx_divider_length"
+        android:color="@color/edx_brand_primary_base" />
+    <corners android:radius="@dimen/edx_box_radius" />
+</shape>

--- a/OpenEdXMobile/res/layout/layout_course_dates_banner.xml
+++ b/OpenEdXMobile/res/layout/layout_course_dates_banner.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <LinearLayout
+        android:id="@+id/container_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/edx_brand_primary_back"
+        android:orientation="vertical"
+        android:padding="@dimen/container_padding">
+
+        <TextView
+            android:id="@+id/banner_info"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/grey_text_mycourse"
+            android:textSize="@dimen/edx_small"
+            tools:text="@string/course_dates_banner_reset_date" />
+
+        <Button
+            android:id="@+id/btn_shift_dates"
+            fontPath="fonts/OpenSans-Semibold.ttf"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/widget_margin"
+            android:background="@drawable/blue_border_white_roundedbg"
+            android:padding="@dimen/edx_half_margin"
+            android:textColor="@android:color/black"
+            android:textSize="@dimen/edx_small"
+            android:visibility="gone"
+            tools:text="@string/course_dates_banner_reset_date_button"
+            tools:visibility="visible" />
+    </LinearLayout>
+</layout>

--- a/OpenEdXMobile/res/values/dimens.xml
+++ b/OpenEdXMobile/res/values/dimens.xml
@@ -243,6 +243,7 @@
     <dimen name="transcript_row_height">50dp</dimen>
     <dimen name="whats_new_image_horizontal_margin">25dp</dimen>
     <dimen name="shadow_view_height">4dp</dimen>
+    <dimen name="container_padding">12dp</dimen>
 
     <!-- Social platforms -->
     <dimen name="social_btn_radius">3dp</dimen>

--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -234,6 +234,32 @@
     <string name="label_ending">Ending {date}</string>
     <!-- Error Message when course dates are not available -->
     <string name="course_dates_unavailable_message">Course dates are not currently available.</string>
+    <!-- Label Course Dates Reset Popup Title -->
+    <string name="course_dates_reset_title">Course Dates</string>
+    <!-- Message Course Dates Reset Successful -->
+    <string name="course_dates_reset_successful">Your dates have been successfully shifted.</string>
+    <!-- Message Course Dates Reset Unsuccessful -->
+    <string name="course_dates_reset_unsuccessful">Your dates could not be shifted. Please try again.</string>
+    <!-- Message Course Dates Info Banner -->
+    <string name="course_dates_info_banner"><b>We\'ve built a suggested schedule to help you stay on track.</b>
+        But don\'t worry—it\'s flexible so you can learn at your own pace. If you happen to fall behind on our suggested dates,
+        you\'ll be able to adjust them to keep yourself on track.</string>
+    <!-- Message Course Dates Banner Upgrade to Complete Graded -->
+    <string name="course_dates_banner_upgrade_to_graded"><b>You are auditing this course,</b>
+        which means that you are unable to participate in graded assignments. To complete graded assignments as part of this course, you can upgrade today.</string>
+    <!-- Label Course Dates Banner Upgrade to Complete Graded Button -->
+    <string name="course_dates_banner_upgrade_to_graded_button">Upgrade now</string>
+    <!-- Message Course Dates Banner Upgrade to Reset -->
+    <string name="course_dates_banner_upgrade_to_reset"><b>You are auditing this course,</b>
+        which means that you are unable to participate in graded assignments. It looks like you missed some important deadlines based on our suggested schedule. To complete graded assignments as part of this course and shift the past due assignments into the future, you can upgrade today.</string>
+    <!-- Label Course Dates Banner Upgrade to Reset Button -->
+    <string name="course_dates_banner_upgrade_to_reset_button">Upgrade to shift due dates</string>
+    <!-- Message Course Dates Banner Reset Date -->
+    <string name="course_dates_banner_reset_date"><b>It looks like you missed some important deadlines based on our suggested schedule.</b>
+        To keep yourself on track, you can update this schedule and shift the past due assignments into the future. Don’t worry—you won’t lose any of the progress you’ve made when you shift your due dates.</string>
+    <!-- Label Course Dates Banner Reset Date Button -->
+    <string name="course_dates_banner_reset_date_button">Shift due dates</string>
+
 
     <!-- Label for date when course is expiring in a specific time frame like in 2 days -->
     <string name="label_expires">Course access expires {date}</string>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseAPI.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseAPI.java
@@ -29,12 +29,14 @@ import org.edx.mobile.model.course.BlockModel;
 import org.edx.mobile.model.course.BlockType;
 import org.edx.mobile.model.course.CourseComponent;
 import org.edx.mobile.model.course.CourseDates;
+import org.edx.mobile.model.course.CourseBannerInfoModel;
 import org.edx.mobile.model.course.CourseStructureV1Model;
 import org.edx.mobile.model.course.DiscussionBlockModel;
 import org.edx.mobile.model.course.DiscussionData;
 import org.edx.mobile.model.course.HasDownloadEntry;
 import org.edx.mobile.model.course.HtmlBlockModel;
 import org.edx.mobile.model.course.IBlock;
+import org.edx.mobile.model.course.ResetCourseDates;
 import org.edx.mobile.model.course.VideoBlockModel;
 import org.edx.mobile.model.course.VideoData;
 import org.edx.mobile.model.course.VideoInfo;
@@ -105,6 +107,22 @@ public class CourseAPI {
     @NonNull
     public Call<CourseDates> getCourseDates(@NonNull String courseId) {
         return courseService.getCourseDates(courseId);
+    }
+
+    /**
+     * @return Course dates banner info against the given course Id.
+     */
+    @NonNull
+    public Call<CourseBannerInfoModel> getCourseBannerInfo(@NonNull String courseId) {
+        return courseService.getCourseBannerInfo(courseId);
+    }
+
+    /**
+     * @return Reset course dates against the given course Id.
+     */
+    @NonNull
+    public Call<ResetCourseDates> resetCourseDates(@NonNull HashMap<String, String> courseBody) {
+        return courseService.resetCourseDates(courseBody);
     }
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseService.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseService.java
@@ -13,8 +13,10 @@ import org.edx.mobile.model.Page;
 import org.edx.mobile.model.api.CourseUpgradeResponse;
 import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import org.edx.mobile.model.api.SyncLastAccessedSubsectionResponse;
+import org.edx.mobile.model.course.CourseBannerInfoModel;
 import org.edx.mobile.model.course.CourseDates;
 import org.edx.mobile.model.course.CourseStructureV1Model;
+import org.edx.mobile.model.course.ResetCourseDates;
 import org.edx.mobile.view.common.TaskProgressCallback;
 import org.json.JSONObject;
 
@@ -135,8 +137,14 @@ public interface CourseService {
     @POST("/api/completion/v1/completion-batch")
     Call<JSONObject> markBlocksCompletion(@Body BlocksCompletionBody completionBody);
 
-    @GET("api/course_home/v1/dates/{course_key}")
+    @GET("/api/course_home/v1/dates/{course_key}")
     Call<CourseDates> getCourseDates(@Path("course_key") String courseId);
+
+    @GET("/api/course_experience/v1/course_deadlines_info/{course_key}")
+    Call<CourseBannerInfoModel> getCourseBannerInfo(@Path("course_key") String courseId);
+
+    @POST("/api/course_experience/v1/reset_course_deadlines")
+    Call<ResetCourseDates> resetCourseDates(@Body HashMap<String, String> courseBody);
 
     final class BlocksCompletionBody {
         @NonNull String username;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/constants/ApiConstants.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/constants/ApiConstants.java
@@ -44,6 +44,8 @@ public class ApiConstants {
 
     public static final String VALIDATION_DECISIONS = "validation_decisions";
 
+    public static final String COURSE_KEY = "course_key";
+
     @StringDef({TOKEN_TYPE_ACCESS, TOKEN_TYPE_REFRESH})
     @Retention(RetentionPolicy.SOURCE)
     public @interface TokenType {}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/CourseBannerInfoModel.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/CourseBannerInfoModel.kt
@@ -1,0 +1,8 @@
+package org.edx.mobile.model.course
+
+import com.google.gson.annotations.SerializedName
+
+data class CourseBannerInfoModel(
+        @SerializedName("dates_banner_info") val datesBannerInfo: CourseDatesBannerInfo,
+        @SerializedName("has_ended") val hasEnded: Boolean = false
+)

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/CourseDatesBannerInfo.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/CourseDatesBannerInfo.kt
@@ -7,4 +7,24 @@ data class CourseDatesBannerInfo(
         @SerializedName("missed_gated_content") val missedGatedContent: Boolean = false,
         @SerializedName("verified_upgrade_link") val verifiedUpgradeLink: String = "",
         @SerializedName("content_type_gating_enabled") val contentTypeGatingEnabled: Boolean = false
-)
+) {
+    fun getCourseBannerType(): CourseBannerType = when {
+        upgradeToGraded() -> CourseBannerType.UPGRADE_TO_GRADED
+        upgradeToReset() -> CourseBannerType.UPGRADE_TO_RESET
+        resetDates() -> CourseBannerType.RESET_DATES
+        showBannerInfo() -> CourseBannerType.INFO_BANNER
+        else -> CourseBannerType.BLANK
+    }
+
+    private fun showBannerInfo(): Boolean = missedDeadlines.not()
+
+    private fun upgradeToGraded(): Boolean = contentTypeGatingEnabled && missedDeadlines.not()
+
+    private fun upgradeToReset(): Boolean = upgradeToGraded().not() && missedDeadlines && missedGatedContent
+
+    private fun resetDates(): Boolean = upgradeToGraded().not() && missedDeadlines && missedGatedContent.not()
+}
+
+enum class CourseBannerType {
+    BLANK, INFO_BANNER, UPGRADE_TO_GRADED, UPGRADE_TO_RESET, RESET_DATES;
+}

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/ResetCourseDates.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/ResetCourseDates.kt
@@ -1,0 +1,11 @@
+package org.edx.mobile.model.course
+
+import com.google.gson.annotations.SerializedName
+
+data class ResetCourseDates(
+        @SerializedName("message") val message: String = "",
+        @SerializedName("body") val body: String = "",
+        @SerializedName("header") val header: String = "",
+        @SerializedName("link") val link: String = "",
+        @SerializedName("link_text") val linkText: String = ""
+)


### PR DESCRIPTION
### Description

[LEARNER-7824](https://openedx.atlassian.net/browse/LEARNER-7824)

- Add Course Dates banner on Course Unit Fragment
- Add Option to shift dates for verified learner
- Show dialog box on success/unsuccess of shift dates API call
- Upgrade button disable as per [discussion](https://openedx.atlassian.net/browse/LEARNER-7814?focusedCommentId=471215) on [LEARNER-7814](https://openedx.atlassian.net/browse/LEARNER-7814)
- Banner strings are defined in [MFE](https://github.com/edx/frontend-app-learning/blob/a6edc9132f648890eb5693e644998174894fbe41/src/course-home/dates-banner/messages.js#L3-L64)

<img src="https://user-images.githubusercontent.com/30689349/94918092-4ce6d300-04cb-11eb-9115-968654120b43.jpg" height="560"/>
<img src="https://user-images.githubusercontent.com/30689349/94918107-52441d80-04cb-11eb-9d4a-6bf3e2790601.jpg" height="560"/>
<img src="https://user-images.githubusercontent.com/30689349/94918109-53754a80-04cb-11eb-88a8-0c751e8d2170.jpg" height="560"/>
<img src="https://user-images.githubusercontent.com/30689349/94918112-540de100-04cb-11eb-944c-5adda3b803c7.jpg" height="560"/>
