### PR TITLE
feat: Add deep-link to the component that is due in my calendar event

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/DeepLink.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/DeepLink.kt
@@ -9,18 +9,21 @@ open class DeepLink(val screenName: String) : Parcelable {
     object Keys {
         const val SCREEN_NAME = "screen_name"
         const val COURSE_ID = "course_id"
+        const val COMPONENT_ID = "component_id"
         const val PATH_ID = "path_id"
         const val TOPIC_ID = "topic_id"
         const val THREAD_ID = "thread_id"
     }
 
     var courseId: String? = null
+    var componentId: String? = null
     var pathId: String? = null
     var topicID: String? = null
     var threadID: String? = null
 
     constructor(screenName: String, paramsJson: JSONObject) : this(screenName) {
         courseId = paramsJson.optString(Keys.COURSE_ID)
+        componentId = paramsJson.optString(Keys.COMPONENT_ID)
         pathId = paramsJson.optString(Keys.PATH_ID)
         topicID = paramsJson.optString(Keys.TOPIC_ID)
         threadID = paramsJson.optString(Keys.THREAD_ID)
@@ -28,6 +31,7 @@ open class DeepLink(val screenName: String) : Parcelable {
 
     constructor(screenName: String, bundle: Bundle) : this(screenName) {
         courseId = bundle.getString(Keys.COURSE_ID)
+        componentId = bundle.getString(Keys.COMPONENT_ID)
         pathId = bundle.getString(Keys.PATH_ID)
         topicID = bundle.getString(Keys.TOPIC_ID)
         threadID = bundle.getString(Keys.THREAD_ID)
@@ -35,13 +39,15 @@ open class DeepLink(val screenName: String) : Parcelable {
 
     constructor(screenName: String, map: Map<String, String>) : this(screenName) {
         courseId = map[Keys.COURSE_ID]
+        componentId = map[Keys.COMPONENT_ID]
         pathId = map[Keys.PATH_ID]
         topicID = map[Keys.TOPIC_ID]
         threadID = map[Keys.THREAD_ID]
     }
 
     override fun toString(): String {
-        return "DeepLink(screenName='$screenName', courseId=$courseId, pathId=$pathId, topicID=$topicID, threadID=$threadID)"
+        return "DeepLink(screenName='$screenName', courseId=$courseId, componentId=$componentId, " +
+                "pathId=$pathId, topicID=$topicID, threadID=$threadID)"
     }
 
     companion object {
@@ -54,6 +60,7 @@ open class DeepLink(val screenName: String) : Parcelable {
 
     constructor(source: Parcel) : this(source.readString()) {
         this.courseId = source.readString()
+        this.componentId = source.readString()
         this.pathId = source.readString()
         this.topicID = source.readString()
         this.threadID = source.readString()
@@ -64,6 +71,7 @@ open class DeepLink(val screenName: String) : Parcelable {
     override fun writeToParcel(dest: Parcel, flags: Int) = with(dest) {
         writeString(screenName)
         writeString(courseId)
+        writeString(componentId)
         writeString(pathId)
         writeString(topicID)
         writeString(threadID)

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/DeepLinkManager.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/DeepLinkManager.java
@@ -44,8 +44,9 @@ public class DeepLinkManager {
             case Screen.COURSE_HANDOUT:
             case Screen.COURSE_ANNOUNCEMENT:
             case Screen.DISCUSSION_POST:
-            case Screen.DISCUSSION_TOPIC: {
-                router.showCourseDashboardTabs(activity, null, deepLink.getCourseId(),
+            case Screen.DISCUSSION_TOPIC:
+            case Screen.COURSE_COMPONENT: {
+                router.showCourseDashboardTabs(activity, null, deepLink.getCourseId(), deepLink.getComponentId(),
                         deepLink.getTopicID(), deepLink.getThreadID(), false, screenName);
                 break;
             }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/Screen.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/deeplink/Screen.java
@@ -19,4 +19,5 @@ public class Screen {
     public static final String DEGREE_DISCOVERY = "degree_discovery";
     public static final String DISCUSSION_POST = "discussion_post";
     public static final String DISCUSSION_TOPIC = "discussion_topic";
+    public static final String COURSE_COMPONENT = "course_component";
 }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDatesPageFragment.kt
@@ -325,7 +325,13 @@ class CourseDatesPageFragment : OfflineSupportBaseFragment(), BaseFragment.Permi
             )
         }
         courseDates?.courseDateBlocks?.forEach { courseDateBlock ->
-            CalendarUtils.addEventsIntoCalendar(context = contextOrThrow, calendarId = calendarId, courseName = courseData.course.name, courseDateBlock = courseDateBlock)
+            CalendarUtils.addEventsIntoCalendar(
+                context = contextOrThrow,
+                calendarId = calendarId,
+                courseId = courseData.courseId,
+                courseName = courseData.course.name,
+                courseDateBlock = courseDateBlock
+            )
         }
         checkIfCalendarExists()
         if (updateEvents) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -139,6 +139,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
     private View loadingIndicator;
     private FrameLayout flBulkDownload;
     private View videoQualityLayout;
+    private TextView tvVideoDownloadQuality;
     private CourseOutlineAdapter.DownloadListener downloadListener;
     private Call<CourseUpgradeResponse> getCourseUpgradeStatus;
     private CourseUpgradeResponse courseUpgradeData;
@@ -179,6 +180,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
         loadingIndicator = view.findViewById(R.id.loading_indicator);
         flBulkDownload = view.findViewById(R.id.fl_bulk_download_container);
         videoQualityLayout = view.findViewById(R.id.video_quality_layout);
+        tvVideoDownloadQuality = view.findViewById(R.id.tv_video_download_quality);
         swipeContainer.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
             public void onRefresh() {
@@ -770,7 +772,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
     }
 
     private void setUpVideoQualityHeader(CourseComponent courseComponent) {
-        if (isVideoMode && isOnCourseOutline && getView() != null) {
+        if (isVideoMode && isOnCourseOutline) {
             videoQualityLayout.setVisibility(View.VISIBLE);
             videoQualityLayout.setOnClickListener(v -> {
                 environment.getAnalyticsRegistry().trackVideoDownloadQualityClicked(Analytics.Events.COURSE_VIDEOS_VIDEO_DOWNLOAD_QUALITY_CLICKED,
@@ -862,7 +864,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
     }
 
     private void setVideoQualityHeaderLabel(VideoQuality videoQuality) {
-        ((TextView) getView().findViewById(R.id.tv_video_download_quality)).setText(videoQuality.getTitleResId());
+        tvVideoDownloadQuality.setText(videoQuality.getTitleResId());
     }
 
     private void showVideoQualitySelectionModal(CourseComponent courseComponent) {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -39,7 +39,9 @@ import org.edx.mobile.base.BaseFragment;
 import org.edx.mobile.base.BaseFragmentActivity;
 import org.edx.mobile.course.CourseAPI;
 import org.edx.mobile.databinding.LayoutCourseDatesBannerBinding;
+import org.edx.mobile.deeplink.DeepLink;
 import org.edx.mobile.deeplink.Screen;
+import org.edx.mobile.deeplink.ScreenDef;
 import org.edx.mobile.event.CourseDashboardRefreshEvent;
 import org.edx.mobile.event.CourseUpgradedEvent;
 import org.edx.mobile.event.MediaStatusChangeEvent;
@@ -142,13 +144,15 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
     private CourseUpgradeResponse courseUpgradeData;
     private String calendarTitle = "";
     private String accountName = "";
+    private String screenName;
 
     public static Bundle makeArguments(@NonNull EnrolledCoursesResponse model,
-                                       @Nullable String courseComponentId, boolean isVideosMode) {
+                                       @Nullable String courseComponentId, boolean isVideosMode, @ScreenDef String screenName) {
         final Bundle arguments = new Bundle();
         final Bundle courseBundle = new Bundle();
         courseBundle.putSerializable(Router.EXTRA_COURSE_DATA, model);
         courseBundle.putString(Router.EXTRA_COURSE_COMPONENT_ID, courseComponentId);
+        courseBundle.putString(Router.EXTRA_SCREEN_NAME, screenName);
 
         arguments.putBundle(Router.EXTRA_BUNDLE, courseBundle);
         arguments.putBoolean(Router.EXTRA_IS_VIDEOS_MODE, isVideosMode);
@@ -273,7 +277,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
         CalendarUtils.INSTANCE.deleteAllCalendarEvents(requireContext(), calendarId);
         if (courseDateViewModel.getCourseDates().getValue() != null) {
             for (CourseDateBlock courseDateBlock : courseDateViewModel.getCourseDates().getValue().getCourseDateBlocks()) {
-                CalendarUtils.INSTANCE.addEventsIntoCalendar(getContextOrThrow(), calendarId, courseData.getCourse().getName(), courseDateBlock);
+                CalendarUtils.INSTANCE.addEventsIntoCalendar(getContextOrThrow(), calendarId, courseData.getCourseId(), courseData.getCourse().getName(), courseDateBlock);
             }
             showCalendarUpdatedSnackbar();
             trackCalendarEvent(Analytics.Events.CALENDAR_UPDATE_SUCCESS, Analytics.Values.CALENDAR_UPDATE_SUCCESS);
@@ -297,6 +301,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
             courseData = (EnrolledCoursesResponse) bundle.getSerializable(Router.EXTRA_COURSE_DATA);
             courseUpgradeData = bundle.getParcelable(Router.EXTRA_COURSE_UPGRADE_DATA);
             courseComponentId = bundle.getString(Router.EXTRA_COURSE_COMPONENT_ID);
+            screenName = bundle.getString(DeepLink.Keys.SCREEN_NAME);
             isVideoMode = savedInstanceState.getBoolean(Router.EXTRA_IS_VIDEOS_MODE);
             isSingleVideoDownload = savedInstanceState.getBoolean("isSingleVideoDownload");
             if (savedInstanceState.containsKey(Router.EXTRA_IS_ON_COURSE_OUTLINE)) {
@@ -309,7 +314,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
 
     private void fetchCourseComponent() {
         final String courseId = courseData.getCourseId();
-        if (courseComponentId != null) {
+        if (courseComponentId != null && TextUtils.isEmpty(screenName)) {
             final CourseComponent courseComponent = courseManager.getComponentByIdFromAppLevelCache(courseId, courseComponentId);
             if (courseComponent != null) {
                 // Course data exist in app session cache
@@ -539,13 +544,21 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
         }
     }
 
+    private void detectDeepLinking() {
+        if (Screen.COURSE_COMPONENT.equalsIgnoreCase(screenName)
+                && !TextUtils.isEmpty(courseComponentId)) {
+            environment.getRouter().showCourseUnitDetail(CourseOutlineFragment.this,
+                    REQUEST_SHOW_COURSE_UNIT_DETAIL, courseData, courseUpgradeData, courseComponentId, false);
+            screenName = null;
+        }
+    }
+
     private void showShiftDateSnackBar(boolean isSuccess) {
         SnackbarErrorNotification snackbarErrorNotification = new SnackbarErrorNotification(listView);
         if (isSuccess) {
             snackbarErrorNotification.showError(R.string.assessment_shift_dates_success_msg,
                     0, R.string.assessment_view_all_dates, SnackbarErrorNotification.COURSE_DATE_MESSAGE_DURATION,
-                    v -> environment.getRouter().showCourseDashboardTabs(getActivity(), null, courseData.getCourseId(),
-                            null, null, false, Screen.COURSE_DATES));
+                    v -> environment.getRouter().showCourseDashboardTabs(getActivity(), courseData.getCourseId(), Screen.COURSE_DATES));
         } else {
             snackbarErrorNotification.showError(R.string.course_dates_reset_unsuccessful, 0,
                     0, SnackbarErrorNotification.COURSE_DATE_MESSAGE_DURATION, null);
@@ -706,7 +719,6 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
      * @param courseComponent Components of course to be load
      */
     private void loadData(@NonNull CourseComponent courseComponent) {
-        courseComponentId = courseComponent.getId();
         if (courseData == null || getActivity() == null)
             return;
         if (!EventBus.getDefault().isRegistered(this)) {
@@ -752,8 +764,9 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
             environment.getAnalyticsRegistry().trackScreenView(
                     Analytics.Screens.SECTION_OUTLINE, courseData.getCourseId(), courseComponent.getInternalName());
         }
-
         fetchLastAccessed();
+        detectDeepLinking();
+        courseComponentId = courseComponent.getId();
     }
 
     private void setUpVideoQualityHeader(CourseComponent courseComponent) {
@@ -940,7 +953,9 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment
     }
 
     protected boolean isOnCourseOutline() {
-        if (courseComponentId == null) return true;
+        if (courseComponentId == null || getActivity() instanceof CourseTabsDashboardActivity) {
+            return true;
+        }
         final CourseComponent outlineComp = courseManager.getComponentByIdFromAppLevelCache(
                 courseData.getCourseId(), courseComponentId);
         final BlockPath outlinePath = outlineComp.getPath();

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardActivity.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardActivity.java
@@ -15,6 +15,7 @@ import org.edx.mobile.model.api.EnrolledCoursesResponse;
 import de.greenrobot.event.EventBus;
 
 import static org.edx.mobile.view.Router.EXTRA_ANNOUNCEMENTS;
+import static org.edx.mobile.view.Router.EXTRA_COURSE_COMPONENT_ID;
 import static org.edx.mobile.view.Router.EXTRA_COURSE_DATA;
 import static org.edx.mobile.view.Router.EXTRA_COURSE_ID;
 import static org.edx.mobile.view.Router.EXTRA_DISCUSSION_THREAD_ID;
@@ -25,12 +26,14 @@ public class CourseTabsDashboardActivity extends OfflineSupportBaseActivity {
     public static Intent newIntent(@NonNull Context activity,
                                    @Nullable EnrolledCoursesResponse courseData,
                                    @Nullable String courseId,
+                                   @Nullable String componentId,
                                    @Nullable String topicId,
                                    @Nullable String threadId, boolean announcements,
                                    @Nullable @ScreenDef String screenName) {
         final Intent intent = new Intent(activity, CourseTabsDashboardActivity.class);
         intent.putExtra(EXTRA_COURSE_DATA, courseData);
         intent.putExtra(EXTRA_COURSE_ID, courseId);
+        intent.putExtra(EXTRA_COURSE_COMPONENT_ID, componentId);
         intent.putExtra(EXTRA_DISCUSSION_TOPIC_ID, topicId);
         intent.putExtra(EXTRA_DISCUSSION_THREAD_ID, threadId);
         intent.putExtra(EXTRA_ANNOUNCEMENTS, announcements);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardFragment.java
@@ -1,5 +1,8 @@
 package org.edx.mobile.view;
 
+import static android.widget.FrameLayout.LayoutParams;
+import static org.edx.mobile.view.Router.EXTRA_COURSE_COMPONENT_ID;
+
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -38,8 +41,6 @@ import org.edx.mobile.view.custom.ProgressWheel;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
-import static android.widget.FrameLayout.LayoutParams;
 
 public class CourseTabsDashboardFragment extends TabsBaseFragment {
     private static final String ARG_COURSE_NOT_FOUND = "ARG_COURSE_NOT_FOUND";
@@ -247,7 +248,8 @@ public class CourseTabsDashboardFragment extends TabsBaseFragment {
         // Add course outline tab
         items.add(new FragmentItemModel(CourseOutlineFragment.class, courseData.getCourse().getName(),
                 R.drawable.ic_class,
-                CourseOutlineFragment.makeArguments(courseData, null, false),
+                CourseOutlineFragment.makeArguments(courseData, getArguments().getString(EXTRA_COURSE_COMPONENT_ID),
+                        false, screenName),
                 new FragmentItemModel.FragmentStateListener() {
                     @Override
                     public void onFragmentSelected() {
@@ -260,7 +262,7 @@ public class CourseTabsDashboardFragment extends TabsBaseFragment {
         if (environment.getConfig().isCourseVideosEnabled()) {
             items.add(new FragmentItemModel(CourseOutlineFragment.class,
                     getResources().getString(R.string.videos_title), R.drawable.ic_videocam
-                    , CourseOutlineFragment.makeArguments(courseData, null, true),
+                    , CourseOutlineFragment.makeArguments(courseData, null, true, null),
                     new FragmentItemModel.FragmentStateListener() {
                         @Override
                         public void onFragmentSelected() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitWebViewFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitWebViewFragment.java
@@ -316,8 +316,7 @@ public class CourseUnitWebViewFragment extends CourseUnitFragment {
         if (isSuccess) {
             snackbarErrorNotification.showError(R.string.assessment_shift_dates_success_msg,
                     0, R.string.assessment_view_all_dates, SnackbarErrorNotification.COURSE_DATE_MESSAGE_DURATION,
-                    v -> environment.getRouter().showCourseDashboardTabs(getActivity(), null, unit.getCourseId(),
-                            null, null, false, Screen.COURSE_DATES));
+                    v -> environment.getRouter().showCourseDashboardTabs(getActivity(), unit.getCourseId(), Screen.COURSE_DATES));
         } else {
             snackbarErrorNotification.showError(R.string.course_dates_reset_unsuccessful, 0,
                     0, SnackbarErrorNotification.COURSE_DATE_MESSAGE_DURATION, null);
@@ -331,7 +330,7 @@ public class CourseUnitWebViewFragment extends CourseUnitFragment {
         CalendarUtils.INSTANCE.deleteAllCalendarEvents(requireContext(), calendarId);
         if (courseDateViewModel.getCourseDates().getValue() != null) {
             for (CourseDateBlock courseDateBlock : courseDateViewModel.getCourseDates().getValue().getCourseDateBlocks()) {
-                CalendarUtils.INSTANCE.addEventsIntoCalendar(getContextOrThrow(), calendarId, courseName, courseDateBlock);
+                CalendarUtils.INSTANCE.addEventsIntoCalendar(getContextOrThrow(), calendarId, unit.getCourseId(), courseName, courseDateBlock);
             }
             showCalendarUpdatedSnackbar();
             trackCalendarEvent(Analytics.Events.CALENDAR_UPDATE_SUCCESS, Analytics.Values.CALENDAR_UPDATE_SUCCESS);

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
@@ -160,18 +160,26 @@ public class Router {
     public void showCourseDashboardTabs(@NonNull Activity activity,
                                         @Nullable EnrolledCoursesResponse model,
                                         boolean announcements) {
-        showCourseDashboardTabs(activity, model, null, null, null, announcements, null);
+        showCourseDashboardTabs(activity, model, null, null, null, null, announcements, null);
+    }
+
+    public void showCourseDashboardTabs(@NonNull Activity activity,
+                                        @Nullable String courseId,
+                                        @Nullable @ScreenDef String screenName) {
+        activity.startActivity(CourseTabsDashboardActivity.newIntent(activity, null, courseId,
+                null, null, null, false, screenName));
     }
 
     public void showCourseDashboardTabs(@NonNull Activity activity,
                                         @Nullable EnrolledCoursesResponse model,
                                         @Nullable String courseId,
+                                        @Nullable String componentId,
                                         @Nullable String topicId,
                                         @Nullable String threadId,
                                         boolean announcements,
                                         @Nullable @ScreenDef String screenName) {
         activity.startActivity(CourseTabsDashboardActivity.newIntent(activity, model, courseId,
-                topicId, threadId, announcements, screenName));
+                componentId, topicId, threadId, announcements, screenName));
     }
 
     public void showCourseUpgradeWebViewActivity(@NonNull Context context,


### PR DESCRIPTION
### Description

[LEARNER-8298](https://openedx.atlassian.net/browse/LEARNER-8298)

- Add the deep links to the calendar event and navigate to the course component that is due.
- Fix issue of showing calendar outdated modal. After adding the deep link in the calendar event, the App shows the event outdated model cuz the app matching the event description and the time to check that events are the updated from the outside of the app or not.
- issue was fixed by the use of the `contains` string method instated of the `equals`.
- Fix video download quality banner visibility. Video download banner is not visible for the first time on the videos tab and appears on the pull to refresh.

fixes: LEARNER-8298

Acceptance Criteria
- [x] A link in the calendar event should
- [x] If the user is on a mobile device with the app installed, open the app and take the user to the course component that is due.
- [x] If the user is on a mobile device without the app installed, take the user to the app page in the app store.
- [x] Fixed the Video Download quality banner issue, banner is not visible for the first time and appears on the pull to refresh.

<img src="https://user-images.githubusercontent.com/43750646/133821476-d85b2b56-3000-49a4-9a19-3e1389fdfcaf.png" height="512"/>