### PR TITLE
feat: Integration of the payment SDK

### DIFF
--- a/OpenEdXMobile/AndroidManifest.xml
+++ b/OpenEdXMobile/AndroidManifest.xml
@@ -27,6 +27,9 @@
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.WRITE_CALENDAR" />
 
+    <!-- Required by app to to perform in app purchases -->
+    <uses-permission android:name="com.android.vending.BILLING" />
+
     <!-- Setup for Code Coverage -->
     <instrumentation
         android:name="org.edx.mobile.instrumentation.EdxInstrumentation"

--- a/OpenEdXMobile/build.gradle
+++ b/OpenEdXMobile/build.gradle
@@ -270,6 +270,7 @@ dependencies {
         exclude group: 'org.hamcrest'
     }
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${KOTLIN_VERSION}"
+    implementation "com.android.billingclient:billing-ktx:$kotlin_version_billing"
 
     /**
      * Using debugImplementation here, so that LeakCanary only runs with debug variants of the builds.

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/inapppurchases/BillingProcessor.kt
@@ -1,0 +1,158 @@
+package org.edx.mobile.inapppurchases
+
+import android.app.Activity
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import com.android.billingclient.api.*
+import org.edx.mobile.logger.Logger
+
+/**
+ * The BillingProcessor implements all billing functionality for application.
+ * Purchases can happen while in the app.
+ *
+ * This BillingProcessor knows nothing about the application, all necessary information is either
+ * passed into the constructor, exported as observable Flows, or exported through callbacks.
+ * */
+class BillingProcessor(val context: Context, val listener: BillingFlowListeners?) :
+    PurchasesUpdatedListener,
+    BillingClientStateListener {
+
+    private val TAG = BillingProcessor::class.java.simpleName
+    private val logger = Logger(TAG)
+
+    private var RECONNECT_TIMER_START_MILLISECONDS = 1L * 1000L
+    private val RECONNECT_MAX_TIME = 3 // retry connect max times
+
+    private val handler = Handler(Looper.getMainLooper())
+    private var connectionTryCount = 0
+
+    // Billing client, connection, cached data
+    private val billingClient: BillingClient = BillingClient.newBuilder(context)
+        .setListener(this)
+        .enablePendingPurchases()
+        .build()
+
+    init {
+        billingClient.startConnection(this)
+    }
+
+    override fun onBillingSetupFinished(billingResult: BillingResult) {
+        logger.debug(
+            "BillingSetupFinished -> Response code: " + billingResult.responseCode.toString() +
+                    " Debug message: " + billingResult.debugMessage
+        )
+        listener?.onBillingSetupFinished(billingResult)
+    }
+
+    /**
+     * This is a pretty unusual occurrence. It happens primarily if the Google Play Store
+     * self-upgrades or is force closed.
+     */
+    override fun onBillingServiceDisconnected() {
+        if (connectionTryCount > RECONNECT_MAX_TIME) {
+            connectionTryCount++
+            retryBillingServiceConnectionWithExponentialBackoff()
+        } else {
+            listener?.onBillingServiceDisconnected()
+        }
+    }
+
+    override fun onPurchasesUpdated(
+        billingResult: BillingResult,
+        purchases: MutableList<Purchase>?
+    ) {
+        if (purchases != null && !purchases[0].isAcknowledged) {
+            acknowledgePurchase(purchases[0])
+        }
+    }
+
+    fun purchaseItem(activity: Activity, productId: String) {
+        if (billingClient.isReady) {
+
+            // this block of code is only for test purpose only have to remove before merging it.
+            billingClient.queryPurchasesAsync(
+                BillingClient.SkuType.INAPP
+            ) { _, purchases ->
+                if (purchases.size > 0) {
+                    consumePurchase(purchases[0].purchaseToken)
+                }
+            }
+
+            querySyncDetails(productId,
+                SkuDetailsResponseListener { billingResult, skuDetailsList ->
+                    logger.debug(
+                        "Getting Purchases -> Response code: " + billingResult.responseCode.toString() +
+                                " Debug message: " + billingResult.debugMessage
+                    )
+                    if (skuDetailsList != null) {
+                        launchBillingFlow(activity, skuDetailsList[0])
+                    }
+                })
+        }
+    }
+
+    private fun launchBillingFlow(activity: Activity, skuDetail: SkuDetails) {
+        val billingFlowParamsBuilder = BillingFlowParams.newBuilder()
+        billingFlowParamsBuilder.setSkuDetails(skuDetail)
+        billingClient.launchBillingFlow(
+            activity, billingFlowParamsBuilder.build()
+        )
+    }
+
+    private fun acknowledgePurchase(purchase: Purchase) {
+        billingClient.acknowledgePurchase(
+            AcknowledgePurchaseParams.newBuilder()
+                .setPurchaseToken(purchase.purchaseToken)
+                .build()
+        ) { billingResult: BillingResult ->
+            if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
+                logger.debug(
+                    "acknowledgePurchase -> " +
+                            "Response code: " + billingResult.responseCode.toString() +
+                            " Debug message: " + billingResult.debugMessage
+                )
+                listener?.onPurchaseComplete(purchase)
+            }
+        }
+    }
+
+    /**
+     * Retries the billing service connection with exponential backoff.
+     */
+    private fun retryBillingServiceConnectionWithExponentialBackoff() {
+        handler.postDelayed(
+            { billingClient.startConnection(this@BillingProcessor) },
+            RECONNECT_TIMER_START_MILLISECONDS
+        )
+    }
+
+    private fun consumePurchase(purchaseToken: String) {
+        billingClient.consumeAsync(
+            ConsumeParams.newBuilder()
+                .setPurchaseToken(purchaseToken)
+                .build()
+        ) { billingResult, _ -> logger.debug(billingResult.responseCode.toString() + billingResult.debugMessage) }
+    }
+
+    private fun querySyncDetails(productId: String, listener: SkuDetailsResponseListener) {
+        billingClient.querySkuDetailsAsync(
+            SkuDetailsParams.newBuilder()
+                .setType(BillingClient.SkuType.INAPP)
+                .setSkusList(listOf(productId))
+                .build(), listener
+        )
+    }
+
+    fun disconnect() {
+        billingClient.endConnection()
+    }
+
+    interface BillingFlowListeners {
+        fun onBillingServiceDisconnected() {}
+
+        fun onBillingSetupFinished(billingResult: BillingResult) {}
+
+        fun onPurchaseComplete(purchase: Purchase)
+    }
+}

