### PR TITLE
fix: Sync adapters must specify an account and account type issue

### DIFF
--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -859,4 +859,6 @@
     <string name="open_in_browser_message">This part of the course may work best in a web browser.</string>
     <!-- Open in browser Title -->
     <string name="open_in_browser_text"><u>Open in browser</u></string>
+    <!-- Error message while creating calendar for the course events -->
+    <string name="adding_calendar_error_message">Error Adding Calendar, Please try later</string>
 </resources>

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
+import android.provider.CalendarContract
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -99,7 +100,7 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment(), BaseFragment.Permi
         courseData = arguments?.getSerializable(Router.EXTRA_COURSE_DATA) as EnrolledCoursesResponse
         calendarTitle = "${environment.config.platformName} - ${courseData.course.name}"
         isSelfPaced = courseData.course.isSelfPaced
-        accountName = environment.loginPrefs.currentUserProfile?.name ?: "local_user"
+        accountName = environment.loginPrefs.currentUserProfile?.email ?: CalendarUtils.LOCAL_USER
 
         errorNotification = FullScreenErrorNotification(binding.swipeContainer)
 
@@ -245,7 +246,7 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment(), BaseFragment.Permi
                 }
             } else if (CalendarUtils.hasPermissions(context = contextOrThrow)) {
                 val calendarId = CalendarUtils.getCalendarId(context = contextOrThrow, accountName = accountName, calendarTitle = calendarTitle)
-                if (calendarId != (-1).toLong()) {
+                if (calendarId != -1L) {
                     deleteCalendar(calendarId)
                 }
             }
@@ -307,10 +308,18 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment(), BaseFragment.Permi
     }
 
     private fun insertCalendarEvent() {
-        val calendarId: Long = CalendarUtils.createOrUpdateCalendar(context = contextOrThrow, accountName = accountName, calendarTitle = calendarTitle)
+        val calendarId: Long = CalendarUtils.createOrUpdateCalendar(
+            context = contextOrThrow,
+            accountName = accountName,
+            calendarTitle = calendarTitle
+        )
         // if app unable to create the Calendar for the course
-        if (calendarId == (-1).toLong()) {
-            Toast.makeText(contextOrThrow, "Error Adding Calendar, Please try later", Toast.LENGTH_SHORT).show()
+        if (calendarId == -1L) {
+            Toast.makeText(
+                contextOrThrow,
+                getString(R.string.adding_calendar_error_message),
+                Toast.LENGTH_SHORT
+            ).show()
             binding.switchSync.isChecked = false
             return
         }


### PR DESCRIPTION
### Description

[LEARNER-8476](https://openedx.atlassian.net/browse/LEARNER-8476)

- Sync adapters must specify an account and account type issue
- Create the course calendar with the user email.
- Code user column names instated of the index to get data from the cursor.