### PR TITLE
Fix Firebase Analytics issue via Segment-Firebase SDK

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -197,7 +197,7 @@ dependencies {
     implementation ('com.github.bumptech.glide:okhttp3-integration:4.11.0')
 
     // Segment Library
-    implementation 'com.segment.analytics.android:analytics:4.2.6'
+    implementation 'com.segment.analytics.android:analytics:4.7.0'
     // Segment's Firebase integration
     implementation 'com.segment.analytics.android.integrations:firebase:1.2.0'
     // Segment's GA integration

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
@@ -3,6 +3,8 @@ package org.edx.mobile.module.analytics;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.segment.analytics.Properties;
+
 import org.edx.mobile.util.images.ShareUtils;
 
 import java.util.Map;
@@ -502,6 +504,9 @@ public interface Analytics {
         String AA_EXPERIMENT = "aa_experiment";
         // Video Play Medium
         String PLAY_MEDIUM = "play_medium";
+        // Used to access the analytics data in middle ware
+        String EVENT = "event";
+        String PROPERTIES = "properties";
     }
 
     interface Values {
@@ -746,6 +751,35 @@ public interface Analytics {
                 default:
                     return "other";
             }
+        }
+
+        /**
+         * Method to remove the un-supported characters by the Firebase Analytics from the
+         * given string.
+         */
+        public static String removeUnSupportedCharacters(String value) {
+            return value.replaceAll(":", "_")
+                    .replaceAll("-", "_")
+                    .replaceAll("__", "_");
+        }
+
+        /**
+         * Method used to format the Analytics data as per firebase recommendations
+         * Ref: https://stackoverflow.com/questions/44421234/firebase-analytics-custom-list-of-values
+         */
+        public static Properties formatFirebaseAnalyticsData(Object object) {
+            Properties properties = (Properties) object;
+            Properties newProperties = new Properties();
+            for (Map.Entry<String, Object> entry : properties.entrySet()) {
+                String key = entry.getKey();
+                String entryValueString = String.valueOf(entry.getValue());
+                if (entryValueString.length() > 100) {
+                    // Truncate to first 100 characters
+                    entryValueString = entryValueString.trim().substring(0, 100);
+                }
+                newProperties.put(Analytics.Util.removeUnSupportedCharacters(key), entryValueString);
+            }
+            return newProperties;
         }
     }
 


### PR DESCRIPTION
## Description

[LEARNER-7979](https://openedx.atlassian.net/browse/LEARNER-7979)

- Remove unsupported special characters `:`, "-" from the event name properties and from the keys.
- The parameters having a value of more than 100 characters are trimmed to 100 to pass the 100 characters limit of Firebase Analytics.
- Use middleware to format the analytics data for that we have to update the segment lib that provide the middleware functionality.

Ref: https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/middleware/
Ref: https://stackoverflow.com/questions/44421234/firebase-analytics-custom-list-of-values