--- a/constants.gradle
+++ b/constants.gradle
@@ -12,4 +12,5 @@ project.ext {
     // App dependencies
     androidXVersion = '1.0.0'
     androidXAppCompactVersion = '1.2.0'
+    kotlin_version_billing = "4.0.0"
 }


### PR DESCRIPTION
### Description

[LEARNER-8429](https://openedx.atlassian.net/browse/LEARNER-8429)

- Set up the app & store it for IAPs
- No communication will be made with the backend
- Hardcoded sample product id.

Tapping “upgrade now” brings up the option to make an in-app purchase, Payment can be made “successfully”, and considered complete on receiving a receipt for an IAP.

### Testing
- [ ] Tapping “upgrade now” brings up the option to make an in app purchase
- [ ] Payment can be made “successfully” (i.e., Apple/Google IAP integration works correctly)
- [ ] This story can be considered complete if we successfully receive a receipt for an IAP (no need to do anything with the receipt)
- [ ] This story is dependent on the Task ticket to set up the app & store for IAPs
- [ ] This story does not address actually purchasing the course, only paying for it – i.e., just the successful integration of the payment SDK
- [ ] No communication will be made with the backend

**Ref**
- Doc: https://developer.android.com/google/play/billing
- Samples: https://github.com/android/play-billing-samples/tree/master/TrivialDriveKotlin
- To add User email in [License Testing](https://play.google.com/console/u/0/developers/8473335675309440011/license-tester) on Play Console: https://stackoverflow.com/a/51285353