### PR TITLE
fix: Your course calendar is out of date dialog shows multiple times

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/util/CalendarUtils.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/util/CalendarUtils.kt
@@ -302,12 +302,14 @@ object CalendarUtils {
                         datesList.forEachIndexed { index, unit ->
                             if (description.contains(unit.title, ignoreCase = true)) {
                                 val date = unit.getDateCalendar()
+                                // As event started 1 hour before it's due time so mincing 1 hour from current date
+                                date.add(Calendar.HOUR_OF_DAY, -1)
+
                                 // Comparing the existed events start time with current dates block
-                                // As event started 1 hour before it's due time so mincing 1 hour from current date block
                                 if (date.get(Calendar.YEAR) == startDate.get(Calendar.YEAR) &&
                                     date.get(Calendar.MONTH) == startDate.get(Calendar.MONTH) &&
                                     date.get(Calendar.DAY_OF_MONTH) == startDate.get(Calendar.DAY_OF_MONTH) &&
-                                    date.get(Calendar.HOUR_OF_DAY) - 1 == startDate.get(Calendar.HOUR_OF_DAY) &&
+                                    date.get(Calendar.HOUR_OF_DAY) == startDate.get(Calendar.HOUR_OF_DAY) &&
                                     date.get(Calendar.MINUTE) == startDate.get(Calendar.MINUTE)
                                 ) {
                                     count++


### PR DESCRIPTION
### Description

[LEARNER-8511](https://openedx.atlassian.net/browse/LEARNER-8511)

- Fix the comparison between dates
- Minus an hour from the whole date instead of the hour only