### PR TITLE
feat: Add LeakCanary to the project

### DIFF
--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -270,6 +270,15 @@ dependencies {
         exclude group: 'org.hamcrest'
     }
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${KOTLIN_VERSION}"
+
+    /**
+     * Using debugImplementation here, so that LeakCanary only runs with debug variants of the builds.
+     * p.s. it won't run with the debuggable variant.
+     *
+     * Following link explains setting up LeakCanary for different product flavors:
+     * https://square.github.io/leakcanary/recipes/#setting-up-leakcanary-for-different-product-flavors
+     */
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.7'
 }
 
 configurations {

--- a/constants.gradle
+++ b/constants.gradle
@@ -1,6 +1,6 @@
 project.ext {
     APPLICATION_ID = "org.edx.mobile"
-    KOTLIN_VERSION = "1.3.41"
+    KOTLIN_VERSION = "1.3.50"
     GRADLE_PLUGIN_VERSION = "3.3.2"
     BUILD_TOOLS_VERSION = "28.0.3"
     COMPILE_SDK_VERSION = 28


### PR DESCRIPTION
### Description

[LEARNER-8519](https://openedx.atlassian.net/browse/LEARNER-8519)

In the current setup, LeakCanary only runs with `debug` variant of the builds i.e. `prodDebug`. So, it won't run with our `prodDebuggable` variant.

Following link explains setting up LeakCanary for different product flavors:
https://square.github.io/leakcanary/recipes/#setting-up-leakcanary-for-different-product-flavors

Also, our previously used Kotlin version i.e. v1.3.41 was causing a compile-time error when using the `prodDebug` variant. I've bumped the version to v1.3.50 which fixes the issue.