### PR TITLE
feat: Braze push notification integration

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -224,7 +224,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.3.0-alpha01'
 
     // Braze SDK Integration
-    implementation "com.appboy:android-sdk-ui:13.1.2"
+    implementation 'com.appboy:appboy-segment-integration:7.0.0'
 
     // test project configuration
     testImplementation 'junit:junit:4.12'

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -140,13 +140,14 @@ public abstract class MainApplication extends MultiDexApplication {
         }
 
         // Braze SDK Initialization
-        if (config.getBrazeConfig().isEnabled()) {
+        if (config.getBrazeConfig().isEnabled() && config.getFirebaseConfig().isEnabled()) {
             AppboyConfig appboyConfig = new AppboyConfig.Builder()
-                    .setApiKey(config.getBrazeConfig().getApiKey())
-                    .setCustomEndpoint(config.getBrazeConfig().getEndPointKey())
+                    .setIsFirebaseCloudMessagingRegistrationEnabled(config.getBrazeConfig().isPushNotificationsEnabled())
+                    .setFirebaseCloudMessagingSenderIdKey(config.getFirebaseConfig().getProjectNumber())
+                    .setHandlePushDeepLinksAutomatically(true)
                     .build();
-            Appboy.configure(this, appboyConfig);
-            registerActivityLifecycleCallbacks(new AppboyLifecycleCallbackListener(true, false));
+            Appboy.configure(getApplicationContext(), appboyConfig);
+            registerActivityLifecycleCallbacks(new AppboyLifecycleCallbackListener(true, true));
         }
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/base/MainApplication.java
@@ -142,11 +142,12 @@ public abstract class MainApplication extends MultiDexApplication {
         // Braze SDK Initialization
         if (config.getBrazeConfig().isEnabled() && config.getFirebaseConfig().isEnabled()) {
             AppboyConfig appboyConfig = new AppboyConfig.Builder()
-                    .setIsFirebaseCloudMessagingRegistrationEnabled(config.getBrazeConfig().isPushNotificationsEnabled())
+                    .setIsFirebaseCloudMessagingRegistrationEnabled(config.areFirebasePushNotificationsEnabled()
+                            && config.getBrazeConfig().isPushNotificationsEnabled())
                     .setFirebaseCloudMessagingSenderIdKey(config.getFirebaseConfig().getProjectNumber())
                     .setHandlePushDeepLinksAutomatically(true)
                     .build();
-            Appboy.configure(getApplicationContext(), appboyConfig);
+            Appboy.configure(this, appboyConfig);
             registerActivityLifecycleCallbacks(new AppboyLifecycleCallbackListener(true, true));
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
@@ -13,6 +13,7 @@ import com.segment.analytics.Analytics.Builder;
 import com.segment.analytics.Options;
 import com.segment.analytics.Properties;
 import com.segment.analytics.Traits;
+import com.segment.analytics.android.integrations.appboy.AppboyIntegration;
 import com.segment.analytics.android.integrations.firebase.FirebaseIntegration;
 import com.segment.analytics.integrations.BasePayload;
 import com.segment.analytics.integrations.Integration;
@@ -72,6 +73,8 @@ public class SegmentAnalytics implements Analytics {
                         chain.proceed(newPayload);
                     });
         }
+        if (config.getBrazeConfig().isEnabled() && config.getFirebaseConfig().isEnabled())
+            builder = builder.use(AppboyIntegration.FACTORY);
         tracker = builder.build();
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
@@ -73,8 +73,9 @@ public class SegmentAnalytics implements Analytics {
                         chain.proceed(newPayload);
                     });
         }
-        if (config.getBrazeConfig().isEnabled() && config.getFirebaseConfig().isEnabled())
+        if (config.getBrazeConfig().isEnabled() && config.getFirebaseConfig().isEnabled()) {
             builder = builder.use(AppboyIntegration.FACTORY);
+        }
         tracker = builder.build();
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/notifications/services/NotificationService.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/notifications/services/NotificationService.java
@@ -1,5 +1,6 @@
 package org.edx.mobile.notifications.services;
 
+import com.appboy.AppboyFirebaseMessagingService;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
@@ -22,7 +23,11 @@ public class NotificationService extends FirebaseMessagingService {
         final IEdxEnvironment environment = MainApplication.getEnvironment(this);
 
         if (environment.getConfig().areFirebasePushNotificationsEnabled()) {
-            PushLinkManager.INSTANCE.onFCMForegroundNotificationReceived(remoteMessage);
+            if (AppboyFirebaseMessagingService.isBrazePushNotification(remoteMessage)) {
+                AppboyFirebaseMessagingService.handleBrazeRemoteMessage(this, remoteMessage);
+            } else {
+                PushLinkManager.INSTANCE.onFCMForegroundNotificationReceived(remoteMessage);
+            }
         }
     }
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
@@ -475,6 +475,9 @@ public class Config {
         @SerializedName("CLOUD_MESSAGING_ENABLED")
         private boolean mCloudMessagingEnabled;
 
+        @SerializedName("PROJECT_NUMBER")
+        private String mProjectNumber;
+
         public enum AnalyticsSource {
             @SerializedName("segment")
             SEGMENT,
@@ -496,6 +499,10 @@ public class Config {
             return mEnabled && mAnalyticsSource == AnalyticsSource.FIREBASE;
         }
 
+        public String getProjectNumber() {
+            return mProjectNumber;
+        }
+
         public boolean areNotificationsEnabled() {
             return mEnabled && mCloudMessagingEnabled;
         }
@@ -505,23 +512,15 @@ public class Config {
         @SerializedName("ENABLED")
         private boolean enabled;
 
-        @SerializedName("API_KEY")
-        private String apiKey;
-
-        @SerializedName("END_POINT_KEY")
-        private String endPointKey;
-
+        @SerializedName("PUSH_NOTIFICATIONS_ENABLED")
+        private boolean mPushNotificationsEnabled;
 
         public boolean isEnabled() {
             return enabled;
         }
 
-        public String getApiKey() {
-            return apiKey;
-        }
-
-        public String getEndPointKey() {
-            return endPointKey;
+        public boolean isPushNotificationsEnabled() {
+            return mPushNotificationsEnabled;
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ allprojects {
         maven { url 'https://maven.google.com' }
         maven { url 'https://jitpack.io' }
         maven { url "https://appboy.github.io/appboy-android-sdk/sdk" }
+        maven { url "https://appboy.github.io/appboy-segment-android/sdk" }
     }
     project.apply from: "${rootDir}/constants.gradle"
 }


### PR DESCRIPTION
### Description

[LEARNER-8431](https://openedx.atlassian.net/browse/LEARNER-8431)

- Removed the standalone integration in favor of segment.io
- Integrated Push Notification. For Braze Push Notifications,
  if the app is in background or foreground we will see a notification
  and not a popup module
- Simple In-app messages are also enabled without any deep links

**Integration:** [Segment's Braze](https://segment.com/docs/connections/destinations/catalog/braze/)
**Notification Extras:** : [Extras](https://openedx.atlassian.net/wiki/spaces/LEARNER/pages/1067713219/Push+Notifications+on+Mobile)