### PR TITLE
feat: Remove `action` Key from Analytics Events

### DIFF
--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
@@ -739,7 +739,6 @@ public interface Analytics {
         String SLIDE = "slide";
         String MOBILE = "mobile";
         String VIDEOPLAYER = "videoplayer";
-        String PASSWORD = "Password";
         String FACEBOOK = "Facebook";
         String GOOGLE = "Google";
         String MICROSOFT = "Microsoft";
@@ -781,9 +780,7 @@ public interface Analytics {
         String COURSE_DISCOVERY = "course-discovery";
 
         String PUSH_NOTIFICATION = "notifications";
-        String ANNOUNCEMENT = "announcement";
 
-        String CONNECTION_CELL = "edx.bi.app.connection.cell";
         String CONNECTION_SPEED = "edx.bi.app.connection.speed";
 
         String NOTIFICATION_RECEIVED = "edx.bi.app.notification.course.update.received";
@@ -840,7 +837,6 @@ public interface Analytics {
         // Cast device connection state
         String CAST_CONNECTED = "edx.bi.app.cast.connected";
         String CAST_DISCONNECTED = "edx.bi.app.cast.disconnected";
-        String VIDEO_CASTED = "edx.bi.app.cast.video_casted";
         // -- Play mediums --
         // Casting Device Types
         String GOOGLE_CAST = "google_cast";
@@ -1052,7 +1048,6 @@ public interface Analytics {
         // Casting Devices Event
         String CAST_CONNECTED = "Cast: Connected";
         String CAST_DISCONNECTED = "Cast: Disconnected";
-        String VIDEO_CASTED = "Cast: Video Casted";
         // PLS Course Dates Banner
         String PLS_BANNER_VIEWED = "PLS Banner Viewed";
         String PLS_SHIFT_DATES_BUTTON_TAPPED = "PLS Shift Button Tapped";

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/Analytics.java
@@ -22,11 +22,10 @@ public interface Analytics {
      *
      * @param screenName The screen name to track
      * @param courseId   course id of the course we are viewing
-     * @param action     any custom action we need to send with event
      * @param values     any custom key- value pairs we need to send with event
      */
     void trackScreenView(@NonNull String screenName, @Nullable String courseId,
-                         @Nullable String action, @Nullable Map<String, String> values);
+                         @Nullable Map<String, String> values);
 
     /**
      * This function is used to track Video Playing
@@ -688,9 +687,6 @@ public interface Analytics {
         String PAYMENT_ENABLED = "payment_enabled";
         String IAP_EXPERIMENT_GROUP = "iap_experiment_group";
         String IAP_FLOW_TYPE = "flow_type";
-
-        String CELL_CARRIER = "cell_carrier";
-        String CELL_ZERO_RATED = "cell_zero_rated";
 
         String CONNECTION_TYPE = "connection_type";
         String CONNECTION_SPEED = "connection_speed";

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/AnalyticsRegistry.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/AnalyticsRegistry.java
@@ -34,14 +34,13 @@ public class AnalyticsRegistry implements Analytics {
         trackScreenView(screenName, null, null);
     }
 
-    public void trackScreenView(@NonNull String screenName, @Nullable String courseId,
-                                @Nullable String action) {
-        trackScreenView(screenName, courseId, action, null);
+    public void trackScreenView(@NonNull String screenName, @Nullable String courseId) {
+        trackScreenView(screenName, courseId, null);
     }
 
     @Override
     public void trackScreenView(@NonNull String screenName, @Nullable String courseId,
-                                @Nullable String action, @Nullable Map<String, String> values) {
+                                @Nullable Map<String, String> values) {
         // Remove a key-value pair, if the value for a key is null
         if (values != null) {
             for (Map.Entry<String, String> entry : values.entrySet()) {
@@ -52,7 +51,7 @@ public class AnalyticsRegistry implements Analytics {
         }
 
         for (Analytics service : services) {
-            service.trackScreenView(screenName, courseId, action, values);
+            service.trackScreenView(screenName, courseId, values);
         }
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/FirebaseAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/FirebaseAnalytics.java
@@ -57,17 +57,12 @@ public class FirebaseAnalytics implements Analytics {
      *
      * @param screenName The screen name to track
      * @param courseId   course id of the course we are viewing
-     * @param action     any custom action we need to send with event
      * @param values     any custom key-value pairs we need to send with event
      */
     @Override
     public void trackScreenView(@NonNull String screenName, @Nullable String courseId,
-                                @Nullable String action,
                                 @Nullable Map<String, String> values) {
         final FirebaseEvent event = new FirebaseEvent(screenName);
-        if (!TextUtils.isEmpty(action)) {
-            event.putString(Keys.ACTION, action);
-        }
         if (!TextUtils.isEmpty(courseId)) {
             event.putCourseId(courseId);
         }
@@ -241,7 +236,7 @@ public class FirebaseAnalytics implements Analytics {
                 Values.DISCOVERY_COURSES_SEARCH);
         event.putString(Keys.LABEL, searchQuery);
         event.putString(Keys.APP_VERSION, versionName);
-        event.putString(Keys.ACTION, isLoggedIn ? Values.DISCOVERY_COURSES_SEARCH_TAB : Values.DISCOVERY_COURSES_SEARCH_LANDING);
+        event.putString(Keys.SCREEN_NAME, isLoggedIn ? Values.DISCOVERY_COURSES_SEARCH_TAB : Values.DISCOVERY_COURSES_SEARCH_LANDING);
         logFirebaseEvent(event.getName(), event.getBundle());
     }
 
@@ -699,7 +694,7 @@ public class FirebaseAnalytics implements Analytics {
         final FirebaseEvent event = new FirebaseEvent(Events.EXPLORE_ALL_COURSES, Values.EXPLORE_ALL_COURSES);
         event.addCategoryToBiEvents(Values.USER_ENGAGEMENT, Values.DISCOVERY);
         event.putString(Keys.APP_VERSION, versionName);
-        event.putString(Keys.ACTION, Values.DISCOVERY_COURSES_SEARCH_LANDING);
+        event.putString(Keys.SCREEN_NAME, Values.DISCOVERY_COURSES_SEARCH_LANDING);
         logFirebaseEvent(event.getName(), event.getBundle());
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/module/analytics/SegmentAnalytics.java
@@ -121,18 +121,13 @@ public class SegmentAnalytics implements Analytics {
      *
      * @param screenName The screen name to track
      * @param courseId   course id of the course we are viewing
-     * @param action     any custom action we need to send with event
      * @param values     any custom key-value pairs we need to send with event
      */
     @Override
     public void trackScreenView(@NonNull String screenName, @Nullable String courseId,
-                                @Nullable String action,
                                 @Nullable Map<String, String> values) {
         // Sending screen view
         SegmentEvent aEvent = new SegmentEvent();
-        if (!TextUtils.isEmpty(action)) {
-            aEvent.properties.put(Keys.ACTION, action);
-        }
         if (!TextUtils.isEmpty(courseId)) {
             aEvent.properties.put(Keys.COURSE_ID, courseId);
         }
@@ -418,7 +413,7 @@ public class SegmentAnalytics implements Analytics {
         aEvent.properties.putValue(Keys.NAME, Values.DISCOVERY_COURSES_SEARCH);
         aEvent.properties.putValue(Keys.LABEL, searchQuery);
         aEvent.data.putValue(Keys.APP_VERSION, versionName);
-        aEvent.data.putValue(Keys.ACTION, isLoggedIn ? Values.DISCOVERY_COURSES_SEARCH_TAB : Values.DISCOVERY_COURSES_SEARCH_LANDING);
+        aEvent.data.putValue(Keys.SCREEN_NAME, isLoggedIn ? Values.DISCOVERY_COURSES_SEARCH_TAB : Values.DISCOVERY_COURSES_SEARCH_LANDING);
         trackSegmentEvent(Events.DISCOVERY_COURSES_SEARCH, aEvent.properties);
     }
 
@@ -984,7 +979,7 @@ public class SegmentAnalytics implements Analytics {
         aEvent.properties = addCategoryToBiEvents(aEvent.properties,
                 Values.USER_ENGAGEMENT, Values.DISCOVERY);
         aEvent.data.putValue(Keys.APP_VERSION, versionName);
-        aEvent.data.putValue(Keys.ACTION, Values.DISCOVERY_COURSES_SEARCH_LANDING);
+        aEvent.data.putValue(Keys.SCREEN_NAME, Values.DISCOVERY_COURSES_SEARCH_LANDING);
         trackSegmentEvent(Events.EXPLORE_ALL_COURSES, aEvent.properties);
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionCommentsFragment.java
@@ -90,7 +90,7 @@ public class CourseDiscussionCommentsFragment extends BaseFragment implements Di
             values.put(Analytics.Keys.AUTHOR, discussionResponse.getAuthor());
         }
         analyticsRegistry.trackScreenView(Analytics.Screens.FORUM_VIEW_RESPONSE_COMMENTS,
-                discussionThread.getCourseId(), discussionThread.getTitle(), values);
+                discussionThread.getCourseId(), values);
     }
 
     @Nullable

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionPostsSearchFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionPostsSearchFragment.java
@@ -96,7 +96,7 @@ public class CourseDiscussionPostsSearchFragment extends CourseDiscussionPostsBa
         final Map<String, String> values = new HashMap<>();
         values.put(Analytics.Keys.SEARCH_STRING, searchQuery);
         analyticsRegistry.trackScreenView(Analytics.Screens.FORUM_SEARCH_THREADS,
-                courseData.getCourse().getId(), searchQuery, values);
+                courseData.getCourse().getId(), values);
     }
 
     private void parseExtras() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionPostsThreadFragment.java
@@ -224,19 +224,16 @@ public class CourseDiscussionPostsThreadFragment extends CourseDiscussionPostsBa
     }
 
     private void trackScreenView() {
-        final String actionItem;
         final Map<String, String> values = new HashMap<>();
         String topicId = discussionTopic.getIdentifier();
         if (DiscussionTopic.ALL_TOPICS_ID.equals(topicId)) {
-            topicId = actionItem = Analytics.Values.POSTS_ALL;
+            topicId = Analytics.Values.POSTS_ALL;
         } else if (DiscussionTopic.FOLLOWING_TOPICS_ID.equals(topicId)) {
-            topicId = actionItem = Analytics.Values.POSTS_FOLLOWING;
-        } else {
-            actionItem = discussionTopic.getName();
+            topicId = Analytics.Values.POSTS_FOLLOWING;
         }
         values.put(Analytics.Keys.TOPIC_ID, topicId);
         analyticsRegistry.trackScreenView(Analytics.Screens.FORUM_VIEW_TOPIC_THREADS,
-                courseData.getCourse().getId(), actionItem, values);
+                courseData.getCourse().getId(), values);
     }
 
     @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseDiscussionResponsesFragment.java
@@ -169,7 +169,7 @@ public class CourseDiscussionResponsesFragment extends BaseFragment implements C
             values.put(Analytics.Keys.AUTHOR, discussionThread.getAuthor());
         }
         analyticsRegistry.trackScreenView(Analytics.Screens.FORUM_VIEW_THREAD,
-                courseData.getCourse().getId(), discussionThread.getTitle(), values);
+                courseData.getCourse().getId(), values);
     }
 
     private void setScreenTitle() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseOutlineFragment.java
