### PR TITLE
chore: update github actions cache from v2 to v4

### DIFF
--- a/.github/workflows/androidTestSuite.yml
+++ b/.github/workflows/androidTestSuite.yml
@@ -94,7 +94,7 @@ jobs:
 
       # Cache and restore the particular Android Virtual Device
       - name: AVD cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: avd-cache
         with:
           path: |


### PR DESCRIPTION
### Description

PR updates GitHub `actions/cache` from v2 to v4 as `actions/cache v1-v2` is closing down