### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
   # Check if emulator has finished booting
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
-  - travis_wait 30 make e2e
+  - make e2e
   # Script to check linting issues.
   - ./gradlew lintProdDebug
 


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
