### PR TITLE
fix: Handle nullException of ProductInfo if payment is disabled

### DIFF
--- a/OpenEdXMobile/AndroidManifest.xml
+++ b/OpenEdXMobile/AndroidManifest.xml
@@ -49,7 +49,7 @@
 
     <application
         android:name=".base.RuntimeApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
@@ -57,7 +57,8 @@
         android:supportsRtl="${supportsRtl}"
         android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/AppTheme"
-        tools:targetApi="tiramisu">
+        tools:targetApi="tiramisu"
+        tools:ignore="DataExtractionRules">
 
         <activity
             android:name="org.edx.mobile.view.SplashActivity"

--- a/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
+++ b/OpenEdXMobile/src/main/java/org/edx/mobile/view/CourseUnitMobileNotSupportedFragment.kt
@@ -51,6 +51,7 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
     @Inject
     lateinit var iapDialog: InAppPurchasesDialog
 
+    private var lmsUSDPrice: Double = 0.0
     private var localizedPrice: Double = 0.0
     private var currencyCode: String = ""
 
@@ -134,7 +135,7 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
                 environment.analyticsRegistry.trackValuePropShowMoreLessClicked(
                     unit.courseId,
                     unit.id,
-                    unit.productInfo.lmsUSDPrice,
+                    lmsUSDPrice,
                     localizedPrice,
                     currencyCode,
                     isSelfPaced,
@@ -228,6 +229,7 @@ class CourseUnitMobileNotSupportedFragment : CourseUnitFragment() {
     }
 
     private fun setUpUpgradeButton(productDetails: ProductDetails.OneTimePurchaseOfferDetails) {
+        lmsUSDPrice = unit?.productInfo?.lmsUSDPrice ?: 0.0
         localizedPrice = productDetails.getPriceAmount()
         currencyCode = productDetails.priceCurrencyCode
         binding.layoutUpgradeBtn.root.setVisibility(true)


### PR DESCRIPTION
### Description

[LEARNER-10104](https://2u-internal.atlassian.net/browse/LEARNER-10104)

- Initialise lmsUSDPrice only if payment is enabled
- set `allowBackup` to `false` in Manifest