@@ -435,7 +435,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment implements
         Intent intent = environment.getRouter().getCourseUnitDetailIntent(requireActivity(),
                 courseData, courseUpgradeData, component.getId(), isVideoMode);
         environment.getAnalyticsRegistry().trackScreenView(
-                Analytics.Screens.UNIT_DETAIL, courseData.getCourse().getId(), component.getParent().getInternalName());
+                Analytics.Screens.UNIT_DETAIL, courseData.getCourse().getId());
         courseUnitDetailLauncher.launch(intent);
     }
 
@@ -623,7 +623,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment implements
                 Map<String, String> values = new HashMap<>();
                 values.put(Analytics.Keys.SUBSECTION_ID, courseComponent.getBlockId());
                 environment.getAnalyticsRegistry().trackScreenView(isSpecialExamInfo ? Analytics.Screens.SPECIAL_EXAM_BLOCK : Analytics.Screens.EMPTY_SUBSECTION_OUTLINE,
-                        courseComponent.getCourseId(), null, values);
+                        courseComponent.getCourseId(), values);
 
                 errorNotification.showError(R.string.assessment_not_available, 0, R.string.assessment_view_on_web, new View.OnClickListener() {
                     @Override
@@ -637,7 +637,7 @@ public class CourseOutlineFragment extends OfflineSupportBaseFragment implements
 
         if (!isOnCourseOutline) {
             environment.getAnalyticsRegistry().trackScreenView(
-                    Analytics.Screens.SECTION_OUTLINE, courseData.getCourseId(), courseComponent.getInternalName());
+                    Analytics.Screens.SECTION_OUTLINE, courseData.getCourseId());
         }
         detectDeepLinking();
         courseComponentId = courseComponent.getId();

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardFragment.kt
@@ -227,7 +227,7 @@ class CourseTabsDashboardFragment : BaseFragment() {
             EventBus.getDefault().register(this)
 
         environment.analyticsRegistry.trackScreenView(
-            Analytics.Screens.COURSE_DASHBOARD, courseData.course.id, null
+            Analytics.Screens.COURSE_DASHBOARD, courseData.course.id
         )
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseTabsDashboardFragment.kt
@@ -813,7 +813,7 @@ class CourseTabsDashboardFragment : BaseFragment() {
             )
         ) {
             environment.analyticsRegistry.trackScreenView(
-                Analytics.Screens.COURSE_OUTLINE, courseData.courseId, null
+                Analytics.Screens.COURSE_OUTLINE, courseData.courseId
             )
         }
     }
