### PR TITLE
fix: Open in new tab banner not visible on older operating systems

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitWebViewFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitWebViewFragment.java
@@ -173,7 +173,7 @@ public class CourseUnitWebViewFragment extends CourseUnitFragment {
                     "try {" +
                             "    var top_div_list = document.querySelectorAll('div[data-usage-id=\"" + unit.getId() + "\"]');\n" +
                             "    top_div_list.length == 1 && top_div_list[0].querySelectorAll(\"iframe\").length > 0;" +
-                            "} catch {" +
+                            "} catch(err) {" +
                             "    false;" +
                             "};";
             binding.authWebview.evaluateJavascript(javascript, value -> {


### PR DESCRIPTION
### Description

[LEARNER-8618](https://openedx.atlassian.net/browse/LEARNER-8618)

The issue was caused by the catch block, we have updated the syntax from catch to catch(err) which resolved the issue.