### PR TITLE
feat: Save artifacts of AWS device farm in jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,4 +74,10 @@ pipeline {
             }
         }
     }
+
+    post {
+        always {
+            archiveArtifacts artifacts: '*/Test spec output.txt, */Video.mp4, */Customer Artifacts.zip', onlyIfSuccessful: true
+        }
+    }
 } 


### PR DESCRIPTION
[LEARNER-8533](https://openedx.atlassian.net/browse/LEARNER-8533)

### Description
Save automation test results on Jenkins build

Now every Jenkins job has test results of AWS device farm, saved in its own pipeline build, which was previously available for 30 minutes only. Now with every commit on Android repo, a developer can see automation results executed on the Jenkins job.

 - Add post step in jenkins pipeline
 - Archive video file, output text file, and customer Artifacts file if the build is successful

Reference:
https://www.jenkins.io/doc/pipeline/steps/core/#code-archiveartifacts-code-archive-the-artifacts