### PR TITLE
Disabled user account handling

### DIFF
--- a/OpenEdXMobile/res/values/errors.xml
+++ b/OpenEdXMobile/res/values/errors.xml
@@ -115,4 +115,6 @@
     <!-- Error message shown when a permission is not granted -->
     <string name="permission_not_granted">Permission not granted</string>
 
+    <!-- This error message will be shown if user tried to login with third party (facebook/google) and server returns 403 status code, Disabled user-->
+    <string name="auth_provider_disabled_user_error">Your account is disabled. Please contact customer support for assistance.</string>
 </resources>

--- a/OpenEdXMobile/res/values/labels.xml
+++ b/OpenEdXMobile/res/values/labels.xml
@@ -42,4 +42,6 @@
     <string name="label_undo">Undo</string>
     <!-- Label denoting an error -->
     <string name="label_error">Error</string>
+    <!-- Customer support text, using as button title for disabled user-->
+    <string name="CUSTOMER_SUPPORT">Customer Support</string>
 </resources>

--- a/OpenEdXMobile/res/values/labels.xml
+++ b/OpenEdXMobile/res/values/labels.xml
@@ -43,5 +43,5 @@
     <!-- Label denoting an error -->
     <string name="label_error">Error</string>
     <!-- Customer support text, using as button title for disabled user-->
-    <string name="CUSTOMER_SUPPORT">Customer Support</string>
+    <string name="label_customer_support">Customer Support</string>
 </resources>

--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -659,6 +659,8 @@
 
     <!--  Email subject line when user attempts to submit feedback about the app -->
     <string name="email_subject">Customer Feedback</string>
+    <!--  Email subject line when user account is disabled to submit feedback about the app -->
+    <string name="email_subject_account_disabled">Account Disabled</string>
     <!--  Email subject line when a user attempts to submit a review using the app review workflow -->
     <string name="review_email_subject">Customer Review</string>
     <!--  Submit Feedback app version text -->

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
@@ -279,6 +279,9 @@ public abstract class BaseFragmentActivity extends BaseAppActivity
      */
     @SuppressWarnings("unused")
     public void onEvent(LogoutEvent event) {
+        environment.getRouter().forceLogout(this,
+                environment.getAnalyticsRegistry(),
+                environment.getNotificationDelegate());
         finish();
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
@@ -282,7 +282,6 @@ public abstract class BaseFragmentActivity extends BaseAppActivity
         environment.getRouter().forceLogout(this,
                 environment.getAnalyticsRegistry(),
                 environment.getNotificationDelegate());
-        finish();
     }
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/BaseFragmentActivity.java
@@ -282,6 +282,7 @@ public abstract class BaseFragmentActivity extends BaseAppActivity
         environment.getRouter().forceLogout(this,
                 environment.getAnalyticsRegistry(),
                 environment.getNotificationDelegate());
+        finish();
     }
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/authenticator/OauthRefreshTokenAuthenticator.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/authenticator/OauthRefreshTokenAuthenticator.java
@@ -9,6 +9,7 @@ import com.google.inject.Inject;
 import org.edx.mobile.authentication.LoginService;
 
 import org.edx.mobile.authentication.AuthResponse;
+import org.edx.mobile.event.LogoutEvent;
 import org.edx.mobile.http.provider.RetrofitProvider;
 import org.edx.mobile.http.HttpStatusException;
 import org.edx.mobile.logger.Logger;
@@ -19,6 +20,7 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 
+import de.greenrobot.event.EventBus;
 import okhttp3.Authenticator;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -40,6 +42,7 @@ public class OauthRefreshTokenAuthenticator implements Authenticator {
     private final static String TOKEN_EXPIRED_ERROR_MESSAGE = "token_expired";
     private final static String TOKEN_NONEXISTENT_ERROR_MESSAGE = "token_nonexistent";
     private final static String TOKEN_INVALID_GRANT_ERROR_MESSAGE = "invalid_grant";
+    private final static String DISABLED_USER_ERROR_MESSAGE = "user_is_disabled";
     private Context context;
 
     @Inject
@@ -88,6 +91,9 @@ public class OauthRefreshTokenAuthenticator implements Authenticator {
                                 .header("Authorization", currentAuth.token_type + " " + currentAuth.access_token)
                                 .build();
                     }
+                case DISABLED_USER_ERROR_MESSAGE:
+                    EventBus.getDefault().post(new LogoutEvent());
+                    break;
             }
         }
         return null;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/http/authenticator/OauthRefreshTokenAuthenticator.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/http/authenticator/OauthRefreshTokenAuthenticator.java
@@ -92,6 +92,8 @@ public class OauthRefreshTokenAuthenticator implements Authenticator {
                                 .build();
                     }
                 case DISABLED_USER_ERROR_MESSAGE:
+                    // If the user is logged-in & marked as disabled then on the next server response
+                    // app will force the user to logout and navigate it to the launcher screen.
                     EventBus.getDefault().post(new LogoutEvent());
                     break;
             }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/LoginActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/LoginActivity.java
