### PR TITLE
fix: Fullstory JS Injection in Youtube Player WebView

### DIFF
--- a/OpenEdXMobile/proguard-rules.pro
+++ b/OpenEdXMobile/proguard-rules.pro
@@ -37,3 +37,7 @@
 -dontwarn com.google.protobuf.**
 -dontwarn com.huawei.hms.ads.**
 -dontwarn edu.umd.cs.findbugs.**
+
+# Keep Rule to preserve classes, methods, and fields in the YouTube Player SDK
+# This is necessary for reflection on WebView for Fullstory integration
+-keep class com.pierfrancescosoffritti.androidyoutubeplayer.core.player.views.** { *; }


### PR DESCRIPTION
### Description

[LEARNER-10034](https://2u-internal.atlassian.net/browse/LEARNER-10034)

- FS SDK injecting JS into YouTube Player WebView caused issues opening the player externally.
- Resolved by calling FS SDK's disableInjection method, requiring the WebView as a parameter.
- Accessed YouTube Player WebView internally using reflection.
- Implemented keep rule for Proguard compatibility.

### Note
- Please test it on a proper release build.