### PR TITLE
Open rendered xBlock in new tab

### DIFF
--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -822,4 +822,6 @@
     <string name="open_in_browser_message">This part of the course may work best in a web browser.</string>
     <!-- Open in browser Title -->
     <string name="open_in_browser_text"><u>Open in browser</u></string>
+    <!-- Open in new tab Title -->
+    <string name="open_in_new_tab_text"><u>Open in new tab</u></string>
 </resources>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitWebViewFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitWebViewFragment.java
@@ -21,6 +21,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
@@ -46,6 +47,9 @@ import org.edx.mobile.view.custom.URLInterceptorWebViewClient;
 import org.edx.mobile.viewModel.CourseDateViewModel;
 import org.edx.mobile.viewModel.ViewModelFactory;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.List;
 
 import de.greenrobot.event.EventBus;
 import roboguice.inject.InjectView;
@@ -111,6 +115,7 @@ public class CourseUnitWebViewFragment extends CourseUnitFragment {
             public void onPageFinished() {
                 if (authWebView.isPageLoaded()) {
                     fetchDateBannerInfo();
+                    evaluateXBlocksForBanner();
                     evaluateJavascriptForiFrame();
                     if (getUserVisibleHint()) {
                         preloadingListener.setLoadingState(PreLoadingListener.State.MAIN_UNIT_LOADED);
@@ -150,6 +155,14 @@ public class CourseUnitWebViewFragment extends CourseUnitFragment {
         }
     }
 
+    private void evaluateXBlocksForBanner() {
+        List<BlockType> allowedBlocks = Arrays.asList(BlockType.PROBLEM, BlockType.OPENASSESSMENT,
+                BlockType.DRAG_AND_DROP_V2, BlockType.WORD_CLOUD);
+        if (allowedBlocks.contains(unit.getType())) {
+            setupOpenInBrowserView(R.string.open_in_new_tab_text);
+        }
+    }
+
     private void evaluateJavascriptForiFrame() {
         if (!TextUtils.isEmpty(unit.getBlockId()) && !evaluatediFrameJS) {
             // execute js code to check an HTML block that contains an iframe
@@ -163,19 +176,17 @@ public class CourseUnitWebViewFragment extends CourseUnitFragment {
             authWebView.evaluateJavascript(javascript, value -> {
                 evaluatediFrameJS = true;
                 if (Boolean.parseBoolean(value)) {
-                    setupOpenInBrowserView();
-                } else {
-                    tvOpenBrowser.setVisibility(View.GONE);
+                    setupOpenInBrowserView(R.string.open_in_browser_text);
                 }
             });
         }
     }
 
-    private void setupOpenInBrowserView() {
+    private void setupOpenInBrowserView(@StringRes int linkTextResId) {
         tvOpenBrowser.setVisibility(View.VISIBLE);
 
         String openInBrowserMessage = getString(R.string.open_in_browser_message) + " "
-                + getString(R.string.open_in_browser_text) + " " + AppConstants.ICON_PLACEHOLDER;
+                + getString(linkTextResId) + " " + AppConstants.ICON_PLACEHOLDER;
         SpannableString openInBrowserSpan = new SpannableString(openInBrowserMessage);
 
         ImageSpan openInNewIcon = new ImageSpan(getContext(), R.drawable.ic_open_in_new);
@@ -194,13 +205,13 @@ public class CourseUnitWebViewFragment extends CourseUnitFragment {
                 super.updateDrawState(textPaint);
             }
         };
-        int openInBrowserIndex = openInBrowserMessage.indexOf(getString(R.string.open_in_browser_text));
+        int openInBrowserIndex = openInBrowserMessage.indexOf(getString(linkTextResId));
         openInBrowserSpan.setSpan(clickableSpan, openInBrowserIndex,
-                openInBrowserIndex + getString(R.string.open_in_browser_text).length(),
+                openInBrowserIndex + getString(linkTextResId).length(),
                 Spanned.SPAN_EXCLUSIVE_INCLUSIVE);
 
         openInBrowserSpan.setSpan(new ForegroundColorSpan(getResources().getColor(R.color.neutralXXDark)),
-                openInBrowserIndex, openInBrowserIndex + getString(R.string.open_in_browser_text).length(),
+                openInBrowserIndex, openInBrowserIndex + getString(linkTextResId).length(),
                 Spanned.SPAN_EXCLUSIVE_INCLUSIVE);
 
         tvOpenBrowser.setText(openInBrowserSpan);


### PR DESCRIPTION
### Description

[LEARNER-8361](https://openedx.atlassian.net/browse/LEARNER-8361)

- Check rendered xblock for html, video, and discussion and display the open in new tab footer in their absence.

<img src="https://user-images.githubusercontent.com/71447999/121692297-67a12b00-cae1-11eb-9061-3b7c69abc4ee.png" height="512"/>
