### PR TITLE
fix: add context null check for BulkDownloadFragment crash

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/BaseCourseUnitVideoFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/BaseCourseUnitVideoFragment.java
@@ -431,10 +431,12 @@ public abstract class BaseCourseUnitVideoFragment extends CourseUnitFragment
                 // p.s. Without this listener the getHeight function returns 0
                 transcriptListLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
                     public void onGlobalLayout() {
-                        transcriptListView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
-                        final float transcriptRowHeight = getResources().getDimension(R.dimen.transcript_row_height);
-                        final float listviewHeight = transcriptListView.getHeight();
-                        topOffset = (listviewHeight / 2) - (transcriptRowHeight / 2);
+                        if (getActivity() != null) {
+                            transcriptListView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                            final float transcriptRowHeight = getActivity().getResources().getDimension(R.dimen.transcript_row_height);
+                            final float listviewHeight = transcriptListView.getHeight();
+                            topOffset = (listviewHeight / 2) - (transcriptRowHeight / 2);
+                        }
                     }
                 };
                 transcriptListView.getViewTreeObserver().addOnGlobalLayoutListener(transcriptListLayoutListener);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/BulkDownloadFragment.java
@@ -356,9 +356,11 @@ public class BulkDownloadFragment extends BaseFragment implements BaseFragment.P
                               @StringRes int titleRes, @NonNull String descPattern,
                               @NonNull String firstPlaceholder, @NonNull String firstPlaceholderVal,
                               @NonNull String secondPlaceholder, @NonNull String secondPlaceholderVal) {
-        binding.ivIcon.setImageDrawable(UiUtils.INSTANCE.getDrawable(requireContext(), iconResId));
-        UiUtils.INSTANCE.setAnimation(binding.ivIcon, animation);
-        binding.tvTitle.setText(titleRes);
+        if (getContext() != null) {
+            binding.ivIcon.setImageDrawable(UiUtils.INSTANCE.getDrawable(getContext(), iconResId));
+            UiUtils.INSTANCE.setAnimation(binding.ivIcon, animation);
+            binding.tvTitle.setText(titleRes);
+        }
         setSubtitle(descPattern, firstPlaceholder, firstPlaceholderVal, secondPlaceholder, secondPlaceholderVal);
     }
 


### PR DESCRIPTION

### Description

[LEARNER-8508](https://openedx.atlassian.net/browse/LEARNER-8508)

- Added Context not null check on BulkDownloadFragment
- Get resources using activity on BaseCourseUnitVideoFragment