### PR TITLE
Fix webview InflateException crash

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -122,7 +122,9 @@ dependencies {
     // with module updates.
     implementation project (':android-iconify-fontawesome')
 
-    implementation "androidx.appcompat:appcompat:$androidXVersion"
+    // Webview crash fix after update the library
+    // Inspiration: https://github.com/PierfrancescoSoffritti/android-youtube-player/issues/461#issuecomment-696772172
+    implementation "androidx.appcompat:appcompat:$androidXAppCompactVersion"
     implementation "androidx.recyclerview:recyclerview:$androidXVersion"
     implementation "androidx.cardview:cardview:$androidXVersion"
     // For the optional Nullable annotation

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/registration/view/RegistrationOptionAutoCompleteTextView.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/registration/view/RegistrationOptionAutoCompleteTextView.kt
@@ -11,9 +11,9 @@ class RegistrationOptionAutoCompleteTextView : AppCompatAutoCompleteTextView {
     private var adapter: ArrayAdapter<RegistrationOption>? = null
     var selectedItem: RegistrationOption? = null
 
-    constructor(context: Context?) : super(context)
-    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
-    constructor(context: Context?, attrs: AttributeSet?, defStyle: Int) : super(context, attrs, defStyle)
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyle: Int) : super(context, attrs, defStyle)
 
     fun hasValue(value: String?): Boolean {
         value?.let {

--- a/constants.gradle
+++ b/constants.gradle
@@ -11,4 +11,5 @@ project.ext {
 
     // App dependencies
     androidXVersion = '1.0.0'
+    androidXAppCompactVersion = '1.2.0'
 }


### PR DESCRIPTION
### Description

[LEARNER-7267](https://openedx.atlassian.net/browse/LEARNER-7267)

- Update 'appcompat' library to v1.2.0
- Inspiration: https://github.com/PierfrancescoSoffritti/android-youtube-player/issues/461#issuecomment-696772172

**How to reproduce:**
- Unable to reproduce the crash on the real device, but can be reproduced on Nexus-5(Android 5.0).
- Just open the app, and leads to a crash.
- Crash logs will be the same as Crashlytics.