### PR TITLE
feat: Delete Account option from profile screen

### DIFF
--- a/OpenEdXMobile/res/drawable/edx_error_base_bordered_button.xml
+++ b/OpenEdXMobile/res/drawable/edx_error_base_bordered_button.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <stroke
+                android:width="@dimen/edx_divider_length"
+                android:color="@color/errorBase" />
+        </shape>
+    </item>
+    <item android:drawable="@drawable/selectable_rounded_box_overlay" />
+</layer-list>

--- a/OpenEdXMobile/res/layout/fragment_account.xml
+++ b/OpenEdXMobile/res/layout/fragment_account.xml
@@ -319,16 +319,36 @@
                 android:id="@+id/app_version"
                 style="@style/profile_field_description"
                 android:layout_marginTop="@dimen/edx_default_margin"
+                android:layout_marginBottom="@dimen/edx_default_margin"
                 android:lineHeight="@dimen/edx_margin"
                 android:textSize="@dimen/edx_xx_small"
                 tools:text="Version X.X.X" />
 
-            <View
+            <LinearLayout
+                android:id="@+id/container_delete_account"
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/edx_line"
-                android:layout_marginTop="@dimen/edx_default_margin"
-                android:layout_marginBottom="@dimen/edx_default_margin"
-                android:background="@color/neutralXLight" />
+                android:layout_height="wrap_content"
+                android:background="@color/neutralWhite"
+                android:orientation="vertical"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/btn_delete_account"
+                    style="@style/edX.Widget.ProfileActionBorderedButton"
+                    android:layout_marginTop="@dimen/button_horizontal_padding"
+                    android:layout_marginBottom="@dimen/edx_half_margin"
+                    android:background="@drawable/edx_error_base_bordered_button"
+                    android:text="@string/label_delete_account_btn"
+                    android:textColor="@color/errorBase" />
+
+                <TextView
+                    style="@style/profile_field_description"
+                    android:layout_marginBottom="@dimen/divider_with_text_margin"
+                    android:text="@string/description_delete_account"
+                    android:textAlignment="center" />
+
+            </LinearLayout>
         </LinearLayout>
     </ScrollView>
 </layout>

--- a/OpenEdXMobile/res/values/strings.xml
+++ b/OpenEdXMobile/res/values/strings.xml
@@ -177,6 +177,12 @@
     <string name="label_view_faq_btn">View FAQ</string>
     <!--  Label of Sign out Button  -->
     <string name="label_sign_out_btn">Sign out</string>
