### PR TITLE
Enable Unsupported xBlock to view on web specially SpecialExamInfo

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseService.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/course/CourseService.java
@@ -118,7 +118,7 @@ public interface CourseService {
 
     @GET("/api/courses/{api_version}/blocks/?" +
             "depth=all&" +
-            "requested_fields=graded,format,student_view_multi_device,due,completion&" +
+            "requested_fields=contains_gated_content,show_gated_sections,special_exam_info,graded,format,student_view_multi_device,due,completion&" +
             "student_view_data=video,discussion&" +
             "block_counts=video&" +
             "nav_depth=3")

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/BlockModel.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/BlockModel.java
@@ -63,6 +63,9 @@ public class BlockModel implements Serializable {
     @SerializedName("student_view_data")
     public BlockData data;
 
+    @SerializedName("special_exam_info")
+    public SpecialExamInfo specialExamInfo;
+
     public boolean isContainer() {
         return type != null ? type.isContainer() : (descendants != null && descendants.size() > 0);
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/CourseComponent.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/CourseComponent.java
@@ -41,6 +41,7 @@ public class CourseComponent implements IBlock, IPathNode {
     private String dueDate;
     private String authorizationDenialMessage;
     private AuthorizationDenialReason authorizationDenialReason;
+    private SpecialExamInfo specialExamInfo;
 
     public CourseComponent() {
     }
@@ -65,6 +66,7 @@ public class CourseComponent implements IBlock, IPathNode {
         this.dueDate = other.dueDate;
         this.authorizationDenialMessage = other.authorizationDenialMessage;
         this.authorizationDenialReason = other.authorizationDenialReason;
+        this.specialExamInfo = other.specialExamInfo;
     }
 
     /**
@@ -86,6 +88,7 @@ public class CourseComponent implements IBlock, IPathNode {
         this.authorizationDenialReason = blockModel.authorizationDenialReason;
         this.blockCount = blockModel.blockCounts == null ? new BlockCount() : blockModel.blockCounts;
         this.completion = blockModel.completion;
+        this.specialExamInfo = blockModel.specialExamInfo;
         this.parent = parent;
         if (parent == null) {
             this.root = this;
@@ -545,5 +548,9 @@ public class CourseComponent implements IBlock, IPathNode {
 
     public AuthorizationDenialReason getAuthorizationDenialReason() {
         return authorizationDenialReason;
+    }
+
+    public SpecialExamInfo getSpecialExamInfo() {
+        return specialExamInfo;
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/SpecialExamInfo.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/model/course/SpecialExamInfo.kt
@@ -1,0 +1,9 @@
+package org.edx.mobile.model.course
+
+import com.google.gson.annotations.SerializedName
+
+data class SpecialExamInfo(
+        @SerializedName("short_description") val shortDescription: String = "",
+        @SerializedName("suggested_icon") val suggestedIcon: String = "",
+        @SerializedName("in_completed_state") val inCompletedState: Boolean = false
+)

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
@@ -542,6 +542,15 @@ public interface Analytics {
      */
     void trackResumeCourseBannerTapped(@NonNull String courseId, @NonNull String blockId);
 
+    /**
+     * Track the View on Web tapped on Subsection screen in case of non supported xBlocks
+     *
+     * @param courseId          Id of the course
+     * @param subsectionId      Id of the non-supported subsection.
+     * @param isSpecialExamInfo Whether the subsection is special exam info or not
+     */
+    void trackSubsectionViewOnWebTapped(@NonNull String courseId, @NonNull String subsectionId, boolean isSpecialExamInfo);
+
     interface Keys {
         String NAME = "name";
         String USER_ID = "user_id";
@@ -623,6 +632,7 @@ public interface Analytics {
         String EVENT = "event";
         String PROPERTIES = "properties";
         String SERVICE = "service";
+        String SPECIAL_EXAM_INFO = "special_exam_info";
     }
 
     interface Values {
@@ -755,6 +765,7 @@ public interface Analytics {
         String COURSE_SECTION_CELEBRATION_SHARE_CLICKED = "edx.ui.lms.celebration.social_share.clicked";
         // Resume Course Banner Tapped
         String RESUME_COURSE_BANNER_TAPPED = "edx.bi.app.course.resume.tapped";
+        String SUBSECTION_VIEW_ON_WEB_TAPPED = "edx.bi.app.course.subsection.view_on_web.tapped";
     }
 
     interface Screens {
@@ -806,6 +817,8 @@ public interface Analytics {
         String PLS_COURSE_DASHBOARD = "course_dashboard";
         String PLS_COURSE_DATES = "dates_screen";
         String PLS_COURSE_UNIT_ASSIGNMENT = "assignments_screen";
+        String SPECIAL_EXAM_BLOCK = "Special Exam Blocked Screen";
+        String EMPTY_SUBSECTION_OUTLINE = "Empty Section Outline";
     }
 
     interface Events {
@@ -887,6 +900,7 @@ public interface Analytics {
         String CELEBRATION_SOCIAL_SHARE_CLICKED = "Celebration: Social Share Clicked";
         // Resume Course Banner
         String RESUME_COURSE_TAPPED = "Resume Course Tapped";
+        String SUBSECTION_VIEW_ON_WEB_TAPPED = "Subsection View On Web Tapped";
     }
 
     /**

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/AnalyticsRegistry.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/AnalyticsRegistry.java
@@ -527,4 +527,11 @@ public class AnalyticsRegistry implements Analytics {
             service.trackResumeCourseBannerTapped(courseId, blockId);
         }
     }
+
+    @Override
+    public void trackSubsectionViewOnWebTapped(@NonNull String courseId, @NonNull String subsectionId, boolean isSpecialExamInfo) {
+        for (Analytics service : services) {
+            service.trackSubsectionViewOnWebTapped(courseId, subsectionId, isSpecialExamInfo);
+        }
+    }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/FirebaseAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/FirebaseAnalytics.java
@@ -748,4 +748,13 @@ public class FirebaseAnalytics implements Analytics {
         event.putString(Keys.CATEGORY, Values.NAVIGATION);
         logFirebaseEvent(event.getName(), event.getBundle());
     }
+
+    @Override
+    public void trackSubsectionViewOnWebTapped(@NonNull String courseId, @NonNull String subsectionId, boolean isSpecialExamInfo) {
+        final FirebaseEvent event = new FirebaseEvent(Events.SUBSECTION_VIEW_ON_WEB_TAPPED, Values.SUBSECTION_VIEW_ON_WEB_TAPPED);
+        event.putCourseId(courseId);
+        event.putString(Keys.SUBSECTION_ID, subsectionId);
+        event.putBoolean(Keys.SPECIAL_EXAM_INFO, isSpecialExamInfo);
+        logFirebaseEvent(event.getName(), event.getBundle());
+    }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
@@ -1028,4 +1028,14 @@ public class SegmentAnalytics implements Analytics {
         aEvent.data.putValue(Keys.BLOCK_ID, blockId);
         trackSegmentEvent(Events.RESUME_COURSE_TAPPED, aEvent.properties);
     }
+
+    @Override
+    public void trackSubsectionViewOnWebTapped(@NonNull String courseId, @NonNull String subsectionId, boolean isSpecialExamInfo) {
+        final SegmentEvent aEvent = new SegmentEvent();
+        aEvent.properties.putValue(Keys.NAME, Values.SUBSECTION_VIEW_ON_WEB_TAPPED);
+        aEvent.data.putValue(Keys.COURSE_ID, courseId);
+        aEvent.data.putValue(Keys.SUBSECTION_ID, subsectionId);
+        aEvent.data.putValue(Keys.SPECIAL_EXAM_INFO, isSpecialExamInfo);
+        trackSegmentEvent(Events.SUBSECTION_VIEW_ON_WEB_TAPPED, aEvent.properties);
+    }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/player/PlayerFragment.java
@@ -253,7 +253,7 @@ public class PlayerFragment extends BaseFragment implements IPlayerListener, Ser
                         urlStringBuffer.append( videoEntry.url);
                     }
                     BrowserUtil.open(getActivity(),
-                            urlStringBuffer.toString());
+                            urlStringBuffer.toString(), true);
                 }
 
             });

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/BrowserUtil.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/BrowserUtil.java
@@ -36,8 +36,9 @@ public class BrowserUtil {
      * 
      * @param activity
      * @param url
+     * @param canTrackEvent
      */
-    public static void open(final FragmentActivity activity, final String url) {
+    public static void open(final FragmentActivity activity, final String url, final boolean canTrackEvent) {
         if (TextUtils.isEmpty(url) || activity == null){
             logger.warn("cannot open URL in browser, either URL or activity parameter is NULL");
             return;
@@ -47,7 +48,7 @@ public class BrowserUtil {
             // use API host as the base URL for relative paths
             String absoluteUrl = String.format("%s%s", environment.getConfig().getApiHostURL(), url);
             logger.debug(String.format("opening relative path URL: %s", absoluteUrl));
-            openInBrowser(activity, absoluteUrl);
+            openInBrowser(activity, absoluteUrl, canTrackEvent);
             return;
         }
 
@@ -59,7 +60,7 @@ public class BrowserUtil {
             if (ConfigUtil.Companion.isWhiteListedURL(url, environment.getConfig())) {
                 // this is white-listed URL
                 logger.debug(String.format("opening white-listed URL: %s", url));
-                openInBrowser(activity, url);
+                openInBrowser(activity, url, canTrackEvent);
             }
             else {
                 // for non-white-listed URLs
@@ -68,7 +69,7 @@ public class BrowserUtil {
                 IDialogCallback callback = new IDialogCallback() {
                     @Override
                     public void onPositiveClicked() {
-                        openInBrowser(activity, url);
+                        openInBrowser(activity, url, canTrackEvent);
                     }
 
                     @Override
@@ -81,19 +82,21 @@ public class BrowserUtil {
         }
         else {
             logger.debug(String.format("non-zero rated network, opening URL: %s", url));
-            openInBrowser(activity, url);
+            openInBrowser(activity, url, canTrackEvent);
         }
     }
 
-    private static void openInBrowser(FragmentActivity context, String url) {
+    private static void openInBrowser(FragmentActivity context, String url, boolean canTrackEvent) {
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.addCategory(Intent.CATEGORY_BROWSABLE);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.setData(Uri.parse(url));
         try {
             context.startActivity(intent);
-            AnalyticsRegistry analyticsRegistry = environment.getAnalyticsRegistry();
-            analyticsRegistry.trackBrowserLaunched(url);
+            if (canTrackEvent) {
+                AnalyticsRegistry analyticsRegistry = environment.getAnalyticsRegistry();
+                analyticsRegistry.trackBrowserLaunched(url);
+            }
         } catch (ActivityNotFoundException e) {
             Toast.makeText(context, R.string.cannot_open_url, Toast.LENGTH_SHORT).show();
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
@@ -193,7 +193,7 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment() {
 
     private fun showOpenInBrowserDialog(link: String) {
         AlertDialogFragment.newInstance(null, getString(R.string.assessment_not_available),
-                getString(R.string.assessment_view_on_web), { dialogInterface: DialogInterface, i: Int -> BrowserUtil.open(activity, link) },
+                getString(R.string.assessment_view_on_web), { dialogInterface: DialogInterface, i: Int -> BrowserUtil.open(activity, link, true) },
                 getString(R.string.label_cancel), null).show(childFragmentManager, null)
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.java
@@ -66,7 +66,7 @@ public class CourseUnitMobileNotSupportedFragment extends CourseUnitFragment {
         }
 
         binding.viewOnWebButton.setOnClickListener(v -> {
-            BrowserUtil.open(getActivity(), unit.getWebUrl());
+            BrowserUtil.open(getActivity(), unit.getWebUrl(), true);
             environment.getAnalyticsRegistry().trackOpenInBrowser(unit.getId(), unit.getCourseId(),
                     unit.isMultiDevice(), unit.getBlockId());
         });

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitOnlyOnYoutubeFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitOnlyOnYoutubeFragment.java
@@ -36,14 +36,14 @@ public class CourseUnitOnlyOnYoutubeFragment extends CourseUnitFragment {
             tvYouTubeMessage.setText(R.string.assessment_needed_updating_youtube);
             view.findViewById(R.id.update_youtube_button).setVisibility(View.VISIBLE);
             view.findViewById(R.id.update_youtube_button).setOnClickListener(v -> {
-                BrowserUtil.open(getActivity(), AppConstants.BROWSER_PLAYSTORE_YOUTUBE_URI);
+                BrowserUtil.open(getActivity(), AppConstants.BROWSER_PLAYSTORE_YOUTUBE_URI, true);
             });
         } else {
             tvYouTubeMessage.setText(R.string.assessment_only_on_youtube);
         }
 
         view.findViewById(R.id.view_on_youtube_button).setOnClickListener(v -> {
-            BrowserUtil.open(getActivity(), ((VideoBlockModel) unit).getData().encodedVideos.youtube.url);
+            BrowserUtil.open(getActivity(), ((VideoBlockModel) unit).getData().encodedVideos.youtube.url, true);
         });
 
         return view;

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitYoutubePlayerFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitYoutubePlayerFragment.java
@@ -193,7 +193,7 @@ public class CourseUnitYoutubePlayerFragment extends BaseCourseUnitVideoFragment
                             getString(R.string.assessment_open_on_youtube),
                             (dialog, which) -> BrowserUtil
                                     .open(getActivity(),
-                                            unit.getData().encodedVideos.getYoutubeVideoInfo().url),
+                                            unit.getData().encodedVideos.getYoutubeVideoInfo().url, true),
                             getString(R.string.label_ok), null
                     );
         }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/custom/URLInterceptorWebViewClient.java
@@ -225,7 +225,7 @@ public class URLInterceptorWebViewClient extends WebViewClient {
             // open URL in external web browser
             // return true means the host application handles the url
             // this should open the URL in the browser with user's confirmation
-            BrowserUtil.open(activity, url);
+            BrowserUtil.open(activity, url, true);
             return true;
         } else {
             // return false means the current WebView handles the url.


### PR DESCRIPTION

### Description

[LEARNER-8311](https://openedx.atlassian.net/browse/LEARNER-8311)

- Update CourseStructure API to receive response for SpecialExamInfo
- Added Support for SpecialExamInfo response in xBlock
- Added Analytics for unsupported xBlocks
- Disable tracking for Browser Launch event in case of Subsection
- Added `View on Web` button to open unsupported xBlocks in webview
<img src="https://user-images.githubusercontent.com/30689349/117646552-55139900-b1a5-11eb-97f0-f8547c45f938.png" height="512"/>
