### PR TITLE
Get Credentials from jenkins and set to AWS device farm

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
             APK_PATH = 'OpenEdXMobile/build/outputs/apk/prod/debuggable'
             CONFIG_REPO_NAME = 'edx-mobile-config'
             TEST_PROJECT_REPO_NAME = 'edx-app-test'
-            AUT_NAME = 'edx-debuggable-2.23.2.apk'
+            AUT_NAME = 'edx-debuggable-2.24.3.apk'
             USER_NAME = credentials('AUTOMATION_USERNAME')
             USER_PASSWORD = credentials('AUTOMATION_PASSWORD')
     }
@@ -43,7 +43,7 @@ pipeline {
         }
         stage('compiling edx-app-android') {
             steps {
-                writeFile file: './OpenEdXMobile/edx.properties', text: 'edx.dir = \'../edx-mobile-config/stage/\''  
+                writeFile file: './OpenEdXMobile/edx.properties', text: 'edx.dir = \'../edx-mobile-config/prod/\''
                 sh 'bash ./resources/compile_android.sh'
             }
         }

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -1,2 +1,3 @@
 boto3==1.9.253 
 requests==2.22.0 
+PyYaml==5.1.2

--- a/resources/setup_virtual_env.sh
+++ b/resources/setup_virtual_env.sh
@@ -3,7 +3,7 @@
 cd .. 
 cd edx-app-android-build
 print_message(){
-echo -e "\n************************************************\n$1\n"
+echo -e "\n***********************************************\n$1\n"
 }
 
 virtual_env_dir="virtual_env"

--- a/resources/setup_virtual_env.sh
+++ b/resources/setup_virtual_env.sh
@@ -3,7 +3,7 @@
 cd .. 
 cd edx-app-android-build
 print_message(){
-echo -e "\n***********************************************\n$1\n"
+echo -e "\n************************************************\n$1\n"
 }
 
 virtual_env_dir="virtual_env"

--- a/resources/trigger_aws_test_run.py
+++ b/resources/trigger_aws_test_run.py
@@ -88,7 +88,8 @@ def aws_job():
 
 def update_credentials():
     """
-    Inject login credentials in "trigger_aws.yml" that used by the automation test cases
+    Inject login credentials in "trigger_aws.yml" that is used to set up the environment
+    for automation test cases execution
 
     """
 

--- a/resources/trigger_aws_test_run.py
+++ b/resources/trigger_aws_test_run.py
@@ -11,6 +11,7 @@ import time
 import boto3
 import requests
 import sys
+import yaml
 
 AUT_NAME = sys.argv[1]
 print('AUT name - {}'.format(AUT_NAME))
@@ -57,6 +58,8 @@ def aws_job():
         PACKAGE_NAME
     )
 
+    update_credentials()
+
     test_specs_arn = upload_file(
         project_arn,
         CUSTOM_SPECS_UPLOAD_TYPE,
@@ -82,6 +85,25 @@ def aws_job():
     get_test_run(test_run_arn)
 
     get_test_run_artifacts(RUN_NAME, test_run_arn)
+
+def update_credentials():
+    with open(CUSTOM_SPECS_NAME, 'r') as stream:
+        try:
+            loaded = yaml.load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+
+        # Need to wrap the USER_NAME/USER_PASSWORD with single qoute because it didnt recognize as variable/reserve
+        # words when found some special charaters
+        loaded['phases']['pre_test']['commands'].append("export USER_NAME=" + "\'" + os.environ['USER_NAME']  + "\'")
+        loaded['phases']['pre_test']['commands'].append("export USER_PASSWORD=" + "\'" + os.environ['USER_PASSWORD'] + "\'")
+
+        # Save it again
+        with open(CUSTOM_SPECS_NAME, 'w') as stream:
+            try:
+                yaml.dump(loaded, stream, default_flow_style=False)
+            except yaml.YAMLError as exc:
+                print(exc)
 
 
 def get_project_arn(project_name):

--- a/resources/trigger_aws_test_run.py
+++ b/resources/trigger_aws_test_run.py
@@ -87,6 +87,11 @@ def aws_job():
     get_test_run_artifacts(RUN_NAME, test_run_arn)
 
 def update_credentials():
+    """
+    Inject login credentials in "trigger_aws.yml" that used by the automation test cases
+
+    """
+
     with open(CUSTOM_SPECS_NAME, 'r') as stream:
         try:
             loaded = yaml.load(stream)


### PR DESCRIPTION
### Description

[LEARNER-7951](https://openedx.atlassian.net/browse/LEARNER-7951)

- Get credentials from Jenkins 
- Send these credentials as environment variables to the AWS device farm