@@ -825,7 +825,7 @@ class CourseTabsDashboardFragment : BaseFragment() {
             CourseOutlineFragment.makeArguments(courseData, null, true, null)
         ) {
             environment.analyticsRegistry.trackScreenView(
-                Analytics.Screens.VIDEOS_COURSE_VIDEOS, courseData.courseId, null
+                Analytics.Screens.VIDEOS_COURSE_VIDEOS, courseData.courseId
             )
         }
     }
@@ -837,7 +837,7 @@ class CourseTabsDashboardFragment : BaseFragment() {
             arguments
         ) {
             environment.analyticsRegistry.trackScreenView(
-                Analytics.Screens.FORUM_VIEW_TOPICS, courseData.courseId, null, null
+                Analytics.Screens.FORUM_VIEW_TOPICS, courseData.courseId
             )
         }
     }
@@ -849,7 +849,7 @@ class CourseTabsDashboardFragment : BaseFragment() {
             CourseDatesPageFragment.makeArguments(courseData)
         ) {
             analyticsRegistry.trackScreenView(
-                Analytics.Screens.COURSE_DATES, courseData.courseId, null
+                Analytics.Screens.COURSE_DATES, courseData.courseId
             )
         }
     }
@@ -861,7 +861,7 @@ class CourseTabsDashboardFragment : BaseFragment() {
             CourseHandoutFragment.makeArguments(courseData)
         ) {
             analyticsRegistry.trackScreenView(
-                Analytics.Screens.COURSE_HANDOUTS, courseData.courseId, null
+                Analytics.Screens.COURSE_HANDOUTS, courseData.courseId
             )
         }
     }