+    <!-- Delete my account screen Title -->
+    <string name="title_delete_my_account">Delete my account</string>
+    <!--  Label of Delete Account Button  -->
+    <string name="label_delete_account_btn">Delete account</string>
+    <!--  Description of Delete Account  -->
+    <string name="description_delete_account">Follow the instructions on the next screen to delete your account and all related data.</string>
     <!--  Label of App Version  -->
     <string name="label_app_version">Version</string>
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
@@ -876,6 +876,7 @@ public interface Analytics {
         String WIFI_ALLOW = "edx.bi.app.profile.wifi.allow";
         String WIFI_DONT_ALLOW = "edx.bi.app.profile.wifi.dont_allow";
         String EMAIL_SUPPORT_CLICKED = "edx.bi.app.profile.email_support.clicked";
+        String DELETE_ACCOUNT_CLICKED = "edx.bi.app.profile.delete_account.clicked";
         // Video Download Quality
         String PROFILE_VIDEO_DOWNLOAD_QUALITY_CLICKED = "edx.bi.app.profile.video_download_quality.clicked";
         String COURSE_VIDEOS_VIDEO_DOWNLOAD_QUALITY_CLICKED = "edx.bi.app.course_videos.video_download_quality.clicked";
@@ -1047,6 +1048,7 @@ public interface Analytics {
         String WIFI_ALLOW = "Wifi Allow";
         String WIFI_DONT_ALLOW = "Wifi Dont Allow";
         String EMAIL_SUPPORT_CLICKED = "Email Support Clicked";
+        String DELETE_ACCOUNT_CLICKED = "Profile: Delete Account Clicked";
         // Video Download Quality
         String PROFILE_VIDEO_DOWNLOAD_QUALITY_CLICKED = "Profile: Video Download Quality Clicked";
         String COURSE_VIDEOS_VIDEO_DOWNLOAD_QUALITY_CLICKED = "Course Videos: Video Download Quality Clicked";

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/Config.java
@@ -40,6 +40,7 @@ public class Config {
     private static final String PLATFORM_DESTINATION_NAME = "PLATFORM_DESTINATION_NAME";
     private static final String FEEDBACK_EMAIL_ADDRESS = "FEEDBACK_EMAIL_ADDRESS";
     private static final String FAQ_URL = "FAQ_URL";
+    private static final String DELETE_ACCOUNT_URL = "DELETE_ACCOUNT_URL";
     private static final String OAUTH_CLIENT_ID = "OAUTH_CLIENT_ID";
     private static final String SPEED_TEST_ENABLED = "SPEED_TEST_ENABLED";
     private static final String APP_UPDATE_URIS = "APP_UPDATE_URIS";
@@ -673,8 +674,12 @@ public class Config {
         return getString(FEEDBACK_EMAIL_ADDRESS);
     }
 
-    public String getFaqUrl(){
+    public String getFaqUrl() {
         return getString(FAQ_URL);
+    }
+
+    public String getDeleteAccountUrl() {
+        return getString(DELETE_ACCOUNT_URL);
     }
 
     public String getOAuthClientId() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/AccountFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/AccountFragment.kt
@@ -106,6 +106,20 @@ class AccountFragment : BaseFragment() {
         binding.appVersion.text = String.format("%s %s %s", getString(R.string.label_app_version),
                 BuildConfig.VERSION_NAME, config?.environmentDisplayName)
 
+        config?.deleteAccountUrl?.let { deleteAccountUrl ->
+            binding.containerDeleteAccount.visibility = View.VISIBLE
+            binding.btnDeleteAccount.setOnClickListener {
+                environment?.router?.showAuthenticatedWebViewActivity(
+                    this.requireContext(),
+                    deleteAccountUrl, getString(R.string.title_delete_my_account)
+                )
+                trackEvent(
+                    Analytics.Events.DELETE_ACCOUNT_CLICKED,
+                    Analytics.Values.DELETE_ACCOUNT_CLICKED
+                )
+            }
+        }
+
         environment?.analyticsRegistry?.trackScreenViewEvent(Analytics.Events.PROFILE_PAGE_VIEWED, Analytics.Screens.PROFILE)
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/AuthenticatedWebViewActivity.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/AuthenticatedWebViewActivity.kt
@@ -25,9 +25,14 @@ class AuthenticatedWebViewActivity : BaseSingleFragmentActivity() {
 
         @JvmStatic
         fun newIntent(activity: Context?, unit: CourseComponent): Intent {
+            return newIntent(activity, url = unit.blockUrl, screenTitle = unit.displayName)
+        }
+
+        @JvmStatic
+        fun newIntent(activity: Context?, url: String, screenTitle: String): Intent {
             val intent = Intent(activity, AuthenticatedWebViewActivity::class.java)
-            intent.putExtra(EXTRA_COMPONENT_URL, unit.blockUrl)
-            intent.putExtra(EXTRA_SCREEN_TITLE, unit.displayName)
+            intent.putExtra(EXTRA_COMPONENT_URL, url)
+            intent.putExtra(EXTRA_SCREEN_TITLE, screenTitle)
             return intent
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/Router.java
@@ -343,6 +343,11 @@ public class Router {
         context.startActivity(AuthenticatedWebViewActivity.newIntent(context, unit));
     }
 
+    public void showAuthenticatedWebViewActivity(@NonNull Context context, @NonNull String url,
+                                                 @NonNull String name) {
+        context.startActivity(AuthenticatedWebViewActivity.newIntent(context, url, name));
+    }
+
     /**
      * Clear the login data and exit to the splash screen. This should only be called internally;
      * for handling manual logout,


### PR DESCRIPTION
### Description

[LEARNER-8528](https://openedx.atlassian.net/browse/LEARNER-8528)

The learner will be able to delete the account and unlink all linked accounts from the Profile screen.

### Notes

If the learner deleted the account, he won't be able to interact with the app other than the cached data for that session only. 

### Config 
Config PR: https://github.com/edx/edx-mobile-config/pull/121

<img src="https://user-images.githubusercontent.com/71447999/135829895-f1c9332f-2412-443c-b753-79d5dda0c2ba.png" width="300" />