### PR TITLE
Bumps crashlytics sdk to v17.2.2

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -207,7 +207,7 @@ dependencies {
     }
 
     // Firebase Crashlytics SDK
-    implementation ('com.google.firebase:firebase-crashlytics:17.0.0'){
+    implementation ('com.google.firebase:firebase-crashlytics:17.2.2'){
         exclude group: 'javax.inject'
         transitive = true
     }

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
         classpath 'com.google.firebase:perf-plugin:1.2.1'  // Performance Monitoring plugin
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${KOTLIN_VERSION}"
         // Firebase Crashlytics Gradle plugin.
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.1.1'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.3.0'
     }
 }
 


### PR DESCRIPTION
### Description

- During the integration of firebase-crashlytics, currently used version i-e- `v17.0.0` gives error in the logs on start of app and doesn't show the crash data in the crashlytics console.
- After updating to latest version i-e- `v17.2.2` issue gets solved.
- Crashlytics console also enforce to use firebase android sdk `v17.1.1` or higher. Screen shot slice attached below.

<img width="557" alt="Screen Shot 2020-10-19 at 2 01 14 PM" src="https://user-images.githubusercontent.com/25842457/96425702-be39bc00-1215-11eb-9b86-783e159f1d70.png">

### Testing

#### Behaviour with sdk v17.0.0:
1. Change the package name of the android project
2. Create a new firebase project in the firebase console
3. Add a new Android app against the new package name from the firebase console project settings.
4. Add all the required firebase keys in the android configuration file.
5. Add a test code for the testing of firebase-crashlytics ask integration. [Ref](https://firebase.google.com/docs/crashlytics/test-implementation?authuser=1&platform=android)
6. On starting of the app you will get following firebase error logs:
`
 Failed to retrieve settings from https://firebase-settings.crashlytics.com/spi/v2/platforms/android/gmp/----/settings
`
7. Firebase console doesn't show the test crash data in crashlytics tab.

#### Behaviour with sdk v17.2.2:
Repeat steps from 1 to 5. Change package name again and create a new firebase project

6. On opening of app no error logs appears this time.
7. Firebase console shows the test crash data in crashlytics tab after some time.

### Firebase Docs:
- https://firebase.google.com/docs/crashlytics/get-started?authuser=1&platform=android

### Note:
- `firebase-crashlytics-gradle` also needs to be updated in correspondence with crashlytics sdk version.