@@ -1,7 +1,6 @@
 package org.edx.mobile.view;
 
 import android.app.Activity;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
@@ -370,10 +369,10 @@ public class LoginActivity
                 case HttpStatus.FORBIDDEN:
                     LoginActivity.this.showAlertDialog(getString(R.string.login_error),
                             getString(R.string.auth_provider_disabled_user_error),
-                            getString(R.string.CUSTOMER_SUPPORT),
+                            getString(R.string.label_customer_support),
                             (dialog, which) -> environment.getRouter()
                                     .showFeedbackScreen(LoginActivity.this,
-                                            getString(R.string.email_subject)), getString(android.R.string.cancel), null);
+                                            getString(R.string.email_subject_account_disabled)), getString(android.R.string.cancel), null);
                     break;
                 default:
                     showAlertDialog(getString(R.string.login_error), ErrorUtils.getErrorMessage(ex, LoginActivity.this));

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -653,9 +653,17 @@ public class RegisterActivity extends BaseFragmentActivity
         // handle if this is a LoginException
         tryToSetUIInteraction(true);
         logger.error(ex);
-        SocialFactory.SOCIAL_SOURCE_TYPE socialType = SocialFactory.SOCIAL_SOURCE_TYPE.fromString(backend);
-        updateUIOnSocialLoginToEdxFailure(socialType, accessToken);
-
+        if (ex instanceof HttpStatusException && ((HttpStatusException) ex).getStatusCode() == HttpStatus.FORBIDDEN) {
+            RegisterActivity.this.showAlertDialog(getString(R.string.login_error),
+                    getString(R.string.auth_provider_disabled_user_error),
+                    getString(R.string.CUSTOMER_SUPPORT),
+                    (dialog, which) -> environment.getRouter()
+                            .showFeedbackScreen(RegisterActivity.this,
+                                    getString(R.string.email_subject)), getString(android.R.string.cancel), null);
+        } else {
+            SocialFactory.SOCIAL_SOURCE_TYPE socialType = SocialFactory.SOCIAL_SOURCE_TYPE.fromString(backend);
+            updateUIOnSocialLoginToEdxFailure(socialType, accessToken);
+        }
     }
 
     //help functions for UI enable/disable states

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/RegisterActivity.java
@@ -656,10 +656,10 @@ public class RegisterActivity extends BaseFragmentActivity
         if (ex instanceof HttpStatusException && ((HttpStatusException) ex).getStatusCode() == HttpStatus.FORBIDDEN) {
             RegisterActivity.this.showAlertDialog(getString(R.string.login_error),
                     getString(R.string.auth_provider_disabled_user_error),
-                    getString(R.string.CUSTOMER_SUPPORT),
+                    getString(R.string.label_customer_support),
                     (dialog, which) -> environment.getRouter()
                             .showFeedbackScreen(RegisterActivity.this,
-                                    getString(R.string.email_subject)), getString(android.R.string.cancel), null);
+                                    getString(R.string.email_subject_account_disabled)), getString(android.R.string.cancel), null);
         } else {
             SocialFactory.SOCIAL_SOURCE_TYPE socialType = SocialFactory.SOCIAL_SOURCE_TYPE.fromString(backend);
             updateUIOnSocialLoginToEdxFailure(socialType, accessToken);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
@@ -351,8 +351,6 @@ public class Router {
     public void forceLogout(Context context, AnalyticsRegistry analyticsRegistry, NotificationDelegate delegate) {
         loginPrefs.clear();
 
-        EventBus.getDefault().post(new LogoutEvent());
-
         analyticsRegistry.trackUserLogout();
         analyticsRegistry.resetIdentifyUser();
 


### PR DESCRIPTION
### Description

[LEARNER-7913](https://openedx.atlassian.net/browse/LEARNER-7913)

- Log out the learner on receiving the error code `user_is_disabled`.
- Show a proper error when a disabled user tries to log in.

**Test the PR:**

- [x] If the Learner is signed-in and marked as disabled, the user should be sign-out on the server response.
- [x] Learner should not be able to sign-in with the social account if the user account is disabled and Show the proper error message with the option of contact to customer support.

**Screenshots:**

<img src="https://user-images.githubusercontent.com/43750646/96173806-d5d92200-0f41-11eb-99b1-bbf64bbd3081.png" height="560"/> ----- <img src="https://user-images.githubusercontent.com/43750646/96263190-2ac97680-0fdc-11eb-97f1-90342eb45e71.png" height="560"/>

**Config**
```
API_HOST_URL: 'https://mobileapitest.sandbox.edx.org'
OAUTH_CLIENT_ID: 'PBVYdCMfkbwhnxDL0vQiQ2cKndRkqolFqPYKfvfl'
```
Manage User account by the following link: https://mobileapitest.sandbox.edx.org/support/manage_user

**Note:** Back-end code is not deployed on the PROD/STAGE server till now.