@@ -873,7 +873,7 @@ class CourseTabsDashboardFragment : BaseFragment() {
             CourseAnnouncementsFragment.makeArguments(courseData)
         ) {
             analyticsRegistry.trackScreenView(
-                Analytics.Screens.COURSE_ANNOUNCEMENTS, courseData.courseId, null
+                Analytics.Screens.COURSE_ANNOUNCEMENTS, courseData.courseId
             )
         }
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddCommentFragment.java
@@ -78,7 +78,7 @@ public class DiscussionAddCommentFragment extends BaseFragment {
             values.put(Analytics.Keys.AUTHOR, discussionResponse.getAuthor());
         }
         analyticsRegistry.trackScreenView(Analytics.Screens.FORUM_ADD_RESPONSE_COMMENT,
-                discussionThread.getCourseId(), discussionThread.getTitle(), values);
+                discussionThread.getCourseId(), values);
     }
 
     @Override

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddPostFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddPostFragment.java
@@ -248,7 +248,7 @@ public class DiscussionAddPostFragment extends BaseFragment {
                 Map<String, String> values = new HashMap<>();
                 values.put(Analytics.Keys.TOPIC_ID, selectedTopic.getIdentifier());
                 analyticsRegistry.trackScreenView(Analytics.Screens.FORUM_CREATE_TOPIC_THREAD,
-                        courseData.getCourse().getId(), selectedTopic.getName(), values);
+                        courseData.getCourse().getId(), values);
             }
         });
     }

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/DiscussionAddResponseFragment.java
@@ -77,7 +77,7 @@ public class DiscussionAddResponseFragment extends BaseFragment {
             values.put(Analytics.Keys.AUTHOR, discussionThread.getAuthor());
         }
         analyticsRegistry.trackScreenView(Analytics.Screens.FORUM_ADD_RESPONSE,
-                discussionThread.getCourseId(), discussionThread.getTitle(), values);
+                discussionThread.getCourseId(), values);
     }
 
     private void parseExtras() {

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/CourseModalDialogFragment.kt
@@ -121,7 +121,6 @@ class CourseModalDialogFragment : DialogFragment() {
         environment.analyticsRegistry.trackScreenView(
             Events.VALUE_PROP_MODAL_VIEW,
             courseId,
-            null,
             mapOf(Pair(KEY_SCREEN_NAME, screenName))
         )
         var experimentGroup: String? = null

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/RatingDialogFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/RatingDialogFragment.java
@@ -106,7 +106,7 @@ public class RatingDialogFragment extends DialogFragment implements AlertDialog.
         // Send rating dialog viewed analytics
         final Map<String, String> values = new HashMap<>();
         values.put(Analytics.Keys.APP_VERSION, BuildConfig.VERSION_NAME);
-        analyticsRegistry.trackScreenView(Analytics.Screens.APP_REVIEWS_VIEW_RATING, null, null, values);
+        analyticsRegistry.trackScreenView(Analytics.Screens.APP_REVIEWS_VIEW_RATING, null, values);
         analyticsRegistry.trackAppRatingDialogViewed(BuildConfig.VERSION_NAME);
     }
 

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/VideoDownloadQualityDialogFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/VideoDownloadQualityDialogFragment.kt
@@ -55,9 +55,8 @@ class VideoDownloadQualityDialogFragment(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        environment.analyticsRegistry.trackScreenView(
-            Analytics.Screens.VIDEO_DOWNLOAD_QUALITY, null,
-            Analytics.Values.SCREEN_NAVIGATION
+        environment.analyticsRegistry.trackEvent(
+            Analytics.Screens.VIDEO_DOWNLOAD_QUALITY, Analytics.Values.SCREEN_NAVIGATION
         )
         val platformName = resources.getString(R.string.platform_name)
         binding.tvVideoQualityMessage.text = ResourceUtil.getFormattedString(

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/VideoDownloadQualityDialogFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/dialog/VideoDownloadQualityDialogFragment.kt
@@ -55,9 +55,7 @@ class VideoDownloadQualityDialogFragment(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        environment.analyticsRegistry.trackEvent(
-            Analytics.Screens.VIDEO_DOWNLOAD_QUALITY, Analytics.Values.SCREEN_NAVIGATION
-        )
+        environment.analyticsRegistry.trackScreenView(Analytics.Screens.VIDEO_DOWNLOAD_QUALITY)
         val platformName = resources.getString(R.string.platform_name)
         binding.tvVideoQualityMessage.text = ResourceUtil.getFormattedString(
             resources,
@@ -83,7 +81,7 @@ class VideoDownloadQualityDialogFragment(
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         binding =
-            VideoQualityDialogFragmentBinding.inflate(LayoutInflater.from(context), null, false)
+            VideoQualityDialogFragmentBinding.inflate(layoutInflater, null, false)
         return AlertDialog.Builder(requireContext())
             .setNegativeButton(
                 R.string.label_cancel

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/whatsnew/WhatsNewFragment.java
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/whatsnew/WhatsNewFragment.java
@@ -75,7 +75,7 @@ public class WhatsNewFragment extends BaseFragment {
         final Map<String, String> map = new HashMap<>();
         map.put(Analytics.Keys.APP_VERSION, BuildConfig.VERSION_NAME);
         environment.getAnalyticsRegistry().trackScreenView(Analytics.Screens.WHATS_NEW, null,
-                null, map);
+                map);
     }
 
     private void initViewPager() {


### PR DESCRIPTION
### Description

[LEARNER-9973](https://2u-internal.atlassian.net/browse/LEARNER-9973)

In compliance with the VPPA claim, we are removing the 'action' key along with its associated values from all analytics events. This change ensures that our platform adheres to privacy regulations while continuing to provide valuable insights through analytics data.

Affected events. The eliminated value is indicated within brackets.
- `Forum: View Response Comments` (Thread Title) 
- `Forum: Add Response Comment` (Thread Title)
- `Forum: Search Threads` (Search query) (still passed in another parameter)
- `Forum: View Topic Threads` (Topic ID) (still passed in another parameter)
- `Forum: View Thread` (Thread Title)
- `Forum: Add Thread Response` (Thread Title)
- `Forum: Create Topic Thread` (Topic Name)
- `Unit Detail` (Component Name)
- `Special Exam Blocked Screen` (Component Name)
- `Empty Section Outline` (Component Name)
- `Section Outline` (Component Name)


Replaced the `action` key with `screen_name` for these events:
- `Explore All Courses` (“landing_screen”)
- `Discovery: Courses Search` (“discovery_tab“ /  “landing_screen“)


Ignore the In-App Purchase alert dialogs events that record the "action taken" event under the `action` key.